### PR TITLE
docs: add DCO signing requirements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,4 +18,66 @@ user-visible behavior and verification performed. By submitting a contribution,
 you confirm that you have the right to contribute it under the
 [Apache License 2.0](LICENSE).
 
+## Signing Your Work
+
+- We require that all contributors "sign-off" on their commits. This certifies
+  that the contribution is your original work, or you have rights to submit it
+  under the same license, or a compatible license.
+
+  - Any contribution which contains commits that are not Signed-Off will not be
+    accepted.
+
+- To sign off on a commit you simply use the `--signoff` (or `-s`) option when
+  committing your changes:
+
+  ```bash
+  git commit -s -m "Add cool feature."
+  ```
+
+  This will append the following to your commit message:
+
+  ```text
+  Signed-off-by: Your Name <your@email.com>
+  ```
+
+- Full text of the
+  [Developer Certificate of Origin](https://developercertificate.org/):
+
+  ```text
+  Developer Certificate of Origin
+  Version 1.1
+
+  Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+  Everyone is permitted to copy and distribute verbatim copies of this
+  license document, but changing it is not allowed.
+
+
+  Developer's Certificate of Origin 1.1
+
+  By making a contribution to this project, I certify that:
+
+  (a) The contribution was created in whole or in part by me and I
+      have the right to submit it under the open source license
+      indicated in the file; or
+
+  (b) The contribution is based upon previous work that, to the best
+      of my knowledge, is covered under an appropriate open source
+      license and I have the right under that license to submit that
+      work with modifications, whether created in whole or in part
+      by me, under the same open source license (unless I am
+      permitted to submit under a different license), as indicated
+      in the file; or
+
+  (c) The contribution was provided directly to me by some other
+      person who certified (a), (b) or (c) and I have not modified
+      it.
+
+  (d) I understand and agree that this project and the contribution
+      are public and that a record of the contribution (including all
+      personal information I submit with it, including my sign-off) is
+      maintained indefinitely and may be redistributed consistent with
+      this project or the open source license(s) involved.
+  ```
+
 Report vulnerabilities through [SECURITY.md](SECURITY.md), not public issues.


### PR DESCRIPTION
## What changed

- added the required `Signing Your Work` guidance to `CONTRIBUTING.md`
- documented `git commit -s` and the generic `Signed-off-by` trailer
- included the complete, unmodified Developer Certificate of Origin 1.1 text

## Why

OSRB identified the missing DCO contribution mechanism as the remaining repository-compliance item before approval.

## Verification

- confirmed the wording against the current NVIDIA DCO minimum and `NVIDIA/SkillSpector`
- `git diff --check`
- `make PYTHON=.venv/bin/python lint`
- full test suite on supported Python 3.13: `1686 passed, 3 skipped`
- `make PYTHON=.venv/bin/python build`
- verified the commit contains Christopher Kevin DCO sign-off

This intentionally changes only `CONTRIBUTING.md`; the pull-request template and existing history are unchanged.