### PR TITLE
Align public tier documentation with internal guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@ extends an AI agent — see the
 SkillEvaluator gates skills through three progressively deeper tiers, from
 free offline checks to live agent A/B evaluation:
 
+## Three-tier overview
+
 | Tier | Purpose | Representative commands | Requires |
 | --- | --- | --- | --- |
-| Tier 1 · deterministic core | Validate schema, quality, security, secrets, PII, licenses, code integrity, Unicode safety, and scripts | `validate`, `quality-check`, `security-scan`, `pii-scan`, `lint-scripts` | No API key; full scanner coverage needs the `security` extra and the external Gitleaks binary |
-| Tier 1 · LLM checks | Judge instruction quality with an LLM; optionally deepen security analysis and suppress false positives | `rubric-eval` (LLM required), optional `--llm` / `--llm-verify` flags on the scans above | An LLM provider key |
+| Tier 1 | Validate schema, quality, security, secrets, PII, licenses, code integrity, Unicode safety, and scripts; optionally add LLM judging and deeper security analysis | `validate`, `quality-check`, `security-scan`, `pii-scan`, `lint-scripts`, `rubric-eval` | Deterministic checks need no API key; full scanner coverage needs the `security` extra and Gitleaks; LLM checks need a provider key |
 | Tier 2 | Detect redundant content within one skill and overlapping skills across a collection or local catalog | `context-optimization-check` / `dedup-scan` (intra-skill), `similarity-check` (inter-skill) | An embeddings provider; intra-skill analysis also needs a chat LLM — local OpenAI-compatible endpoints work |
 | Tier 3 | Create evaluation datasets and measure agent behavior with and without a skill | `create-eval-dataset`, `evaluate`, `compare` | Keyless templates and report inspection need no credential; LLM generation needs a provider key; live evaluation also needs the agent credential and a Docker, local OS, or cloud sandbox |
 
@@ -55,9 +56,11 @@ For a complete offline Tier 1 run, install Gitleaks once, then use `validate`:
 
 ```bash
 brew install gitleaks                                      # macOS
-# go install github.com/gitleaks/gitleaks/v8@latest       # Linux/other with Go
 skillevaluator validate ./my-skill --no-dedup
 ```
+
+On other platforms, install a binary from the official
+[Gitleaks releases](https://github.com/gitleaks/gitleaks/releases).
 
 For a smaller Tier 1-only environment, install the `security` extra instead of
 `all`; see [installation options](docs/INSTALLATION.md#choosing-extras).
@@ -82,7 +85,7 @@ flowchart LR
     T3 --> R["Reports<br/>CLI, JSON, HTML, Markdown"]
 ```
 
-## Tier 1: Static and security validation
+## Tier 1: Static and Security Validation
 
 Deterministic checks run offline after their scanner binaries are installed —
 this is the everyday command and a ready-made CI gate (`validate` exits
@@ -96,17 +99,35 @@ skillevaluator security-scan ./my-skill         # one category at a time
 skillevaluator rubric-eval ./my-skill           # LLM-as-judge scoring — the one Tier 1 command that needs a provider key
 ```
 
+| Check | What it covers |
+| --- | --- |
+| `schema` | Frontmatter, folder structure, naming, and content policy |
+| `security` | SkillSpector scanning for prompt injection, data exfiltration, and related risks |
+| `pii` | Credentials, tokens, personal data, and other sensitive information |
+| `license` | Frontmatter, license-file, and SPDX compliance |
+| `code-integrity` | Bandit, packaged Semgrep checks, Gitleaks, links, dependency declarations, and static test discovery |
+| `unicode` | Invisible Unicode, bidirectional overrides, and ASCII smuggling |
+| `quality` | Deterministic quality scoring with a 0–100 score and A–F grade |
+| `lint` | Advisory script structure, nesting, constants, shebang, and input-validation checks |
+| `version` | Optional version metadata validation |
+| `dependency` | Optional dependency vulnerability audit |
+
+`rubric-eval` adds an LLM-as-judge review across nine instruction-quality
+criteria. The optional `--llm` and `--llm-verify` flags deepen security
+analysis and can suppress false positives.
+
 Check selection (`--checks`), report formats (`-r cli,json,html,markdown`), the
-automatically generated `BENCHMARK.md`,
-content types, the optional `--llm`/`--llm-verify` deepening, and a CI recipe:
+automatically generated `BENCHMARK.md`, skill discovery, the optional
+`--llm`/`--llm-verify` deepening, and a CI recipe:
 [Tier 1 guide](docs/TIER1_VALIDATION.md).
 
 ## Configure a provider (for the LLM-backed parts)
 
-Everything beyond the deterministic core shares one configured provider —
-its credential is the "LLM provider key" in the table above. Quickest is a
-free [NVIDIA API Catalog](https://build.nvidia.com/) key; it covers LLM
-judging and Tier 2 embeddings with one variable:
+LLM-backed features use the configured chat provider. Tier 2 also needs an
+embeddings provider: it can use the same service when embeddings are available,
+or a separately configured local or hosted endpoint. A free
+[NVIDIA API Catalog](https://build.nvidia.com/) key covers both LLM judging and
+Tier 2 embeddings with one variable:
 
 ```bash
 export SKILL_EVAL_LLM_PROVIDER=nv_build
@@ -116,7 +137,14 @@ export NVIDIA_API_KEY='nvapi-...'
 OpenAI, Anthropic, Bedrock, any OpenAI-compatible endpoint, and fully local
 servers work too: [configuration guide](docs/CONFIGURATION.md).
 
-## Tier 2: Semantic deduplication
+The external publication profile is the default. `--external` is shorthand
+for `--profile external`, and `--policy` can overlay a custom policy file.
+
+Telemetry is disabled by default. To opt in, install the `telemetry` extra
+(included in `all`), set `SKILLEVALUATOR_TELEMETRY_ENABLED=true`, and configure
+an OpenTelemetry endpoint; see the [configuration guide](docs/CONFIGURATION.md#telemetry).
+
+## Tier 2: Semantic Deduplication
 
 With a provider configured, find duplicated guidance inside one skill or
 compare skills with embeddings. `dedup-scan` is an alias for the canonical
@@ -135,13 +163,17 @@ skillevaluator similarity-check ./skills --save-catalog ./skill-catalog.json
 skillevaluator similarity-check ./candidate-skill --catalog ./skill-catalog.json
 ```
 
+Similarity findings use four classifications: `EXACT_DUPLICATE` (at least
+0.95), `HIGH_SIMILARITY` (at least 0.90), `SIMILAR` (at least 0.75), and
+`LOOSELY_RELATED` (at least 0.50).
+
 The catalog is a versioned JSON file containing embeddings and skill metadata,
-not credentials. It stays local unless you choose to share it; no Milvus,
-vector database, or catalog service is involved. Thresholds, reports, catalog
+not credentials. It stays local unless you choose to share it; no external
+vector database or catalog service is involved. Thresholds, reports, catalog
 validation, and exactly where the chat LLM comes in:
 [Tier 2 guide](docs/TIER2_DEDUPLICATION.md).
 
-## Tier 3: Skill evaluation with live agents
+## Tier 3: Live Agent Evaluation
 
 Tier 3 evaluates your skill by running a real agent (`codex`, and other
 supported CLIs) against generated tasks, with and without the skill, inside
@@ -155,11 +187,31 @@ runtime/system exceptions. Unsandboxed local execution requires explicitly
 opting into trusted mode. Cloud backends are available through the same
 `--env-mode` flag.
 
-**Two credentials are needed before a live run:** the evaluator provider key
-from the section above (generates tasks and judges results), and the selected
-agent's own native key — for example `codex` needs an OpenAI Responses key plus
-`OPENAI_BASE_URL`, while `claude-code` needs an Anthropic key. NVIDIA Build's
-key is not interchangeable with either agent credential.
+Standard grading reports lead with five human-readable dimensions. Skill Lift
+is the measured difference between the with-skill and without-skill runs, while
+pass@k shows multi-attempt reliability separately from the dimension scores.
+In `custom_only` mode, the user-owned grader defines the score instead.
+
+| Dimension | Question |
+| --- | --- |
+| **Security** | Is it safe to use? |
+| **Correctness** | Does it do what it is supposed to? |
+| **Discoverability** | Is it loaded when it should be? |
+| **Effectiveness** | Is it better with the skill than without? |
+| **Efficiency** | Does it use tools and tokens efficiently? |
+
+Live evaluation has **two credential roles**: the evaluator provider generates
+tasks and performs standard grading, while the selected agent needs credentials
+compatible with its own API. A compatible local-mode agent can reuse a mapped
+provider credential; Docker and cloud agents receive values configured through
+`evals/config.yml`. When NVIDIA Build is the evaluator, `codex` needs a separate
+OpenAI-compatible Responses credential and model, while `claude-code` needs an
+Anthropic credential and model.
+
+The commands below assume that the agent credential is mapped through
+`harbor.runtime_env` as shown in the [Tier 3 guide](docs/TIER3_LIVE_EVALUATION.md#prerequisites-and-credentials).
+For `codex` with NVIDIA Build, also select an OpenAI-compatible model with
+`--agent-model`:
 
 ```bash
 # 1. Readiness check first — seconds, and it names any missing key or sandbox
@@ -167,17 +219,33 @@ skillevaluator doctor --agents codex --env-mode docker
 
 # 2. Generate eval tasks (writes evals/evals.json; --no-llm for a keyless template)
 skillevaluator create-eval-dataset ./my-skill --full
+skillevaluator create-eval-dataset ./my-skill --full --refine
 
 # 3. Run the with-skill vs. without-skill evaluation
-skillevaluator evaluate ./my-skill --agents codex --env-mode docker
+skillevaluator evaluate ./my-skill --agents codex --env-mode docker \
+  --agent-model codex=gpt-4.1-mini
 
 # 4. Read the results
 skillevaluator view ./my-skill      # HTML report
 skillevaluator compare ./my-skill   # side-by-side comparison
 ```
 
+Results are written under `evals/results` by default. Use `--results-dir` or
+`SKILLEVALUATOR_RESULTS_DIR` to place them elsewhere. The `--refine` option
+uses existing or collected agent trajectories to improve generated cases.
+
 Custom graders, Harbor-format tasks, and agent credential setup:
 [Tier 3 guide](docs/TIER3_LIVE_EVALUATION.md).
+
+## Expert tier aliases
+
+Tier-prefixed commands call the same implementations as the primary commands:
+
+```bash
+skillevaluator tier1 validate ./my-skill --no-dedup
+skillevaluator tier2 similarity-check ./skills
+skillevaluator tier3 evaluate ./my-skill --agents codex --env-mode docker
+```
 
 ## Installation options
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -101,4 +101,5 @@ skillevaluator --help
 The `gitleaks` secrets scanner is a required external Go binary that pip cannot
 install. When `code-integrity` runs without it, validation is `INCOMPLETE` and
 returns non-zero. Install it separately: `brew install gitleaks` (macOS) or
-`go install github.com/gitleaks/gitleaks/v8@latest`.
+download a binary from the official
+[Gitleaks releases](https://github.com/gitleaks/gitleaks/releases).

--- a/docs/TIER1_VALIDATION.md
+++ b/docs/TIER1_VALIDATION.md
@@ -1,17 +1,53 @@
 # Tier 1: Static and Security Validation
 
-Tier 1 is the deterministic quality gate: schema, quality, security, PII,
-license, secrets, code-integrity, Unicode-safety, and script checks that run
+Tier 1 is the deterministic quality gate for skills: schema, quality, security,
+PII, license, secrets, code-integrity, Unicode-safety, and script checks that run
 offline after the scanner binaries are installed. No API key is needed for the
-deterministic stages. The only LLM-backed
-pieces of Tier 1 are `rubric-eval` (LLM required) and the optional
-`--llm`/`--llm-verify` flags — those need a configured provider
-(see [CONFIGURATION.md](CONFIGURATION.md)).
+deterministic stages. The only LLM-backed pieces of Tier 1 are `rubric-eval`
+(LLM required) and the optional `--llm`/`--llm-verify` flags — those need a
+configured provider (see [CONFIGURATION.md](CONFIGURATION.md)).
+
+## Table of Contents
+
+- [Commands](#commands)
+- [Skill Detection and Selection](#skill-detection-and-selection)
+- [Validation Profiles](#validation-profiles)
+- [Checks](#checks)
+  - [Selecting checks](#selecting-checks)
+  - [schema](#schema-repository-governance)
+  - [security](#security-vulnerability-scanning)
+  - [pii](#pii-detection)
+  - [license](#license-compliance)
+  - [code-integrity](#code-integrity)
+  - [dependency](#dependency-cve-audit-opt-in)
+  - [unicode](#unicode-smuggling-detection)
+  - [quality](#quality-scoring)
+  - [Rubric evaluation](#rubric-evaluation-llm-as-judge)
+  - [lint](#lint-script-linting-advisory)
+  - [version](#version-check-opt-in)
+- [LLM Verification](#llm-verification)
+- [Reports](#reports)
+- [Using validate in CI](#using-validate-in-ci)
+- [Configuration](#configuration)
+- [Troubleshooting](#troubleshooting)
+- [Skill Content Summary](#skill-content-summary)
+- [See Also](#see-also)
 
 ## Commands
 
+Tier 1 is exposed through one umbrella command and five standalone commands:
+
+| Command | Purpose |
+| --- | --- |
+| `validate` | Run the selected Tier 1 checks, Tier 2 deduplication by default, and optional advisory Tier 3 evaluation |
+| `quality-check` | Score skill quality across four weighted categories |
+| `rubric-eval` | Run the nine-criterion LLM-as-judge rubric |
+| `security-scan` | Run SkillSpector static scanning and optional LLM analysis |
+| `pii-scan` | Detect PII, credentials, secrets, and local identifiers |
+| `lint-scripts` | Run advisory AST-based checks on Python scripts |
+
 ```bash
-skillevaluator validate ./my-skill            # full Tier 1 + Tier 2 dedup
+skillevaluator validate ./my-skill            # default Tier 1 suite + Tier 2 dedup
 skillevaluator validate ./my-skill --no-dedup # Tier 1 only, no key needed
 skillevaluator quality-check ./my-skill       # quality score only
 skillevaluator security-scan ./my-skill       # security checks only
@@ -23,28 +59,176 @@ skillevaluator rubric-eval ./my-skill         # LLM-as-judge rubric scoring
 skillevaluator validate ./my-skill --llm      # + LLM security analysis
 ```
 
-`validate` is the umbrella command: Tier 1 checks gate the exit code
-(non-zero on failure or incomplete required scanner evidence — safe to use as
-a CI gate), Tier 2 dedup runs by
+`validate` is the umbrella command: Tier 1 checks gate the exit code (non-zero
+on failure or incomplete required scanner evidence), Tier 2 dedup runs by
 default and degrades gracefully without embedding access, and Tier 3 can be
 attached with `--agent-eval` as an advisory pass.
 
-## Selecting checks
+## Skill Detection and Selection
+
+Pass either a skill directory containing `SKILL.md` or a collection containing
+skills under `skills/` or `team-skills/`. Folder-level validation discovers each
+live `SKILL.md` below the target while excluding configured names such as
+`evals`, `results`, `versions`, `.git`, `.venv`, `node_modules`, and
+`__pycache__`.
+
+`validate` auto-detects skill targets. Use `--type skill` when the path is
+ambiguous:
+
+```bash
+skillevaluator validate ./skills/my-skill --type skill
+skillevaluator validate ./skills --type skill --continue-on-failure
+```
+
+`--fail-fast` stops after the first failed check. `--continue-on-failure`
+overrides it, records the full pipeline, and keeps scanning a collection after
+a critical finding.
+
+## Validation Profiles
+
+The bundled `external` profile is the default public-publication policy. It
+requires a well-formed `metadata.author` value but does not restrict the email
+domain. Missing or malformed author attribution is HIGH severity. Blocked
+license findings are CRITICAL; missing or unknown licenses are reported for
+review.
+
+```bash
+skillevaluator validate ./my-skill                         # default = external
+skillevaluator validate ./my-skill --profile external      # explicit public profile
+skillevaluator validate ./my-skill --external              # alias for --profile external
+skillevaluator validate ./my-skill --policy ./policy.yaml  # custom overlay
+SKILLEVALUATOR_PROFILE=external skillevaluator validate ./my-skill
+```
+
+Precedence, highest to lowest, is `--policy` overlay, `--profile` flag,
+`SKILLEVALUATOR_PROFILE` environment variable, then the bundled `external`
+default.
+
+A custom policy overlays the external profile. It can narrow the accepted
+author domain and change severities by `CATEGORY.check_name` or `CATEGORY.*`:
+
+```yaml
+profile: community-strict
+identity:
+  author_email_regex: '<[^>]+@example\.org>'
+severity_overrides:
+  SCHEMA.author_missing: critical
+  LICENSE.*: critical
+```
+
+The active profile is included in the terminal banner and saved reports so
+reviewers can see which gate was applied.
+
+## Checks
+
+### Selecting checks
 
 `--checks` takes a comma-separated subset of the Tier 1 checks:
 
 | Check | What it covers |
 | --- | --- |
-| `schema` | SKILL.md frontmatter, repository governance, naming |
-| `security` | SkillSpector static scan; `--llm` adds enrichment without replacing static findings |
-| `pii` | Personally identifiable information |
-| `license` | License compliance |
-| `code-integrity` | Bandit, packaged-rule Semgrep, external Gitleaks, and dead-link/dependency-file/static-test-discovery hygiene |
-| `unicode` | Unicode smuggling detection |
-| `quality` | Quality score (skill-only; threshold via `--min-score`, default 70) |
-| `lint` | Script linting (skill-only) |
-| `version` | Opt-in: version checks (not run by default) |
-| `dependency` | Opt-in: dependency vulnerability audit (not run by default) |
+| `schema` | `SKILL.md` frontmatter, repository governance, and naming |
+| `security` | SkillSpector static scan; `--llm` adds analysis without replacing static findings |
+| `pii` | Personally identifiable information, credentials, and local identifiers |
+| `license` | License evidence and compliance |
+| `code-integrity` | Bandit, packaged-policy Semgrep, external Gitleaks, dead links, dependency-file hygiene, and static test discovery |
+| `unicode` | Unicode smuggling and invisible-character detection |
+| `quality` | Four-category quality score; threshold via `--min-score` (default 70) |
+| `lint` | Advisory Python script linting |
+| `version` | Opt-in three-part numeric version check |
+| `dependency` | Opt-in dependency vulnerability audit |
+
+The default set is `schema`, `security`, `pii`, `license`, `code-integrity`,
+`unicode`, `quality`, and `lint`. `version` and `dependency` run only when
+selected explicitly.
+
+```bash
+skillevaluator validate ./my-skill --checks schema,pii
+skillevaluator validate ./my-skill --checks schema,security,quality,lint
+skillevaluator validate ./my-skill --checks dependency
+```
+
+Accepted aliases include `code`/`code-risk` for `code-integrity`,
+`scripts`/`script-lint` for `lint`, `dependencies`/`deps`/`dependency-audit` for
+`dependency`, and `licence`/`license-check` for `license`.
+
+### schema (repository governance)
+
+The `schema` check validates `SKILL.md` frontmatter and repository placement:
+
+- YAML frontmatter must parse and satisfy the skill schema.
+- `name` and `description` are required. Names are 1–64 characters and
+  descriptions are 1–1024 characters.
+- Names use kebab-case, start with a letter, and cannot have trailing or
+  consecutive hyphens. The directory name must match the frontmatter `name`.
+- `alwaysApply` and `globs` are forbidden skill fields.
+- Optional fields include `license`, `compatibility`, `metadata`, and
+  `allowed-tools`.
+- The standard hierarchy is `skills/<skill-name>/` or
+  `team-skills/<team>/<skill-name>/`. A nonstandard standalone location is
+  reported as an advisory finding.
+- `SKILL.md` should remain at or below 500 lines; larger files receive an
+  advisory finding.
+- The default profile expects `metadata.author` in `Name <email@host>` form but
+  does not require a particular email domain.
+
+### security (vulnerability scanning)
+
+`security-scan`, and the `security` check inside `validate`, run SkillSpector.
+Static scanning covers common patterns in four broad areas:
+
+- **Prompt injection** — instruction override, hidden instructions, prompt
+  disclosure, role manipulation, and context-reset attempts.
+- **Data exfiltration** — external transmission, environment-variable
+  harvesting, file-system enumeration, and clipboard access.
+- **Privilege escalation** — elevated execution, credential-file access, and
+  system-configuration modification.
+- **Supply chain** — unpinned dependencies, external script fetching, and code
+  obfuscation.
+
+```bash
+skillevaluator security-scan ./my-skill
+skillevaluator security-scan ./my-skill --llm
+skillevaluator security-scan ./my-skill --llm --llm-verify
+```
+
+The LLM pass requires a configured provider. It enriches the static result but
+does not replace static findings or make missing scanner evidence pass.
+
+### pii (detection)
+
+`pii-scan`, and the `pii` check inside `validate`, use configurable regex
+patterns to detect sensitive values.
+
+| Group | Examples | Notes |
+| --- | --- | --- |
+| Personal information | Personal paths, non-placeholder email addresses, phone numbers, SSNs, GPS coordinates, MAC addresses | Personal macOS/Windows paths are flagged; SSNs are CRITICAL |
+| Credentials and secrets | Database connection strings, hardcoded API keys, cloud keys, GitHub tokens, private keys, JWTs, webhook URLs | Most credential findings are CRITICAL |
+| Network and financial | Public IPs, credit-card numbers, cryptocurrency wallet addresses | Private RFC1918 addresses are excluded |
+
+Common placeholders such as `YOUR_API_KEY_HERE`, `example`, `test`, `dummy`,
+and `placeholder`, along with `@example.com` and `@test.com`, are excluded.
+Configured allowed paths are also excluded.
+
+### license (compliance)
+
+The `license` check looks for license evidence in frontmatter, common license
+files, and SPDX headers. It normalizes detected identifiers and applies the
+packaged permissive allowlist and restrictive blocklist. Missing or unknown
+licenses are reported for review; blocked licenses fail according to the active
+profile.
+
+### code-integrity
+
+The `code-integrity` check combines three validation groups:
+
+- **Code risk (Bandit and Semgrep)** — SQL or command injection, hardcoded
+  passwords, insecure cryptography, unsafe deserialization, `shell=True`,
+  `eval()`/`exec()`, CWE patterns, and language-specific anti-patterns.
+- **Secrets (Gitleaks)** — API keys, tokens, passwords, private keys, database
+  credentials, and other high-confidence secret patterns.
+- **Hygiene** — dead relative Markdown links, banned or unpinned dependency
+  declarations, and static discovery of conventional Python test filenames.
 
 Default Tier 1 does not import or execute target-controlled Python code. The
 `test_discovery` result is filename evidence only: it counts regular, in-tree,
@@ -58,41 +242,147 @@ Bandit, Semgrep, Gitleaks, or SkillSpector run as `INCOMPLETE`: terminal and
 saved reports are non-green and `validate` exits non-zero. Install
 `skillevaluator[security]` for the bundled Python scanners and install Gitleaks
 separately (`brew install gitleaks` or
-`go install github.com/gitleaks/gitleaks/v8@latest`).
+download a binary from the official
+[Gitleaks releases](https://github.com/gitleaks/gitleaks/releases)).
 
-Semgrep uses `skillevaluator/config/semgrep_rules.yaml` from the installed
-package, with metrics and version checks disabled; Tier 1 never fetches a
-Semgrep registry policy at runtime. Bundled scanners resolve next to the
-SkillEvaluator interpreter before PATH. Intentional replacements require an
-auditable absolute executable path in `SKILLEVALUATOR_BANDIT_PATH`,
-`SKILLEVALUATOR_SEMGREP_PATH`, or `SKILLEVALUATOR_SKILLSPECTOR_PATH`; relative,
-missing, and non-executable overrides fail closed.
+Semgrep uses a policy packaged with the installed distribution, with metrics
+and version checks disabled; Tier 1 never fetches a registry policy at runtime.
+Bundled scanners resolve next to the SkillEvaluator interpreter before PATH.
+Intentional replacements require an auditable absolute executable path in
+`SKILLEVALUATOR_BANDIT_PATH`, `SKILLEVALUATOR_SEMGREP_PATH`, or
+`SKILLEVALUATOR_SKILLSPECTOR_PATH`; relative, missing, and non-executable
+overrides fail closed.
 
-`rubric-eval` derives each criterion verdict locally: scores of 7/10 or higher
-pass, and lower scores fail regardless of the model-provided pass flag. The
-overall score is an importance-weighted mean, and the rubric passes only when
-that score meets `--min-score` and every criterion passes.
+### dependency (CVE audit, opt-in)
 
-Other useful flags: `--fail-fast` stops at the first failing check,
-`--continue-on-failure` records everything without stopping, `--llm` enables
-LLM-backed security analysis (requires a provider; add `--llm-verify` for a
-false-positive suppression pass), and `--profile external` (the default)
-validates for public publication. A custom policy YAML can be overlaid with
-`--policy`.
+The opt-in `dependency` check scans `requirements*.txt` for known Python package
+vulnerabilities. When `pyproject.toml` is present, `pip-audit --local` audits the
+active Python environment rather than resolving the dependencies declared in
+that file. `pip-audit` is the primary scanner; Safety supplies secondary
+coverage for requirements files when installed separately. The audit may use
+network-backed vulnerability databases.
 
-## Content types
+```bash
+skillevaluator validate ./my-skill --checks dependency
+```
 
-`validate` auto-detects what it is looking at; force it with `--type`:
+### unicode (smuggling detection)
 
-| Type | Detected from |
-| --- | --- |
-| `skill` | `SKILL.md` in `skills/` or `team-skills/` |
-| `rules` | `.mdc` files in `team-rules/` |
-| `workflows` | `workflow-rules.mdc` in a workflow directory |
-| `plugin` | `agent_plugin.yaml`/`.yml` or `.claude-plugin/plugin.json` manifest |
+The `unicode` check detects invisible Unicode characters associated with ASCII
+smuggling, hidden-data encoding, and trojan-source attacks.
 
-Quality, lint, and version checks are skill-only and are skipped for the
-other types.
+| Category | Range | Default severity |
+| --- | --- | --- |
+| Unicode Tags (ASCII smuggling) | `U+E0000..U+E007F` | CRITICAL; decodes the hidden ASCII payload |
+| BiDi overrides (trojan source) | `U+202A..U+202E`, `U+2066..U+2069`, `U+200E/F`, `U+061C` | HIGH |
+| Zero-width characters | `U+200B/C/D`, `U+034F`, `U+180E`, `U+2060`, `U+FEFF` | MEDIUM or LOW |
+| Invisible operators and deprecated controls | `U+2061..U+2064`, `U+206A..U+206F` | MEDIUM |
+| Variation selectors | `U+FE00..U+FE0F`, `U+E0100..U+E01EF` | LOW |
+
+Severity increases with suspicious run length. A BOM (`U+FEFF`) at byte zero
+is downgraded to INFO, and binary files are skipped using MIME and null-byte
+detection.
+
+### quality (scoring)
+
+`quality-check`, and the `quality` check inside `validate`, produce a 0–100
+composite score across four weighted categories.
+
+| Category | Weight | What it evaluates |
+| --- | --- | --- |
+| Correctness | 35% | Frontmatter, naming, examples, paths, and skill-type-specific structure |
+| Discoverability | 25% | Description quality, trigger wording, purpose, scope, and naming |
+| Reliability | 25% | Error handling, prerequisites, limitations, troubleshooting, and implementation safeguards |
+| Efficiency | 15% | Token budget, body length, repetition, instruction clarity, and reference use |
+
+Grades are A for scores of at least 90, B for at least 80, C for at least 70,
+D for at least 60, and F below 60. The default `--min-score` is 70.
+
+The checker detects five skill shapes and applies relevant checks:
+
+- **script-based** — Python or shell files under `scripts/`.
+- **lib-based** — a Python module containing `__init__.py`.
+- **resource-based** — assets, templates, design-system content, or resources.
+- **guide-only** — documentation without executable or resource content.
+- **hybrid** — scripts plus library or resource content.
+
+### Rubric evaluation (LLM-as-Judge)
+
+`rubric-eval` sends bounded skill documentation and selected supplementary
+content to a configured LLM provider. It scores nine criteria:
+
+1. Description clarity and when to use the skill.
+2. Instruction clarity and actionable steps.
+3. Example quality and query variation.
+4. Documentation completeness.
+5. Scope definition.
+6. Professional tone and formatting.
+7. Trigger simulation against positive and negative queries.
+8. End-to-end completeness.
+9. Actionable error handling.
+
+Each criterion is scored from 0 to 10. The local evaluator, not the model's
+boolean, treats 7 or higher as passing. The overall score is an
+importance-weighted mean, and the rubric passes only when that score reaches
+`--min-score` and every criterion passes.
+
+```bash
+skillevaluator rubric-eval ./my-skill --min-score 70
+```
+
+### lint (script linting, advisory)
+
+`lint-scripts`, and the `lint` check inside `validate`, parse Python scripts
+under `scripts/` and report advisory findings. These findings do not make the
+Tier 1 gate fail.
+
+| Check | Severity | Detects |
+| --- | --- | --- |
+| `flat_script` | MEDIUM | No function definitions |
+| `deep_nesting` | MEDIUM | Control-flow nesting deeper than 6 |
+| `magic_numbers` | LOW | Raw numeric constants outside the safe constant set |
+| `missing_shebang` | LOW | No leading shebang (`#!`) |
+| `no_input_validation` | LOW | No `argparse`, `click`, `typer`, or explicit raise pattern |
+
+### version check (opt-in)
+
+The opt-in `version` check validates `metadata.version` as a three-part numeric
+value in `major.minor.patch` form:
+
+```yaml
+metadata:
+  version: "1.2.3"
+```
+
+When `SKILLEVALUATOR_PREVIOUS_VERSION` is set, the current version must be
+numerically greater than the previous value. A missing version remains valid;
+the skill then relies on commit history.
+
+```bash
+SKILLEVALUATOR_PREVIOUS_VERSION=1.2.2 \
+  skillevaluator validate ./my-skill --checks schema,version
+```
+
+## LLM Verification
+
+`validate`, `security-scan`, and `pii-scan` accept `--llm-verify` for a
+second-pass review of static findings:
+
+1. Static analysis produces the initial findings.
+2. Each finding is sent to the configured provider for contextual review.
+3. Confirmed findings remain at their original severity. High-confidence false
+   positives remain visible, are downgraded to INFO, and carry verification
+   metadata explaining the review.
+
+```bash
+skillevaluator security-scan ./my-skill --llm --llm-verify
+skillevaluator pii-scan ./my-skill --llm-verify
+skillevaluator validate ./my-skill --llm-verify
+```
+
+Static scanning still runs first. If a requested LLM stage is unavailable or
+returns unusable evidence, the run does not silently turn green. See
+[CONFIGURATION.md](CONFIGURATION.md) for supported public providers.
 
 ## Reports
 
@@ -102,9 +392,9 @@ destination (default `reports/`):
 | Format | Output |
 | --- | --- |
 | `cli` | Rich terminal table (default) |
-| `json` | `skillevaluator-output-<timestamp>.json` |
-| `html` | Standalone `skillevaluator-output-<timestamp>.html` |
-| `markdown` | `skillevaluator-output-<timestamp>.md`, ready for PR comments |
+| `json` | `validate` writes `skillevaluator-output-<timestamp>.json`; standalone commands use command-specific basenames |
+| `html` | `validate` writes standalone `skillevaluator-output-<timestamp>.html`; standalone commands use command-specific basenames |
+| `markdown` | `validate` writes `skillevaluator-output-<timestamp>.md`; standalone commands use command-specific basenames |
 
 For skill targets, `validate` also writes `BENCHMARK.md` regardless of the `-r`
 selection. It records `INCOMPLETE` and never recommends publication when
@@ -117,7 +407,7 @@ skillevaluator validate ./my-skill -r cli,json,html -o reports/
 ## Using validate in CI
 
 `validate` returns a non-zero exit code when a Tier 1 gate fails, and the
-markdown report drops straight into a PR comment:
+Markdown report can be posted directly as a PR comment:
 
 ```yaml
 - name: Validate skill
@@ -125,13 +415,63 @@ markdown report drops straight into a PR comment:
     skillevaluator validate ./my-skill --no-llm --no-dedup -r cli,markdown -o reports
 ```
 
-Run it with `--no-llm --no-dedup` for a hermetic, key-free gate, or configure
-a provider secret and drop those flags for full coverage.
+Run with `--no-llm --no-dedup` for a hermetic, key-free gate. For LLM-enriched
+default validation coverage, configure a provider, replace `--no-llm` with
+`--llm`, and remove `--no-dedup`. The opt-in `version` and `dependency` checks
+and standalone `rubric-eval` remain separate choices.
 
-## More commands
+## Configuration
 
-- `skillevaluator tier1|tier2|tier3 <command>` — expert alias groups. The
-  Tier 3-only members (`tier3 validate`, `tier3 harbor-view`) are covered in
-  the [live evaluation guide](TIER3_LIVE_EVALUATION.md).
-- `skillevaluator health-check` and `doctor` probe Tier 3 agent/backend
-  readiness; they are not Tier 1 validation commands.
+Public Tier 1 configuration ships inside the package under
+`skillevaluator/config/`:
+
+- `pii_patterns.yaml` — PII categories, severities, suggestions, and
+  exceptions.
+- `unicode_smuggle_patterns.yaml` — invisible-character categories, severity
+  thresholds, and exceptions.
+- `license_config.yaml` — permissive-license allowlist and restrictive-license
+  blocklist.
+- `profiles/external.yaml` — the default public validation profile.
+
+Semgrep's static policy is also packaged with the distribution. Provider and
+credential configuration is documented in [CONFIGURATION.md](CONFIGURATION.md).
+
+## Troubleshooting
+
+- **Gitleaks is not installed** — install it with `brew install gitleaks` or
+  download a binary from the official
+  [Gitleaks releases](https://github.com/gitleaks/gitleaks/releases).
+- **A Python scanner is missing** — install the security extra with
+  `skillevaluator[security]`. Required scanner failures remain `INCOMPLETE`
+  until the scanner is installed and returns valid evidence.
+- **An LLM-backed stage fails immediately** — configure a supported provider or
+  omit `--llm`/`--llm-verify`. Use `--no-dedup` when a fully key-free Tier 1 run
+  is required.
+- **No scannable files are found** — confirm that the skill contains supported
+  text or code extensions such as `.py`, `.sh`, `.yaml`, `.yml`, `.json`, `.md`,
+  or `.txt`.
+- **An executable override is rejected** — use an existing, executable absolute
+  path for the relevant `SKILLEVALUATOR_*_PATH` variable.
+
+## Skill Content Summary
+
+| Aspect | Skill requirement |
+| --- | --- |
+| Manifest | `SKILL.md` |
+| Standard location | `skills/<skill-name>/` or `team-skills/<team>/<skill-name>/` |
+| Required frontmatter | `name`, `description`, and profile-governed `metadata.author` |
+| Optional frontmatter | `license`, `compatibility`, `metadata`, `allowed-tools` |
+| Forbidden frontmatter | `alwaysApply`, `globs` |
+| Naming | Kebab-case; directory name matches frontmatter `name` |
+| Recommended maximum | 500 lines in `SKILL.md` |
+| Default supporting directories | `references/`, `scripts/`, `assets/`, `evals/`, `tools/`, `config/` |
+
+## See Also
+
+- [Installation](INSTALLATION.md) — install the base package and optional extras.
+- [Configuration](CONFIGURATION.md) — providers, credentials, and offline modes.
+- [Tier 2 Deduplication](TIER2_DEDUPLICATION.md) — semantic overlap and local
+  catalog checks.
+- [Tier 3 Live Evaluation](TIER3_LIVE_EVALUATION.md) — advisory live agent
+  evaluation.
+- [Developer Guide](DEVELOPER_GUIDE.md) — local development and testing.

--- a/docs/TIER2_DEDUPLICATION.md
+++ b/docs/TIER2_DEDUPLICATION.md
@@ -1,52 +1,105 @@
 # Tier 2: Semantic Deduplication
 
-Tier 2 covers two complementary workflows:
+Tier 2 detects duplicate and overlapping skill content with embedding-based
+similarity analysis and, for intra-skill candidates, chat-LLM verification. It
+covers two complementary problems:
 
-- **Intra-skill deduplication** finds repeated or overlapping guidance inside
-  one skill before it bloats the agent's context window.
-- **Inter-skill similarity** compares skills directly or checks one candidate
-  against a versioned local catalog.
+| | Intra-skill context deduplication | Inter-skill similarity |
+| --- | --- | --- |
+| **Scope** | Within one skill directory | Across a skill collection, or one candidate against a local catalog |
+| **Question** | "Does this skill repeat guidance internally?" | "Does this skill overlap an existing skill?" |
+| **Embedding storage** | Ephemeral and in memory for each run | Ephemeral for a direct scan, or a versioned local JSON catalog |
+| **Comparison** | Pairwise cosine similarity followed by Union-Find clustering | Pairwise cosine similarity, or one target compared with catalog entries |
+| **Chat LLM role** | Classifies overlapping candidate clusters | None; the check is embeddings-only |
+| **Command** | `context-optimization-check` (`dedup-scan` is an alias) | `similarity-check` |
 
-Both workflows run from local files. There is no Milvus, vector database,
-catalog server, or NVIDIA-internal service dependency.
+Both modes use local input files. No external vector database or catalog service
+is required.
 
-All three commands need an embeddings API: an LLM provider key
-(see [CONFIGURATION.md](CONFIGURATION.md)) or any local OpenAI-compatible
-endpoint (see the
-[fully-local recipe](CONFIGURATION.md#fully-local-tier-2-no-external-calls)).
+Tier 2 needs a configured embeddings provider. Intra-skill analysis also needs
+a configured chat LLM. If the selected chat provider does not offer embeddings,
+configure an embeddings provider separately. See
+[`CONFIGURATION.md`](CONFIGURATION.md), including the
+[fully local recipe](CONFIGURATION.md#fully-local-tier-2-no-external-calls).
 
-### Data sent to configured providers
+## Table of Contents
 
-- In the default inter-skill mode, skill names and descriptions are sent to
-  the configured embeddings provider. With `--full-body`, the full manifest is sent instead.
-- For intra-skill analysis, scannable content chunks are sent to the embeddings
-  provider. Only overlapping candidate clusters are sent to the configured
-  chat LLM for classification.
+- [Commands](#commands)
+- [Inter-Skill Similarity (`similarity-check`)](#inter-skill-similarity-similarity-check)
+- [Intra-Skill Context Deduplication (`context-optimization-check`)](#intra-skill-context-deduplication-context-optimization-check)
+- [Provider Data and Privacy](#provider-data-and-privacy)
+- [Defaults](#defaults)
+- [Reports and Exit Behavior](#reports-and-exit-behavior)
+- [Safety and Resource Limits](#safety-and-resource-limits)
+- [Edge Cases](#edge-cases)
+- [See Also](#see-also)
 
-Use the fully local provider recipe above when this content must not leave the
-machine. Catalog files remain local unless you explicitly share them.
-
-## Intra-skill deduplication
-
-```bash
-skillevaluator context-optimization-check ./my-skill  # redundant content (threshold 0.8)
-skillevaluator dedup-scan ./my-skill                  # alias for the command above
-```
-
-`context-optimization-check` clusters overlapping sections with embeddings and
-uses a chat LLM to explain the overlap. `dedup-scan` is an alias with the same
-options and behavior. Use `--threshold` to tune sensitivity.
-
-## Inter-skill similarity
-
-Compare every skill in a directory directly:
+## Commands
 
 ```bash
-skillevaluator similarity-check ./skills  # embeddings only; default threshold 0.75
+# Compare every skill in a collection directly.
+skillevaluator similarity-check ./skills --threshold 0.75
+
+# Save a reusable local catalog, then compare one candidate with it.
+skillevaluator similarity-check ./skills --save-catalog ./skill-catalog.json
+skillevaluator similarity-check ./candidate-skill --catalog ./skill-catalog.json
+
+# Find repeated content within one skill.
+skillevaluator context-optimization-check ./my-skill --threshold 0.80
+skillevaluator dedup-scan ./my-skill  # functional alias with the same analysis options
+
+# validate runs the intra-skill pass by default.
+skillevaluator validate ./my-skill
+skillevaluator validate ./my-skill --no-dedup
 ```
 
-For repeated checks, save the collection as a local catalog and compare one
-candidate skill against it:
+`validate` skips its Tier 2 pass with a warning when the optional Tier 2
+dependencies or an embeddings provider are unavailable. Use `--no-dedup` to
+disable that pass explicitly.
+
+## Inter-Skill Similarity (`similarity-check`)
+
+`similarity-check` finds duplicate or overlapping skills with vector-embedding
+cosine similarity. It recursively discovers skill manifests, extracts each
+skill's name and description by default, embeds that text with the configured
+embeddings provider, and reports pairs at or above the selected threshold.
+
+### Direct collection scan
+
+```bash
+skillevaluator similarity-check ./skills
+skillevaluator similarity-check ./skills --full-body --threshold 0.50
+```
+
+A direct scan compares every discovered skill with every other discovered skill.
+The default threshold is `0.75`, which reports `SIMILAR` and stronger matches.
+
+| Classification | Score | Severity/default behavior |
+| --- | --- | --- |
+| `EXACT_DUPLICATE` | >= 0.95 | CRITICAL; blocking |
+| `HIGH_SIMILARITY` | >= 0.90 | HIGH; blocking |
+| `SIMILAR` | >= 0.75 | MEDIUM; advisory |
+| `LOOSELY_RELATED` | >= 0.50 | LOW; advisory |
+| `DISTINCT` | < 0.50 | INFO; advisory; below the default reporting threshold |
+
+The threshold controls which score bands are returned; it does not change the
+classification boundaries. Useful options include:
+
+- `--threshold <0.0-1.0>` controls the minimum reported cosine score.
+- `--full-body` embeds each discovered `SKILL.md` in full, including its
+  frontmatter, with chunked average pooling instead of embedding only the name
+  and description. It does not include supporting files.
+- `--model <model-id>` overrides the configured embedding model for this run.
+- `--type skill` explicitly selects skill discovery when automatic detection is
+  not suitable.
+- `--save-catalog <path>` writes a reusable local catalog from the supplied
+  collection.
+- `--catalog <path>` compares exactly one supplied skill against an existing
+  catalog.
+
+### Local catalog comparison
+
+For repeated checks, save a collection once and query one candidate against it:
 
 ```bash
 skillevaluator similarity-check ./skills --save-catalog ./skill-catalog.json
@@ -54,45 +107,209 @@ skillevaluator similarity-check ./candidate-skill --catalog ./skill-catalog.json
 ```
 
 `--save-catalog` builds the catalog from the supplied collection. `--catalog`
-requires an existing catalog and compares only the supplied target against its
-entries; it does not compare catalog entries with one another or silently
-rebuild a missing catalog.
+requires an existing catalog and a candidate directory containing a root
+`SKILL.md`. It compares only that candidate against the catalog entries; it does
+not compare catalog entries with one another or silently rebuild a missing
+catalog.
 
-Catalogs use a versioned JSON schema and contain finite embedding vectors,
+Catalogs use a versioned JSON schema. They contain finite embedding vectors,
 relative skill paths, display names, descriptions, content fingerprints, and
-the provider/model metadata needed for compatibility checks. They do not
-contain API keys. A malformed, incompatible, non-finite, or oversized catalog
-is rejected with an actionable error; rebuild it with the provider and model
-you intend to query. Because the file includes derived skill content, review it
-before sharing it like any other generated project artifact.
+provider, model, mode, and endpoint-fingerprint metadata for compatibility
+checks. They do not contain API keys.
 
-Direct scans and catalog queries accept `--threshold` to tune sensitivity.
+The provider, model, endpoint, vector length, and description-versus-full-body
+mode used for a query must be compatible with the catalog. A missing, malformed,
+incompatible, non-finite, or oversized catalog is rejected with an actionable
+error. Query with matching settings or rebuild the catalog with the settings
+you intend to use.
 
-## Where the LLM comes in
+Catalogs remain local unless you explicitly share them. Because they contain
+embeddings and other data derived from skill content, review them before sharing
+them like any other generated project artifact.
 
-- `similarity-check` is embeddings-only: no chat LLM is called.
-- `context-optimization-check` and its `dedup-scan` alias use embeddings to
-  find overlap candidates, then a chat LLM to analyze them. Both accept
-  `--llm-model` to override the analysis model.
+## Intra-Skill Context Deduplication (`context-optimization-check`)
 
-## Reports and exit behavior
+As a skill grows, its directory can accumulate repeated content: copied sections
+between `SKILL.md` and reference documents, near-identical guidance under
+different headings, or script docstrings that restate the main instructions.
+That repetition consumes context without adding useful information.
 
-All workflows support CLI, JSON, HTML, and Markdown output:
+Not every similarity is redundant. A short overview in `SKILL.md` and a detailed
+explanation in `references/` are intentional progressive disclosure. Tier 2 uses
+a two-stage process so embeddings can find likely overlap and a chat LLM can
+classify its purpose.
+
+### Two-stage pipeline
+
+```text
+SKILL DIRECTORY
+  SKILL.md | README.md | references/*.md | scripts/*.py, *.sh
+        |
+        v
+  FILE COLLECTOR       Walk the directory, filter extensions, strip frontmatter,
+                       and retain source paths and line numbers
+        |
+        v
+  CONTENT CHUNKER      Markdown heading sections; Python signatures/docstrings;
+                       shell functions and comment blocks
+        |
+        v
+  STAGE 1: EMBEDDINGS  Batch-embed chunks; compare cosine scores;
+                       group connected matches with Union-Find
+        |
+        v
+  STAGE 2: CHAT LLM    Classify each candidate cluster and provide reasoning
+                       plus a suggested author action
+        |
+        v
+  STRUCTURED REPORT    Actionable duplicate findings with source locations
+```
+
+### File collection and chunking
+
+| Extension | Chunking strategy |
+| --- | --- |
+| `.md`, `.mdc` | Heading-based sections; sections over 3,000 characters are split at eligible paragraph boundaries when possible; chunks under 80 characters are dropped |
+| `.py` | Module docstrings plus class and function signatures with their docstrings; implementation bodies are not included |
+| `.sh` | Function bodies and comment blocks of at least three consecutive comment lines |
+| Other extensions | Skipped |
+
+Valid mapping frontmatter is removed from Markdown before chunking. Malformed,
+empty, or non-mapping frontmatter remains part of the analyzed text. Every
+retained chunk keeps its source file and line range so findings can point
+authors to the overlapping sections.
+
+### Stage 1: embedding clustering
+
+All chunks are embedded in batches with the configured embeddings provider. For
+`N` chunks, Tier 2 evaluates `N * (N - 1) / 2` cosine scores. Pairs at or above
+the threshold are joined with Union-Find, and each connected component with at
+least two members becomes a candidate cluster.
+
+The default intra-skill threshold is `0.80`. It is higher than the default
+inter-skill threshold because sections from the same skill naturally share more
+domain vocabulary.
+
+### Stage 2: chat-LLM verification
+
+The actual text in each candidate cluster is sent to the configured chat LLM.
+The model returns a structured verdict with a confidence score, reasoning, and a
+suggested author action:
+
+| Verdict | Meaning | Reporting behavior |
+| --- | --- | --- |
+| `DUPLICATE` | Content repeats the same information without a meaningful addition | Report an actionable finding and recommend consolidation |
+| `INTENTIONAL_DETAIL` | One section summarizes content that another section develops in detail | Do not report an actionable finding |
+| `RELATED_BUT_DISTINCT` | Sections discuss the same topic for different purposes or from different angles | Do not report an actionable finding |
+
+Duplicate findings use the following severity behavior:
+
+| Condition | Severity |
+| --- | --- |
+| `DUPLICATE` with confidence >= 0.70 | HIGH; blocking |
+| `DUPLICATE` with confidence < 0.70 | MEDIUM; advisory |
+| Short, same-file duplicate made only of comment or configuration-style text | Capped at LOW; advisory |
+
+If chat-LLM analysis fails for a candidate cluster, Tier 2 reports the incomplete
+analysis as a blocking error rather than treating the content as clean.
+
+```bash
+skillevaluator context-optimization-check ./my-skill
+skillevaluator context-optimization-check ./my-skill --threshold 0.85
+skillevaluator dedup-scan ./my-skill  # functional alias
+```
+
+Both intra-skill command names accept `--threshold`, `--model`, `--llm-model`,
+and the same report options. Their default report basenames identify which
+command name was invoked.
+
+## Provider Data and Privacy
+
+- A default inter-skill scan sends skill names and descriptions to the configured
+  embeddings provider. `--full-body` sends each discovered `SKILL.md` in full,
+  including frontmatter, in embedding chunks; supporting files are not sent.
+- Intra-skill analysis sends retained content chunks to the configured
+  embeddings provider. Only candidate clusters found by the embedding stage are
+  sent to the configured chat LLM for classification.
+- `similarity-check` never calls a chat LLM.
+- Catalog files are read and written locally; SkillEvaluator does not upload them
+  to a catalog service.
+
+Use the [fully local provider recipe](CONFIGURATION.md#fully-local-tier-2-no-external-calls)
+when skill content must not leave the machine. Review the provider's own data
+handling terms before sending confidential skill content to a hosted endpoint.
+
+## Defaults
+
+| Setting | Default | Purpose |
+| --- | --- | --- |
+| Inter-skill reporting threshold | `0.75` | Reports `SIMILAR` and stronger matches |
+| Intra-skill clustering threshold | `0.80` | Selects candidate chunk pairs for clustering |
+| Minimum content chunk | `80` characters | Drops fragments too small to compare usefully |
+| Large Markdown section split point | `3,000` characters | Attempts to split oversized sections at eligible paragraph boundaries |
+| High-confidence duplicate boundary | `0.70` | Maps actionable duplicate verdicts to HIGH rather than MEDIUM |
+
+Provider endpoints and default models are intentionally documented in
+[`CONFIGURATION.md`](CONFIGURATION.md) instead of duplicated here.
+
+## Reports and Exit Behavior
+
+All Tier 2 commands support CLI, JSON, HTML, and Markdown output:
 
 ```bash
 skillevaluator similarity-check ./skills \
   -r cli,json,html,markdown -o ./reports
 ```
 
-Findings at or above the configured threshold are reported as Tier 2 results.
-Blocking findings produce a non-zero exit code in every output mode, making the
-commands usable as CI gates.
+Inter-skill matches at or above the selected threshold and actionable
+intra-skill duplicate findings are emitted as Tier 2 results. HIGH and CRITICAL
+findings, along with blocking analysis errors, produce a non-zero exit code;
+MEDIUM and LOW findings are advisory. The exit behavior is the same in every
+output mode, so the commands can be used as CI gates.
 
-Tier 2 rejects linked or escaping input files before provider calls and applies
-explicit input, chunk, catalog, and comparison limits. If a project exceeds a
-limit, split the collection into intentional batches rather than scanning an
-unbounded tree.
+## Safety and Resource Limits
 
-`validate` runs the Tier 2 dedup pass by default and skips it gracefully
-when no embedding provider is configured; pass `--no-dedup` to turn it off
-explicitly.
+Tier 2 treats skill content and catalog files as untrusted input. Before any
+provider call, it rejects linked roots, linked or escaping files, non-regular
+files, and paths outside the verified scan root.
+
+Explicit limits bound discovered paths, file counts, per-file and total input
+bytes, content chunks, candidate clusters, catalog size and entry count, vector
+length, returned matches, and pairwise scalar work. Catalog loading also
+rejects duplicate JSON keys, unexpected fields, invalid identities, non-finite
+vectors, and incompatible provider metadata.
+
+If a collection exceeds a limit, split it into intentional batches rather than
+scanning an unbounded directory tree.
+
+## Edge Cases
+
+### Intra-skill analysis
+
+| Scenario | Behavior |
+| --- | --- |
+| Skill contains only `SKILL.md` | Checks repeated sections within that file |
+| Fewer than two chunks remain | Succeeds with “Not enough content to compare” |
+| Markdown has no headings | Treats the body as a preamble and attempts paragraph splitting when oversized; retains the original section if no eligible split is produced |
+| Unsupported extension | Skips the file |
+| Duplicate sections occur in one file | Reports the relevant headings and line ranges |
+| Embedding or chat-LLM analysis is incomplete | Reports an error; does not claim a clean result |
+
+### Inter-skill analysis
+
+| Scenario | Behavior |
+| --- | --- |
+| Direct collection has fewer than two skills | Returns an actionable input error |
+| Catalog source collection is empty | Refuses to save an empty catalog |
+| Catalog path is missing | Returns an error and does not rebuild it silently |
+| Candidate lacks a root `SKILL.md` | Rejects the catalog query |
+| Candidate matches multiple catalog entries | Reports matches in descending similarity order |
+| Provider, endpoint, model, mode, or vector length differs | Rejects the catalog; query with matching settings or rebuild it |
+| Catalog is malformed, non-finite, or oversized | Rejects it before comparison |
+
+## See Also
+
+- [`CONFIGURATION.md`](CONFIGURATION.md) — provider setup and fully local Tier 2.
+- [`TIER1_VALIDATION.md`](TIER1_VALIDATION.md) — static, security, and quality validation.
+- [`TIER3_LIVE_EVALUATION.md`](TIER3_LIVE_EVALUATION.md) — live skill evaluation.
+- [`README.md`](../README.md) — installation and end-to-end examples.

--- a/docs/TIER3_LIVE_EVALUATION.md
+++ b/docs/TIER3_LIVE_EVALUATION.md
@@ -2,10 +2,31 @@
 
 Live evaluation answers one question: **does your skill actually make an agent
 better at the task?** Skill Evaluator runs a real agent (such as `codex`,
-`claude-code`, or `opencode`) against your eval cases twice — once with the
-skill installed and once without — inside an isolated
-[Harbor](https://github.com/harbor-framework/harbor) environment, then judges
-and compares the results.
+`claude-code`, or `opencode`) against the same eval cases with the skill
+installed and, unless `--skip-baseline` is used, without it — in a selected
+[Harbor](https://github.com/harbor-framework/harbor) environment. Docker and
+cloud backends provide environment isolation; local mode applies its configured
+OS-sandbox policy.
+
+With `default` or `default_plus_custom` grading, completed reports lead with five
+human-readable dimensions: **Security, Correctness, Discoverability,
+Effectiveness, and Efficiency**. The with-skill and without-skill results make
+the skill's effect visible rather than treating a single agent run as proof of
+quality. In `custom_only` mode, the user-owned grader defines the score instead.
+
+## Table of Contents
+
+- [Quick Start](#quick-start)
+- [How a Run Works](#how-a-run-works)
+- [Two Ways to Run Tier 3](#two-ways-to-run-tier-3)
+- [Prerequisites and Credentials](#prerequisites-and-credentials)
+- [Commands](#commands)
+- [Choosing an Environment](#choosing-an-environment)
+- [Eval Datasets](#eval-datasets)
+- [Custom Graders and Custom Tasks](#custom-graders-and-custom-tasks-byog--byot)
+- [Skill and Result Layout](#skill-and-result-layout)
+- [Reading Results](#reading-results)
+- [Troubleshooting](#troubleshooting)
 
 ## Quick Start
 
@@ -20,14 +41,14 @@ uv tool install "skillevaluator[tier3] @ git+https://github.com/NVIDIA/SkillEval
 export SKILL_EVAL_LLM_PROVIDER=openai
 export OPENAI_API_KEY='...'
 
-# 3. Configure the agent's own credential (separate from step 2 — see below)
+# 3. Configure the live-agent credential role (see below)
 #    For codex this is an OpenAI Responses API key, configured in
 #    evals/config.yml via environment substitution.
 
 # 4. Generate eval cases for your skill
 skillevaluator create-eval-dataset ./my-skill --full
 
-# 5. Check that your environment is ready (Docker, agent, credentials)
+# 5. Check that the environment is ready
 skillevaluator doctor --agents codex --env-mode docker
 
 # 6. Run the live comparison
@@ -37,79 +58,188 @@ skillevaluator evaluate ./my-skill --agents codex --env-mode docker
 skillevaluator view ./my-skill
 ```
 
-Each step is explained in detail below. If anything fails, start with
-[Troubleshooting](#troubleshooting).
+If a step fails, start with [Troubleshooting](#troubleshooting).
 
 ## How a Run Works
 
-1. `evaluate` reads `evals/evals.json` in your skill directory and builds one
-   Harbor task bundle per eval case.
-2. Harbor starts an isolated environment (Docker by default) and runs the
-   selected agent on each case — in two arms, with and without your skill
-   installed.
-3. A verifier judges each transcript against the case's assertions using your
-   configured public LLM provider.
-4. Reward artifacts are collected into a local report showing pass rates for
-   both arms, so you can see the skill's effect directly.
+1. `evaluate` reads the selected accepted dataset or native task source and
+   builds the Harbor task bundle.
+2. Harbor starts the selected environment and runs the agent with the skill and,
+   unless `--skip-baseline` is set, without it. Isolation follows the selected
+   backend and, for local mode, its active OS-sandbox setting.
+3. With standard grading, each transcript is judged against the case's expected
+   output and assertions using the configured evaluator provider. A
+   `custom_only` grader owns this step instead.
+4. Skill Evaluator collects the result artifacts. Completed standard-grading
+   runs render the five human-readable dimensions, pass rates, and Skill Lift.
 
-Temporary task and job directories are deleted after collection. Pass
-`--harbor-keep-jobs` to retain them for inspection.
+The CLI uses the same in-process evaluation service for focused `evaluate`
+runs and `validate --agent-eval` runs. Temporary task and job directories are
+deleted after collection; pass `--harbor-keep-jobs` to retain them.
 
-## Credentials: Two Separate Things
+## Two Ways to Run Tier 3
 
-Live evaluation always involves **two independent credentials**. Mixing them
-up is the most common setup mistake.
+| Use case | Command | When to use |
+| --- | --- | --- |
+| Full validation | `skillevaluator validate ./my-skill --agent-eval` | Add advisory Tier 3 results after the standard validation stages |
+| Focused evaluation | `skillevaluator evaluate ./my-skill --agents codex` | Iterate on datasets, agents, environments, and grading settings |
+
+Tier 3 remains advisory when attached to `validate`: it is included in the
+combined reports but does not change the validation exit code. Focused live
+evaluation still requires the provider and agent credentials needed by the
+selected setup.
+
+## Prerequisites and Credentials
+
+Tier 3 needs:
+
+1. A preferred generated dataset at `evals/evals.json`, another accepted dataset
+   file, or native tasks under `evals/harbor/`.
+2. The `tier3` extra, which installs Harbor and the evaluator dependencies.
+3. A configured evaluator LLM provider.
+4. The selected live agent's native credential.
+5. A configured environment, such as Docker, local OS isolation, or a supported
+   Harbor cloud backend.
+
+The evaluator and live agent use **two credential roles**. They are not copied
+between roles automatically, although a user may deliberately source both from
+the same host secret. Local mode is an exception: for compatible agent/provider
+pairs, the runner can map evaluator-provider credentials into the environment
+variables read by the local agent CLI.
 
 | Credential | Used for | How to set |
 | --- | --- | --- |
-| Evaluator LLM provider | Dataset generation, verifier judging | `SKILL_EVAL_LLM_PROVIDER` + provider key (see [CONFIGURATION.md](CONFIGURATION.md)) |
-| Live agent's native credential | The agent actually running the task | Per agent, via `evals/config.yml` `harbor.runtime_env` |
+| Evaluator LLM provider | Dataset generation and standard grading | `SKILL_EVAL_LLM_PROVIDER` plus the provider key; see [CONFIGURATION.md](CONFIGURATION.md) |
+| Live agent credential | The agent actually performing the task | Run-scoped values in `evals/config.yml` `harbor.runtime_env` |
 
-For example, NVIDIA Build can power dataset generation and judging, but
-`codex` still requires its own OpenAI Responses API credential — the two are
-never interchangeable. Configure agent credentials through environment-variable
-substitution; never put literal keys in the file:
+For example, NVIDIA Build can power dataset generation and standard grading,
+while `codex` uses an OpenAI Responses API credential. Configure agent
+credentials through environment-variable substitution; never put literal keys
+in the file:
 
 ```yaml
 schema_version: 1
 harbor:
   runtime_env:
-    OPENAI_API_KEY: ${OPENAI_API_KEY}
-    OPENAI_BASE_URL: ${OPENAI_BASE_URL}
+    OPENAI_API_KEY: ${CODEX_OPENAI_API_KEY}
+    OPENAI_BASE_URL: ${CODEX_OPENAI_BASE_URL}
   agents:
     codex:
       model: gpt-4.1-mini
 ```
 
-The agent's model must also be chosen explicitly when the evaluator's provider
-default is not valid for that agent (NVIDIA Build's evaluator model is not a
-Codex model). Use `--agent-model codex=MODEL` to override per invocation.
+The agent model must be selected explicitly when the evaluator provider's
+default model is not valid for that agent. Use `--agent-model codex=MODEL` for
+a per-invocation override.
 
 Security notes:
 
 - Do not commit credentials. `runtime_env` values pass into the task
-  environment; on a shared host they can be visible to users able to inspect
-  process arguments. Use scoped, short-lived credentials, a non-shared host,
-  or an environment with platform-managed secret injection.
-- The evaluator's provider key is not shared with the agent, and agent
-  credentials are not sent to the evaluator's provider.
+  environment and may be visible to users able to inspect processes on a
+  shared host. Prefer scoped, short-lived credentials and isolated hosts.
+- Evaluator-provider credentials are not inserted into `runtime_env`
+  automatically. In local mode, compatible provider credentials may instead be
+  routed directly to the selected agent subprocess. Every value that you place
+  in `runtime_env` is available to every agent selected for that run. For strict
+  per-agent secret isolation, use separate runs with only the values required by
+  that agent.
 - `runtime_env` cannot override host launcher, language-runtime, Docker,
-  Compose, proxy, or telemetry control variables. Configure the selected
-  Harbor backend directly in the host environment.
+  Compose, proxy, or telemetry controls. Configure the selected backend in the
+  host environment.
+
+## Commands
+
+### `evaluate`
+
+```bash
+skillevaluator evaluate <SKILL_PATH> [OPTIONS]
+```
+
+| Option | Default | Purpose |
+| --- | --- | --- |
+| `-a`, `--agents` | `codex` | Comma-separated Harbor agents |
+| `--env-mode` | `docker` | Docker, local, or a supported Harbor cloud backend |
+| `--skip-baseline` | false | Skip the without-skill arm for faster iteration; no Skill Lift is produced |
+| `--n-attempts` | `1` | Attempts per eval case; values above one add pass@k context |
+| `--pass-threshold` | `0.5` | Score required for an attempt to count as passed |
+| `--n-concurrent` | `4` | Concurrent eval cases per agent |
+| `--max-agents` | selected-agent count | Maximum agents run in parallel |
+| `--model` | resolved from agent/config | Global live-agent model override |
+| `--agent-model` | none | Repeatable `AGENT=MODEL` override |
+| `--grading-mode` | `default` | `default`, `default_plus_custom`, or `custom_only` |
+| `--skill-workspace-mode` | `isolated` | `isolated` or `group` skill staging |
+| `--include-skills` | none | Repeatable additional skill directory or parent directory; requires `--skill-workspace-mode group` |
+| `--copy-repo` | false | Copy the surrounding repository into the task environment |
+| `--custom-dockerfile-mode` | `rebase` | `preserve` or `rebase` a custom eval Dockerfile |
+| `--results-dir` | `evals/results` or `SKILLEVALUATOR_RESULTS_DIR` | Write results below an explicit external root |
+| `--harbor-keep-jobs` | false | Retain Harbor job directories for inspection |
+| `--timeout-multiplier` | `1.0` | Scale Harbor setup, run, and verifier timeouts |
+| `--override-cpus`, `--override-memory-mb`, `--override-storage-mb` | engine default | Per-environment resource overrides |
+
+Examples:
+
+```bash
+# Multi-agent comparison
+skillevaluator evaluate ./my-skill --agents codex,opencode --env-mode docker
+
+# Faster iteration without the baseline arm
+skillevaluator evaluate ./my-skill --agents codex --skip-baseline
+
+# Three attempts per case for pass@k context
+skillevaluator evaluate ./my-skill --agents codex \
+  --n-attempts 3 --pass-threshold 0.7
+```
+
+### `create-eval-dataset`
+
+```bash
+skillevaluator create-eval-dataset <SKILL_PATH> [OPTIONS]
+```
+
+| Option | Default | Purpose |
+| --- | --- | --- |
+| `--full` | false | Generate the four-bucket dataset instead of one case |
+| `--no-llm` | false | Use local templates without an LLM call |
+| `--dry-run` | false | Print generated JSON without writing it |
+| `--force` | false | Overwrite an existing `evals/evals.json` |
+| `--prompt` | none | Use a developer guidance file instead of `evals/EVAL.md` |
+| `--refine` | false | Refine cases using an existing or collected trajectory |
+| `--from-results` | latest results | Select the trajectory search directory for refinement |
+| `--results-dir` | none | Search an external results root for refinement data |
+
+### `view`, `compare`, and `doctor`
+
+```bash
+skillevaluator view ./my-skill [--results-dir DIR]
+skillevaluator compare ./my-skill [--results-dir DIR]
+skillevaluator doctor --agents codex --env-mode docker [--verify-models]
+```
+
+- `view` opens the latest local HTML report.
+- `compare` summarizes stored results across agents and arms.
+- `doctor` checks backend readiness, agent availability, and visible host
+  credentials. `evaluate` remains authoritative for skill-specific config and
+  task credential injection.
+
+### Tier 3 expert commands
+
+```bash
+skillevaluator tier3 validate ./my-skill [--json] [--strict] [--harbor-contract]
+skillevaluator tier3 harbor-view <JOBS_DIR>
+```
+
+The first command validates the eval dataset and optional Harbor task contract.
+The second opens retained Harbor job artifacts in Harbor's trajectory browser.
 
 ## Choosing an Environment
 
-Tier 3 uses Harbor's native environments. Docker is the default and needs a
-running Docker daemon. Cloud environments such as `daytona`, `e2b`, or `modal`
-can be selected with `--env-mode`; each one requires installing the matching
-Harbor extra and configuring that provider's credentials per Harbor's
-documentation:
+Docker is the default and needs a running Docker daemon. Harbor cloud
+environments such as `daytona`, `e2b`, or `modal` can be selected with
+`--env-mode`; each needs the corresponding Harbor extra and provider setup:
 
 ```bash
-# uv tool install: add the Harbor extra to the tool's environment
 uv tool install --with 'harbor[daytona]' \
   "skillevaluator[tier3] @ git+https://github.com/NVIDIA/SkillEvaluator.git"
-# (source checkout: pip install 'harbor[daytona]' into the project venv instead)
 
 export DAYTONA_API_KEY='...'
 skillevaluator evaluate ./my-skill --agents codex --env-mode daytona
@@ -117,27 +247,22 @@ skillevaluator evaluate ./my-skill --agents codex --env-mode daytona
 
 ### Local mode (`--env-mode local`)
 
-Local mode runs the agent CLI directly on the host — no Docker — confined by an
-OS sandbox: **bubblewrap** on Linux and **Seatbelt** (`sandbox-exec`) on macOS.
-It is meant for **semi-trusted** skills on a developer machine; use Docker or a
-cloud environment for arbitrary untrusted code.
+Local mode runs the agent CLI directly on the host — no Docker. Under the
+default `require` setting it is confined by an OS sandbox: **bubblewrap** on
+Linux and **Seatbelt** (`sandbox-exec`) on macOS. It is meant for
+**semi-trusted** skills on a developer machine; use Docker or a cloud
+environment for arbitrary untrusted code.
 
-Linux bubblewrap is the strong path (namespace isolation). macOS Seatbelt is
-**semi-trusted**: it confines the filesystem (writes restricted to the run
-directory, host home and other secrets unreadable) and network at the kernel
-level, and denies cross-process metadata (a skill can't read another process's
-command line). The default macOS read policy is a compatibility HOME-denylist.
-Set `SKILLEVALUATOR_LOCAL_STRICT_READS=1` to enable the deny-all-read profile
-with only the selected runtime/system exceptions; this mode is stricter but
-may expose compatibility issues in host developer tools. Common direct and
-nested shell spellings of `setsid`, `nohup`, `daemon`, and `disown` are rejected
-as defense in depth. This is not process containment: a script or native
-program can still detach through system APIs, and Seatbelt has no PID namespace
-that guarantees cleanup. For arbitrary downloaded/untrusted skills on macOS,
-use `--env-mode docker`.
+Linux bubblewrap is the strong path because it uses namespace isolation. macOS
+Seatbelt confines filesystem access and network access at the kernel level, but
+it has no PID namespace that guarantees process cleanup. The default macOS read
+policy is a compatibility HOME denylist. Set
+`SKILLEVALUATOR_LOCAL_STRICT_READS=1` for deny-all reads with selected runtime
+and system exceptions. This is stricter but may expose compatibility issues in
+host developer tools.
 
 ```bash
-# opencode is the agent that works with NVIDIA Build (OpenAI-compatible)
+# opencode works with NVIDIA Build and other OpenAI-compatible endpoints
 export NVIDIA_API_KEY='nvapi-...'
 skillevaluator evaluate ./my-skill --agents opencode \
   --env-mode local --model nvidia/openai/gpt-oss-120b
@@ -145,137 +270,216 @@ skillevaluator evaluate ./my-skill --agents opencode \
 
 Requirements and behavior:
 
-- **Agent CLI installed on `PATH`** (or under `SKILLEVALUATOR_RUNTIME_DIR`):
-  `claude-code`, `codex`, or `opencode`. Local mode never downloads runtimes; if
-  one is missing it prints the vendor install command (e.g.
-  `npm install -g opencode-ai`). The runtime directory must be a dedicated
-  subdirectory; the host home directory and its parents are rejected.
-- **Sandbox required by default (fail-closed).** If no OS sandbox is usable
-  (e.g. bubblewrap missing or user namespaces disabled on Linux), the run
-  refuses to start. Override for skills you fully trust with
-  `SKILLEVALUATOR_LOCAL_SANDBOX=off`, or use `--env-mode docker`.
-- **Confinement:** writes are restricted to the run directory on both
-  platforms. Reads of the user's home are blocked except for the isolated run
-  tree and explicit read-only agent/runtime roots — on Linux the host home is
-  never mounted; on macOS Seatbelt denies reads of the home subtree — so
-  secrets such as `~/.ssh`, `~/.aws`, and project `.env` files stay unreadable.
-  macOS additionally denies cross-process metadata (no reading another
-  process's command line). Set `SKILLEVALUATOR_LOCAL_STRICT_READS=1` when a
-  deny-all-read policy is required.
-- **Network egress is ON by default** so the agent can reach the model
-  endpoint; set `SKILLEVALUATOR_LOCAL_ALLOW_NET=0` to airgap a skill that must
-  not touch the network.
-- **Agent choice:** `opencode` works with NVIDIA Build / any OpenAI-compatible
-  endpoint; with NVIDIA Build its default model is normalized to
-  `nvidia/<provider-model>`. `codex` needs an independent OpenAI Responses API
-  credential and both `OPENAI_API_KEY` and `OPENAI_BASE_URL`; `claude-code`
-  needs an independent Anthropic-native credential and an explicit model when
-  NVIDIA Build is the evaluator provider.
-- **No detached services:** background commands and common shell launcher
-  spellings are rejected, but script/native detachment cannot be structurally
-  contained on macOS. Use Docker or a cloud environment for untrusted code,
-  `pre_agent_setup` services, and sidecars.
+- **Agent CLI installed:** local mode searches `SKILLEVALUATOR_RUNTIME_DIR` and
+  `PATH` for `claude-code`, `codex`, or `opencode`. It does not download missing
+  runtimes.
+- **Sandbox required by default:** if no supported OS sandbox is usable, the
+  `require` setting fails closed. `prefer` may continue with advisory-only
+  protection, while `off` disables kernel confinement and is only for fully
+  trusted skills.
+- **Confinement when the OS sandbox is active:** writes are restricted to the
+  run directory. The host home and common secret locations are excluded from
+  the run's readable filesystem. These guarantees do not apply with
+  `SKILLEVALUATOR_LOCAL_SANDBOX=off`.
+- **Network egress is enabled by default** so the agent can reach its model
+  endpoint. With an active OS sandbox,
+  `SKILLEVALUATOR_LOCAL_ALLOW_NET=0` denies network access; it cannot enforce an
+  air gap when kernel confinement is disabled.
+- **No reliable detached-service containment on macOS:** use Docker or a cloud
+  environment for untrusted code, long-running services, and sidecars.
 
 | Variable | Purpose |
 | --- | --- |
-| `SKILLEVALUATOR_LOCAL_SANDBOX` | `require` (default, fail closed), `prefer` (advisory-only with a warning), or `off` (trusted, no sandbox) |
-| `SKILLEVALUATOR_LOCAL_ALLOW_NET` | Set to `0` to deny network egress inside the sandbox (default on) |
-| `SKILLEVALUATOR_LOCAL_STRICT_READS` | Set to `1` to use deny-all reads with only runtime/system exceptions (default `0` for macOS compatibility) |
-| `SKILLEVALUATOR_RUNTIME_DIR` | Dedicated subdirectory holding bring-your-own agent CLIs, searched before `PATH`; it cannot be the host home or a parent of it |
-
-```bash
-skillevaluator doctor --agents codex --env-mode docker
-```
-
-`doctor` verifies the selected environment, agent availability, and available
-host credentials. It has no skill path, so `evaluate` remains authoritative for
-`evals/config.yml`, per-agent model selection, and task credential injection.
+| `SKILLEVALUATOR_LOCAL_SANDBOX` | `require` (default), `prefer`, or `off` |
+| `SKILLEVALUATOR_LOCAL_ALLOW_NET` | Set to `0` to deny network egress |
+| `SKILLEVALUATOR_LOCAL_STRICT_READS` | Set to `1` for deny-all reads with selected exceptions |
+| `SKILLEVALUATOR_RUNTIME_DIR` | Dedicated directory containing bring-your-own agent CLIs |
 
 ## Eval Datasets
 
-`evaluate` expects `evals/evals.json` inside the skill. Generate it with:
+`create-eval-dataset` writes the preferred `evals/evals.json`. `evaluate` also
+accepts `evals.jsonl`, `evals.yaml`, `evals.yml`, `dataset.json`, and
+`dataset.jsonl` under `evals/`, and it can use native tasks under
+`evals/harbor/`. A full generated dataset covers four useful cases:
+
+| Bucket | Purpose |
+| --- | --- |
+| Explicit positive | The user names the skill directly |
+| Implicit positive | The task needs the skill without naming it |
+| Contextual positive | The task needs the skill within a broader project context |
+| Negative | A related request should not activate the skill |
+
+Generate, preview, or refine cases with:
 
 ```bash
-skillevaluator create-eval-dataset ./my-skill            # 1 case
-skillevaluator create-eval-dataset ./my-skill --full     # 4-bucket dataset
-skillevaluator create-eval-dataset ./my-skill --no-llm   # templates, no key needed
-skillevaluator create-eval-dataset ./my-skill --full --refine  # refine with a real trajectory
+skillevaluator create-eval-dataset ./my-skill --full
+skillevaluator create-eval-dataset ./my-skill --no-llm
+skillevaluator create-eval-dataset ./my-skill --full --dry-run
+skillevaluator create-eval-dataset ./my-skill --full --refine
 ```
 
-Without a configured LLM provider, generation falls back to template-based
-cases; they are runnable but generic. For higher-quality cases, configure a
-provider, add developer guidance in `evals/EVAL.md` (`## Questions`,
-`## Behaviors`, `## Notes` sections), or use `--refine` to ground cases in a
-real agent trajectory.
+New datasets use the preferred agentskills.io shape:
 
-Run controls live in `evals/config.yml`: `n_attempts`, `pass_threshold`,
-`n_concurrent`, resource overrides, runtime environment variables, and
-per-agent model overrides. CLI options take precedence over the file.
+```json
+{
+  "skill_name": "api-caller",
+  "evals": [
+    {
+      "id": "api-caller-001",
+      "prompt": "Inspect this API description and make the requested call.",
+      "expected_output": "The request is validated, executed, and summarized.",
+      "assertions": [
+        "The agent reads the skill instructions.",
+        "The agent validates request inputs before sending the call."
+      ]
+    }
+  ]
+}
+```
+
+Legacy flat entries remain accepted with a warning, but new datasets should use
+the preferred shape. Add `evals/EVAL.md` for domain guidance. Without a
+configured provider, generation falls back to generic local templates.
+
+Run controls live in `evals/config.yml`, including `n_attempts`,
+`pass_threshold`, concurrency, resource overrides, runtime environment values,
+and per-agent models. CLI options take precedence.
 
 ## Custom Graders and Custom Tasks (BYOG / BYOT)
 
-The default verifier judges transcripts against each case's assertions. For
-deterministic or domain-specific grading, bring your own grader (BYOG) or a
-complete Harbor task (BYOT):
+The default grader checks each case against its assertions. For deterministic
+or domain-specific grading, bring your own grader (BYOG) or a complete Harbor
+task (BYOT):
 
 ```bash
-# Scaffold evals/grader.py wired to Skill Evaluator's grading contract
-skillevaluator init-custom-grader ./my-skill
+skillevaluator init-custom-grader ./my-skill \
+  --mode default_plus_custom --language python
 
-# Scaffold a Harbor-format task under evals/harbor/<case-id>/
-skillevaluator init-harbor-task ./my-skill --case-id case-001
+skillevaluator init-harbor-task ./my-skill \
+  --with-config --case-id case-001
 ```
 
-`init-harbor-task` wraps a Harbor-format task in the exact location and shape
-Skill Evaluator discovers — you do not need Harbor's own `harbor tasks init`
-for this. See the `create-custom-grader` reference skill in
-`src/skillevaluator/tier3/reference_skills/` for a worked example.
+Grading modes are:
+
+| Mode | Behavior |
+| --- | --- |
+| `default` | Skill Evaluator grading only |
+| `default_plus_custom` | Skill Evaluator grading plus the custom grader |
+| `custom_only` | The custom grader owns the result |
+
+`init-harbor-task` creates the task where Skill Evaluator discovers it; Harbor's
+own task initializer is not required. See the `create-custom-grader` reference
+skill in `src/skillevaluator/tier3/reference_skills/` for a worked example.
 
 ### Docker Compose safety policy
 
 Custom `docker-compose.yaml` files are for sidecars. The Harbor-owned `main`
-service may set only `depends_on`. Sidecars use a strict allowlist: `image`,
-bounded `build`, `command`, `entrypoint`, `environment`, `expose`,
-`healthcheck`, `depends_on`, `networks`, project-scoped `volumes`, `tmpfs`, and
-a small set of container-local execution settings. Host port mappings are
-removed before execution. Unrecognized service, build, network, volume, and
-top-level keys are rejected rather than passed through to Docker.
+service may set only `depends_on`. Sidecars use a strict allowlist for images,
+bounded builds, commands, environment values, health checks, project-scoped
+storage, and container-local execution settings. Host port mappings are removed
+before execution, and unrecognized keys are rejected.
 
-Skill Evaluator rejects host bind mounts, external or driver-configured named
-volumes, interpolated volume specifications, external/named/custom-driver
-networks, host namespace modes, privileged/device/GPU/runtime access, added
-capabilities, security and cgroup overrides, Docker API socket access,
-`env_file`, `label_file`, `extends`, external container links, credential files,
-and file-backed Compose configs or secrets. Lifecycle hooks, deployment/device
-reservations, development sync, host logging drivers, build cache imports or
-exports, and host-level image tags are also rejected. Sidecar build contexts
-and Dockerfiles must be literal relative paths contained under
-`evals/environment/`; remote/SSH or interpolated paths and privileged,
-host-networked, SSH-forwarded, secret, or insecure-entitlement builds are
-rejected. In non-path values, Compose `${NAME}` interpolation is allowed only
-for names explicitly declared in `harbor.runtime_env`; nested substitutions and
-bare host-value passthrough in service environment entries and build arguments
-follow the same rule.
+Skill Evaluator rejects host bind mounts, external or driver-configured storage,
+host namespace modes, privileged/device/GPU/runtime access, added capabilities,
+Docker API socket access, credential files, external container links, and
+file-backed Compose configs or secrets. Build contexts and Dockerfiles must be
+literal relative paths contained in the applicable environment directory —
+`evals/environment/` for generated tasks or
+`evals/harbor/<case>/environment/` for a native task. Remote, SSH, interpolated,
+privileged, host-networked, secret, and insecure-entitlement builds are
+rejected.
+
+## Skill and Result Layout
+
+```text
+my-skill/
+├── SKILL.md
+├── scripts/
+└── evals/
+    ├── evals.json                  # Preferred generated Tier 3 dataset
+    ├── EVAL.md                     # Optional generation guidance
+    ├── config.yml                  # Optional run settings
+    ├── grader.py                   # Optional BYOG grader
+    ├── harbor/                     # Optional BYOT tasks
+    ├── environment/                # Optional custom environment
+    ├── files/                      # Optional task inputs
+    └── results/
+        └── <timestamp>/
+            ├── result.json
+            ├── run_config.json
+            ├── attempt_policy.json
+            ├── report.html                  # Generated on a best-effort basis
+            ├── comparison.json             # Multi-agent runs only
+            └── <agent>/
+                ├── lift.json               # Present when baseline lift is available
+                ├── with-skill/
+                │   ├── summary.json
+                │   └── trials/
+                └── without-skill/          # Present when the baseline arm is enabled
+                    ├── summary.json
+                    └── trials/
+```
+
+Use `--results-dir DIR` to write the results below `DIR/<skill-name>/` instead of
+the skill directory. `SKILLEVALUATOR_RESULTS_DIR` supplies the default external
+root when the CLI option is omitted.
 
 ## Reading Results
 
 ```bash
-skillevaluator view ./my-skill        # open the latest local HTML report
-skillevaluator compare ./my-skill     # compare with/without-skill results
+skillevaluator view ./my-skill
+skillevaluator compare ./my-skill
 ```
 
-Keep raw Harbor artifacts for debugging with `--harbor-keep-jobs`; the report
-links to retained job directories.
+For completed `default` and `default_plus_custom` runs, the report summarizes
+five human-readable dimensions. In `custom_only`, the custom grader owns the
+score and the standard dimension view is omitted.
+
+| Dimension | Question answered |
+| --- | --- |
+| Security | Is the result safe to use? |
+| Correctness | Does it do what the skill promises? |
+| Discoverability | Is the skill used when it should be? |
+| Effectiveness | Is the result better with the skill? |
+| Efficiency | Does the skill reduce unnecessary effort? |
+
+Each dimension receives a score and PASS, NEUTRAL, or FAIL status. Skill Lift
+is the signed difference between the with-skill result and the without-skill
+baseline. Positive lift means the skill helped; negative lift means it hurt;
+the report's verdict applies the release's current noise band.
+
+With multiple attempts, pass@k shows whether at least one attempt for each case
+met `--pass-threshold`. Under standard grading it is reliability context
+alongside Skill Lift, not a replacement for the five dimensions. In
+`custom_only`, pass@k uses the custom overall reward and the standard dimension
+view remains absent.
+
+The canonical Tier 3 payload embedded by `validate --agent-eval` uses schema
+version 2.0. A completed standard-grading payload includes the summary, five
+dimensions, per-agent results, trials, pass@k, attempt policy, and dataset;
+advisory or skipped payloads may leave some of those sections empty. Focused
+`evaluate` artifacts have file-specific shapes and are not all schema 2.0.
+
+Keep Harbor artifacts for debugging with `--harbor-keep-jobs`; the report links
+to the retained job directories.
 
 ## Troubleshooting
 
 | Symptom | Likely cause and fix |
 | --- | --- |
-| `A public LLM provider is required for live evaluation` | Set `SKILL_EVAL_LLM_PROVIDER` and its key (evaluator side). |
-| Agent fails immediately or authentication errors in the transcript | The agent's own credential is missing — set it via `harbor.runtime_env` in `evals/config.yml`. |
-| `evaluate` cannot start the environment | Docker daemon not running, or the selected `--env-mode` is unconfigured. Run `skillevaluator doctor` with the same flags. |
-| No `evals/evals.json` found | Run `skillevaluator create-eval-dataset ./my-skill` first. |
-| Results look wrong and you need the raw transcripts | Re-run with `--harbor-keep-jobs` and inspect the retained job directories via `skillevaluator view`. |
+| `A public LLM provider is required for live evaluation` | Set `SKILL_EVAL_LLM_PROVIDER` and the corresponding evaluator-provider key. |
+| Agent authentication fails | Configure the live-agent credential role through `harbor.runtime_env` in `evals/config.yml`. |
+| `evaluate` cannot start the environment | Start Docker or configure the selected `--env-mode`; run `doctor` with the same agent and environment. |
+| No eval dataset or native task source found | Run `skillevaluator create-eval-dataset ./my-skill` or add accepted files under `evals/`. |
+| Agent model is rejected | Supply a model valid for that agent with `--agent-model AGENT=MODEL`. |
+| Results look wrong or a case is hard to diagnose | Re-run with `--harbor-keep-jobs`, then inspect retained artifacts with `view` or `tier3 harbor-view`. |
 
-Every live run requires a configured public LLM provider and any credentials
-required by the selected Harbor agent and environment.
+Every live run requires a configured evaluator provider plus the credentials
+required by the selected agent and environment.
+
+## See Also
+
+- [Configuration](CONFIGURATION.md) — provider, embedding, credential, and telemetry setup.
+- [Installation](INSTALLATION.md) — extras and system requirements.
+- [Tier 1 validation](TIER1_VALIDATION.md) — deterministic and security checks.
+- [Tier 2 deduplication](TIER2_DEDUPLICATION.md) — semantic overlap checks.

--- a/tests/test_oss_packaging.py
+++ b/tests/test_oss_packaging.py
@@ -364,8 +364,9 @@ def test_public_docs_show_tier_two_collection_and_catalog_workflows() -> None:
     assert "--save-catalog" in public_docs
     assert "--catalog" in public_docs
     assert "dedup-scan` is an alias" in public_docs
-    assert "Milvus" in public_docs
-    assert "names and descriptions are sent" in public_docs
-    assert "full manifest is sent" in public_docs
-    assert "candidate clusters are sent" in public_docs
+    assert "No external vector database or catalog service" in public_docs
+    assert "sends skill names and descriptions" in public_docs
+    assert "sends each discovered `SKILL.md` in full" in public_docs
+    assert "Only candidate clusters found by the embedding stage are" in public_docs
+    assert "sent to the configured chat LLM for classification" in public_docs
     assert "NVIDIA_INFERENCE_KEY" not in public_docs


### PR DESCRIPTION
## Summary

- align the public README and Tier 1–3 guides with the internal documentation structure where the public implementation supports it
- expand Tier 1 check, profile, reporting, CI, configuration, and troubleshooting guidance for skills
- document Tier 2 direct comparison, local JSON catalogs, similarity taxonomy, intra-skill analysis, privacy, safety, and edge cases without an external vector database
- document Tier 3 commands, environments, credential behavior, datasets, grading modes, result layout, Skill Lift, pass@k, and only the five human-readable dimensions
- correct the public Gitleaks installation guidance to use official release binaries

## Public-edition boundaries preserved

- no internal repository, package-index, release, support, or infrastructure references
- no references to excluded content categories in the public README or docs
- no Astra/Kubernetes sandbox material
- no unsupported internal-only commands or API/server documentation
- no raw/runtime evaluator dimensions, mappings, weights, or provenance
- no change to product-name spelling or copyright wording

## Validation

- installed the package base dependencies in a temporary Python 3.12 environment
- checked top-level and relevant Tier 1–3 CLI help against the documented commands and options
- parsed all changed Markdown files
- verified local Markdown links and anchors
- ran `git diff --check`
- scanned public README/docs for excluded category terms and internal infrastructure strings
- verified that dimension references are limited to the five human-readable Tier 3 dimensions