### PR TITLE
Add Fern docs deployment mirroring NVIDIA/Skills

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,22 @@
+name: Publish Docs
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' && contains(github.ref, 'refs/heads/main') && github.run_number > 1 }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Fern
+        run: npm install -g fern-api
+
+      - name: Publish Docs
+        env:
+          FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
+        run: fern generate --docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to Skill Evaluator are documented in this file.
 - Added NVIDIA Build live-agent paths: direct OpenCode support plus Docker
   compatibility bridges for Codex and experimental Claude Code, including
   multi-turn tool-call continuation.
+- Fern documentation site published to `docs.nvidia.com/skillevaluator`,
+  building the `docs/` guides (installation, configuration, and the three
+  evaluation tiers) as MDX pages.
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Each tier is an independent entry point — run any command directly; nothing
 requires running the earlier tiers first. With no keys configured and the Tier
 1 scanners installed, `validate` runs without an API credential (its dedup pass
 skips gracefully); the
-[credential map](docs/CONFIGURATION.md#what-needs-credentials-and-what-runs-offline)
+[credential map](docs/configuration.mdx#what-needs-credentials-and-what-runs-offline)
 lists exactly what each command needs.
 
 ## Quickstart
@@ -65,7 +65,7 @@ On other platforms, install a binary from the official
 [Gitleaks releases](https://github.com/gitleaks/gitleaks/releases).
 
 For a smaller Tier 1-only environment, install the `security` extra instead of
-`all`; see [installation options](docs/INSTALLATION.md#choosing-extras).
+`all`; see [installation options](docs/installation.mdx#choosing-extras).
 
 If the shell can't find `skillevaluator` after installing, run
 `uv tool update-shell` and open a new terminal (uv installs tools to
@@ -121,7 +121,7 @@ analysis and can suppress false positives.
 Check selection (`--checks`), report formats (`-r cli,json,html,markdown`), the
 automatically generated `BENCHMARK.md`, skill discovery, the optional
 `--llm`/`--llm-verify` deepening, and a CI recipe:
-[Tier 1 guide](docs/TIER1_VALIDATION.md).
+[Tier 1 guide](docs/tier1-validation.mdx).
 
 ## Configure a provider (for the LLM-backed parts)
 
@@ -144,14 +144,14 @@ model. Use `doctor` and a live Tier 3 evaluation for runtime and end-to-end
 verification.
 
 OpenAI, Anthropic, Bedrock, any OpenAI-compatible endpoint, and fully local
-servers work too: [configuration guide](docs/CONFIGURATION.md).
+servers work too: [configuration guide](docs/configuration.mdx).
 
 The external publication profile is the default. `--external` is shorthand
 for `--profile external`, and `--policy` can overlay a custom policy file.
 
 Telemetry is disabled by default. To opt in, install the `telemetry` extra
 (included in `all`), set `SKILLEVALUATOR_TELEMETRY_ENABLED=true`, and configure
-an OpenTelemetry endpoint; see the [configuration guide](docs/CONFIGURATION.md#telemetry).
+an OpenTelemetry endpoint; see the [configuration guide](docs/configuration.mdx#telemetry).
 
 ## Tier 2: Semantic Deduplication
 
@@ -180,7 +180,7 @@ The catalog is a versioned JSON file containing embeddings and skill metadata,
 not credentials. It stays local unless you choose to share it; no external
 vector database or catalog service is involved. Thresholds, reports, catalog
 validation, and exactly where the chat LLM comes in:
-[Tier 2 guide](docs/TIER2_DEDUPLICATION.md).
+[Tier 2 guide](docs/tier2-deduplication.mdx).
 
 ## Tier 3: Live Agent Evaluation
 
@@ -281,7 +281,7 @@ default. Add `--harbor-keep-jobs` to retain them; the final **Artifacts** panel
 then prints the canonical `skillevaluator tier3 harbor-view <JOBS_DIR>` command.
 
 Custom graders, Harbor-format tasks, and agent credential setup:
-[Tier 3 guide](docs/TIER3_LIVE_EVALUATION.md).
+[Tier 3 guide](docs/tier3-live-evaluation.mdx).
 
 ## Expert tier aliases
 
@@ -296,7 +296,7 @@ skillevaluator tier3 evaluate ./my-skill --agents opencode --env-mode docker
 ## Installation options
 
 The quickstart one-liner installs everything. For per-tier extras, plain pip,
-or Docker, see [installation](docs/INSTALLATION.md). Contributors work from a
+or Docker, see [installation](docs/installation.mdx). Contributors work from a
 source checkout:
 
 ```bash
@@ -307,12 +307,12 @@ uv sync --python 3.13 --all-extras
 
 ## Documentation
 
-- [Installation](docs/INSTALLATION.md) — extras, pip, Docker, requirements
-- [Tier 1 guide](docs/TIER1_VALIDATION.md) — checks, flags, reports, CI recipe
-- [Tier 2 guide](docs/TIER2_DEDUPLICATION.md) — dedup commands and thresholds
-- [Tier 3 guide](docs/TIER3_LIVE_EVALUATION.md) — skill evaluation with live agents, in depth
-- [Configuration](docs/CONFIGURATION.md) — credential map, providers, embeddings, telemetry
-- [Developer guide](docs/DEVELOPER_GUIDE.md) — contributor setup
+- [Installation](docs/installation.mdx) — extras, pip, Docker, requirements
+- [Tier 1 guide](docs/tier1-validation.mdx) — checks, flags, reports, CI recipe
+- [Tier 2 guide](docs/tier2-deduplication.mdx) — dedup commands and thresholds
+- [Tier 3 guide](docs/tier3-live-evaluation.mdx) — skill evaluation with live agents, in depth
+- [Configuration](docs/configuration.mdx) — credential map, providers, embeddings, telemetry
+- [Developer guide](docs/developer-guide.mdx) — contributor setup
 - Related: [SkillSpector](https://github.com/NVIDIA/SkillSpector) (skill
   security scanner used by the `security` extra),
   [Agent Skills specification](https://agentskills.io/),

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,80 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+
+# AGENTS.md — `docs/`
+
+Guidance for AI agents editing SkillEvaluator's long-form documentation. This
+folder holds MDX pages published to <https://docs.nvidia.com/skillevaluator> via
+[Fern](https://buildwithfern.com/). Human-facing notes live in
+[`README.md`](README.md); this file is the machine-facing companion.
+
+## What lives here
+
+- `index.mdx` — landing page and three-tier overview (Fern slug `/`)
+- `installation.mdx`, `configuration.mdx` — setup and credential reference
+- `tier1-validation.mdx`, `tier2-deduplication.mdx`, `tier3-live-evaluation.mdx`
+  — the three evaluation tiers
+- `developer-guide.mdx` — contributor setup
+- `assets/` — images referenced by the pages
+- `README.md` (human authoring guide) and this `AGENTS.md` are **not** published
+  pages — do not add them to the navigation
+
+Navigation order, page titles, and slugs are defined in
+[`../fern/docs.yml`](../fern/docs.yml). The Fern CLI version is pinned in
+[`../fern/fern.config.json`](../fern/fern.config.json).
+
+## Rules for editing
+
+1. **Every page needs YAML frontmatter** with `title` and `description`. The
+   `title` renders as the page H1 — do **not** also add a `# Heading` in the
+   body, or the title appears twice.
+
+   ```mdx
+   ---
+   title: "Configuration"
+   description: "One-sentence summary used for SEO and the nav preview."
+   ---
+   ```
+
+2. **File names use URL best practices**: lowercase, hyphen-separated, no spaces
+   or underscores (`tier1-validation.mdx`, not `TIER1_VALIDATION.mdx`). Keep the
+   file name equal to the page `slug` in `docs.yml`.
+
+3. **Adding a page**: create the `.mdx` file, then register it under
+   `navigation` in [`../fern/docs.yml`](../fern/docs.yml). A page not listed
+   there will not appear on the site. Rename via `git mv` to preserve history,
+   and update every reference (see rule 5).
+
+4. **This is MDX, not Markdown.** A bare `<` starts a JSX tag and `{` starts an
+   expression. Keep angle brackets and braces (e.g. `<placeholder>`,
+   `${VAR}`) inside backtick code spans or fenced code blocks, where MDX leaves
+   them literal. Do not use `<https://...>` autolink syntax — write a normal
+   `[text](url)` link.
+
+5. **Links**:
+   - Between pages in this folder, link by slug (`configuration`,
+     `tier1-validation#anchor`) — matches how Fern serves them.
+   - To files outside `docs/`, use a relative repo path kept as `.md`
+     (`../README.md`, `../THIRD_PARTY_NOTICES.md`) — those are not Fern pages.
+   - When renaming a page, grep the whole repo and fix references in the sibling
+     pages, the root [`../README.md`](../README.md), [`README.md`](README.md),
+     and [`../fern/docs.yml`](../fern/docs.yml).
+
+## Verify before committing
+
+Requires **Node.js 22+** and the Fern CLI (`npm install -g fern-api`).
+
+```bash
+fern check       # validate docs.yml config and all links — must pass
+fern docs dev    # optional live preview at http://localhost:3000
+```
+
+`fern check` must pass; it is the same gate the site build relies on. Publishing
+is automatic from `main` via [`../.github/workflows/publish-docs.yml`](../.github/workflows/publish-docs.yml)
+— do not run `fern generate` locally.
+
+## Repo conventions that still apply
+
+- Sign off commits (`git commit -s`); the DCO check rejects unsigned commits
+  (see [`../CONTRIBUTING.md`](../CONTRIBUTING.md)).
+- Update [`../CHANGELOG.md`](../CHANGELOG.md) when a docs change is user-visible.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -52,8 +52,10 @@ Navigation order, page titles, and slugs are defined in
    `[text](url)` link.
 
 5. **Links**:
-   - Between pages in this folder, link by slug (`configuration`,
-     `tier1-validation#anchor`) — matches how Fern serves them.
+   - Between pages in this folder, link with the relative `.mdx` file path
+     (`configuration.mdx`, `tier1-validation.mdx#anchor`). Fern resolves these
+     to the published slug, and they also work when browsing the source on
+     GitHub — a bare slug (`configuration`) 404s on GitHub.
    - To files outside `docs/`, use a relative repo path kept as `.md`
      (`../README.md`, `../THIRD_PARTY_NOTICES.md`) — those are not Fern pages.
    - When renaming a page, grep the whole repo and fix references in the sibling

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,54 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+
+# Documentation
+
+Long-form documentation for SkillEvaluator. Pages are authored in MDX and
+published to <https://docs.nvidia.com/skillevaluator>. This page is the human
+quickstart; [`AGENTS.md`](AGENTS.md) holds the detailed authoring rules (MDX
+gotchas, link conventions, page-adding checklist) for both AI agents and
+contributors making non-trivial edits.
+
+## Layout
+
+- `index.mdx` — landing page and three-tier overview
+- `installation.mdx` — extras, pip, Docker, requirements
+- `configuration.mdx` — credential map, providers, embeddings, telemetry
+- `tier1-validation.mdx` — checks, flags, reports, CI recipe
+- `tier2-deduplication.mdx` — dedup commands and thresholds
+- `tier3-live-evaluation.mdx` — skill evaluation with live agents
+- `developer-guide.mdx` — contributor setup
+
+Navigation order and slugs are defined in [`../fern/docs.yml`](../fern/docs.yml).
+
+## Build Locally
+
+You only need to build locally if you are editing the documentation. The site is
+published automatically from `main` via the Fern GitHub integration.
+
+Prerequisites: Node.js 22+ and npm 10+ (the versions the Fern CLI requires).
+
+```bash
+# Install the Fern CLI
+npm install -g fern-api
+
+# From the repo root, preview the site with live reload
+fern docs dev
+
+# Validate the docs configuration and links
+fern check
+```
+
+`fern docs dev` serves the site at <http://localhost:3000> and reloads on changes
+to `.mdx` files or `fern/docs.yml`.
+
+## Authoring Notes
+
+- New pages must be added to the `navigation` section of
+  [`../fern/docs.yml`](../fern/docs.yml); otherwise they will not appear in the
+  site.
+- Use relative links between MDX pages (`./configuration.mdx`) and relative repo
+  links (`../README.md`) for files outside `docs/`.
+- The Fern version is pinned in
+  [`../fern/fern.config.json`](../fern/fern.config.json); bump it intentionally
+  rather than as a side effect.

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -1,4 +1,7 @@
-# Configuration
+---
+title: "Configuration"
+description: "The credential map plus provider, embeddings, and telemetry configuration for SkillEvaluator."
+---
 
 ## What needs credentials, and what runs offline
 

--- a/docs/developer-guide.mdx
+++ b/docs/developer-guide.mdx
@@ -1,4 +1,7 @@
-# Developer Guide
+---
+title: "Developer Guide"
+description: "Contributor setup for SkillEvaluator — development environment, tooling, and local checks."
+---
 
 ## Development Setup
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,0 +1,75 @@
+---
+title: "SkillEvaluator"
+description: "A multi-tier framework for evaluating AI agent skills — deterministic quality gates, semantic overlap detection, synthetic eval datasets, and live agent A/B evaluation."
+---
+
+SkillEvaluator is an open-source, multi-tier framework for evaluating AI agent
+skills — deterministic quality gates, semantic overlap detection, synthetic eval
+dataset generation, and live agent evaluation. A skill is a folder of
+instructions and scripts (a `SKILL.md` plus supporting files) that extends an AI
+agent — see the [Agent Skills specification](https://agentskills.io/).
+SkillEvaluator gates skills through three progressively deeper tiers, from free
+offline checks to live agent A/B evaluation.
+
+Each tier is an independent entry point — run any command directly; nothing
+requires running the earlier tiers first. With no keys configured and the Tier 1
+scanners installed, `validate` runs without an API credential (its dedup pass
+skips gracefully); the [credential map](configuration#what-needs-credentials-and-what-runs-offline)
+lists exactly what each command needs.
+
+## Three-tier overview
+
+| Tier | Purpose | Representative commands | Requires |
+| --- | --- | --- | --- |
+| [Tier 1](tier1-validation) | Validate schema, quality, security, secrets, PII, licenses, code integrity, Unicode safety, and scripts; optionally add LLM judging and deeper security analysis | `validate`, `quality-check`, `security-scan`, `pii-scan`, `lint-scripts`, `rubric-eval` | Deterministic checks need no API key; full scanner coverage needs the `security` extra and Gitleaks; LLM checks need a provider key |
+| [Tier 2](tier2-deduplication) | Detect redundant content within one skill and overlapping skills across a collection or local catalog | `context-optimization-check` / `dedup-scan` (intra-skill), `similarity-check` (inter-skill) | An embeddings provider; intra-skill analysis also needs a chat LLM — local OpenAI-compatible endpoints work |
+| [Tier 3](tier3-live-evaluation) | Create evaluation datasets and measure agent behavior with and without a skill | `create-eval-dataset`, `evaluate`, `compare` | Keyless templates and report inspection need no credential; LLM generation needs a provider key; live evaluation also needs the agent credential and a Docker, local OS, or cloud sandbox |
+
+## Quickstart
+
+Install every SkillEvaluator Python feature with one command.
+[uv](https://docs.astral.sh/uv/) automatically provisions Python 3.13; if uv is
+not installed yet, follow its
+[one-command installation](https://docs.astral.sh/uv/getting-started/installation/):
+
+```bash
+uv tool install --python 3.13 "skillevaluator[all] @ git+https://github.com/NVIDIA/SkillEvaluator.git"
+```
+
+Run the first offline check directly against your own skill — **no API key,
+Docker, Gitleaks, or repository clone required**:
+
+```bash
+skillevaluator quality-check ./my-skill
+```
+
+For a complete offline Tier 1 run, install Gitleaks once, then use `validate`:
+
+```bash
+brew install gitleaks                         # macOS
+skillevaluator validate ./my-skill --no-dedup
+```
+
+See [Installation](installation) for per-tier extras, plain pip, and Docker, and
+[Configuration](configuration) to wire up a provider for the LLM-backed parts.
+
+## The tiers
+
+- **[Tier 1: Static and Security Validation](tier1-validation)** — the everyday
+  command and a ready-made CI gate. Deterministic schema, quality, security,
+  PII, license, code-integrity, Unicode, and script checks that run offline,
+  plus optional LLM-as-judge scoring.
+- **[Tier 2: Semantic Deduplication](tier2-deduplication)** — find duplicated
+  guidance inside one skill or compare skills across a collection with embedding
+  similarity.
+- **[Tier 3: Live Agent Evaluation](tier3-live-evaluation)** — measure whether a
+  skill actually makes an agent better by running a real agent against generated
+  tasks, with and without the skill, inside Harbor sandboxes.
+
+## More
+
+- [Developer Guide](developer-guide) — contributor setup
+- [SkillSpector](https://github.com/NVIDIA/SkillSpector) — the skill security
+  scanner used by the `security` extra
+- [Harbor](https://github.com/harbor-framework/harbor) — the sandbox framework
+  behind Tier 3

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -14,16 +14,16 @@ offline checks to live agent A/B evaluation.
 Each tier is an independent entry point — run any command directly; nothing
 requires running the earlier tiers first. With no keys configured and the Tier 1
 scanners installed, `validate` runs without an API credential (its dedup pass
-skips gracefully); the [credential map](configuration#what-needs-credentials-and-what-runs-offline)
+skips gracefully); the [credential map](configuration.mdx#what-needs-credentials-and-what-runs-offline)
 lists exactly what each command needs.
 
 ## Three-tier overview
 
 | Tier | Purpose | Representative commands | Requires |
 | --- | --- | --- | --- |
-| [Tier 1](tier1-validation) | Validate schema, quality, security, secrets, PII, licenses, code integrity, Unicode safety, and scripts; optionally add LLM judging and deeper security analysis | `validate`, `quality-check`, `security-scan`, `pii-scan`, `lint-scripts`, `rubric-eval` | Deterministic checks need no API key; full scanner coverage needs the `security` extra and Gitleaks; LLM checks need a provider key |
-| [Tier 2](tier2-deduplication) | Detect redundant content within one skill and overlapping skills across a collection or local catalog | `context-optimization-check` / `dedup-scan` (intra-skill), `similarity-check` (inter-skill) | An embeddings provider; intra-skill analysis also needs a chat LLM — local OpenAI-compatible endpoints work |
-| [Tier 3](tier3-live-evaluation) | Create evaluation datasets and measure agent behavior with and without a skill | `create-eval-dataset`, `evaluate`, `compare` | Keyless templates and report inspection need no credential; LLM generation needs a provider key; live evaluation also needs the agent credential and a Docker, local OS, or cloud sandbox |
+| [Tier 1](tier1-validation.mdx) | Validate schema, quality, security, secrets, PII, licenses, code integrity, Unicode safety, and scripts; optionally add LLM judging and deeper security analysis | `validate`, `quality-check`, `security-scan`, `pii-scan`, `lint-scripts`, `rubric-eval` | Deterministic checks need no API key; full scanner coverage needs the `security` extra and Gitleaks; LLM checks need a provider key |
+| [Tier 2](tier2-deduplication.mdx) | Detect redundant content within one skill and overlapping skills across a collection or local catalog | `context-optimization-check` / `dedup-scan` (intra-skill), `similarity-check` (inter-skill) | An embeddings provider; intra-skill analysis also needs a chat LLM — local OpenAI-compatible endpoints work |
+| [Tier 3](tier3-live-evaluation.mdx) | Create evaluation datasets and measure agent behavior with and without a skill | `create-eval-dataset`, `evaluate`, `compare` | Keyless templates and report inspection need no credential; LLM generation needs a provider key; live evaluation also needs the agent credential and a Docker, local OS, or cloud sandbox |
 
 ## Quickstart
 
@@ -50,25 +50,25 @@ brew install gitleaks                         # macOS
 skillevaluator validate ./my-skill --no-dedup
 ```
 
-See [Installation](installation) for per-tier extras, plain pip, and Docker, and
-[Configuration](configuration) to wire up a provider for the LLM-backed parts.
+See [Installation](installation.mdx) for per-tier extras, plain pip, and Docker, and
+[Configuration](configuration.mdx) to wire up a provider for the LLM-backed parts.
 
 ## The tiers
 
-- **[Tier 1: Static and Security Validation](tier1-validation)** — the everyday
+- **[Tier 1: Static and Security Validation](tier1-validation.mdx)** — the everyday
   command and a ready-made CI gate. Deterministic schema, quality, security,
   PII, license, code-integrity, Unicode, and script checks that run offline,
   plus optional LLM-as-judge scoring.
-- **[Tier 2: Semantic Deduplication](tier2-deduplication)** — find duplicated
+- **[Tier 2: Semantic Deduplication](tier2-deduplication.mdx)** — find duplicated
   guidance inside one skill or compare skills across a collection with embedding
   similarity.
-- **[Tier 3: Live Agent Evaluation](tier3-live-evaluation)** — measure whether a
+- **[Tier 3: Live Agent Evaluation](tier3-live-evaluation.mdx)** — measure whether a
   skill actually makes an agent better by running a real agent against generated
   tasks, with and without the skill, inside Harbor sandboxes.
 
 ## More
 
-- [Developer Guide](developer-guide) — contributor setup
+- [Developer Guide](developer-guide.mdx) — contributor setup
 - [SkillSpector](https://github.com/NVIDIA/SkillSpector) — the skill security
   scanner used by the `security` extra
 - [Harbor](https://github.com/harbor-framework/harbor) — the sandbox framework

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -1,4 +1,7 @@
-# Installation
+---
+title: "Installation"
+description: "Tailor a SkillEvaluator install: smaller per-tier extras, plain pip, and Docker."
+---
 
 The quickest install is the one-liner from the
 [README quickstart](../README.md#quickstart) — everything on this page is for
@@ -20,7 +23,7 @@ This project will download and install additional third-party open source softwa
 - No API key is needed for deterministic Tier 1 checks. Full default scanner
   coverage requires the `security` extra plus Gitleaks. LLM-backed checks and
   Tiers 2–3 use a configured provider — see
-  [CONFIGURATION.md](CONFIGURATION.md).
+  [CONFIGURATION.md](configuration.mdx).
 
 ## Choosing extras
 

--- a/docs/tier1-validation.mdx
+++ b/docs/tier1-validation.mdx
@@ -1,11 +1,14 @@
-# Tier 1: Static and Security Validation
+---
+title: "Tier 1: Static and Security Validation"
+description: "Deterministic quality gates for skills — schema, quality, security, PII, license, code-integrity, Unicode, and script checks, plus optional LLM judging."
+---
 
 Tier 1 is the deterministic quality gate for skills: schema, quality, security,
 PII, license, secrets, code-integrity, Unicode-safety, and script checks that run
 offline after the scanner binaries are installed. No API key is needed for the
 deterministic stages. The only LLM-backed pieces of Tier 1 are `rubric-eval`
 (LLM required) and the optional `--llm`/`--llm-verify` flags — those need a
-configured provider (see [CONFIGURATION.md](CONFIGURATION.md)).
+configured provider (see [CONFIGURATION.md](configuration.mdx)).
 
 ## Table of Contents
 
@@ -382,7 +385,7 @@ skillevaluator validate ./my-skill --llm-verify
 
 Static scanning still runs first. If a requested LLM stage is unavailable or
 returns unusable evidence, the run does not silently turn green. See
-[CONFIGURATION.md](CONFIGURATION.md) for supported public providers.
+[CONFIGURATION.md](configuration.mdx) for supported public providers.
 
 ## Reports
 
@@ -434,7 +437,7 @@ Public Tier 1 configuration ships inside the package under
 - `profiles/external.yaml` — the default public validation profile.
 
 Semgrep's static policy is also packaged with the distribution. Provider and
-credential configuration is documented in [CONFIGURATION.md](CONFIGURATION.md).
+credential configuration is documented in [CONFIGURATION.md](configuration.mdx).
 
 ## Troubleshooting
 
@@ -468,10 +471,10 @@ credential configuration is documented in [CONFIGURATION.md](CONFIGURATION.md).
 
 ## See Also
 
-- [Installation](INSTALLATION.md) — install the base package and optional extras.
-- [Configuration](CONFIGURATION.md) — providers, credentials, and offline modes.
-- [Tier 2 Deduplication](TIER2_DEDUPLICATION.md) — semantic overlap and local
+- [Installation](installation.mdx) — install the base package and optional extras.
+- [Configuration](configuration.mdx) — providers, credentials, and offline modes.
+- [Tier 2 Deduplication](tier2-deduplication.mdx) — semantic overlap and local
   catalog checks.
-- [Tier 3 Live Evaluation](TIER3_LIVE_EVALUATION.md) — advisory live agent
+- [Tier 3 Live Evaluation](tier3-live-evaluation.mdx) — advisory live agent
   evaluation.
-- [Developer Guide](DEVELOPER_GUIDE.md) — local development and testing.
+- [Developer Guide](developer-guide.mdx) — local development and testing.

--- a/docs/tier2-deduplication.mdx
+++ b/docs/tier2-deduplication.mdx
@@ -1,4 +1,7 @@
-# Tier 2: Semantic Deduplication
+---
+title: "Tier 2: Semantic Deduplication"
+description: "Detect redundant content within one skill and overlapping skills across a collection using embedding similarity."
+---
 
 Tier 2 detects duplicate and overlapping skill content with embedding-based
 similarity analysis and, for intra-skill candidates, chat-LLM verification. It
@@ -19,8 +22,8 @@ is required.
 Tier 2 needs a configured embeddings provider. Intra-skill analysis also needs
 a configured chat LLM. If the selected chat provider does not offer embeddings,
 configure an embeddings provider separately. See
-[`CONFIGURATION.md`](CONFIGURATION.md), including the
-[fully local recipe](CONFIGURATION.md#fully-local-tier-2-no-external-calls).
+[`CONFIGURATION.md`](configuration.mdx), including the
+[fully local recipe](configuration.mdx#fully-local-tier-2-no-external-calls).
 
 ## Table of Contents
 
@@ -235,7 +238,7 @@ command name was invoked.
 - Catalog files are read and written locally; SkillEvaluator does not upload them
   to a catalog service.
 
-Use the [fully local provider recipe](CONFIGURATION.md#fully-local-tier-2-no-external-calls)
+Use the [fully local provider recipe](configuration.mdx#fully-local-tier-2-no-external-calls)
 when skill content must not leave the machine. Review the provider's own data
 handling terms before sending confidential skill content to a hosted endpoint.
 
@@ -250,7 +253,7 @@ handling terms before sending confidential skill content to a hosted endpoint.
 | High-confidence duplicate boundary | `0.70` | Maps actionable duplicate verdicts to HIGH rather than MEDIUM |
 
 Provider endpoints and default models are intentionally documented in
-[`CONFIGURATION.md`](CONFIGURATION.md) instead of duplicated here.
+[`CONFIGURATION.md`](configuration.mdx) instead of duplicated here.
 
 ## Reports and Exit Behavior
 
@@ -309,7 +312,7 @@ scanning an unbounded directory tree.
 
 ## See Also
 
-- [`CONFIGURATION.md`](CONFIGURATION.md) — provider setup and fully local Tier 2.
-- [`TIER1_VALIDATION.md`](TIER1_VALIDATION.md) — static, security, and quality validation.
-- [`TIER3_LIVE_EVALUATION.md`](TIER3_LIVE_EVALUATION.md) — live skill evaluation.
+- [`CONFIGURATION.md`](configuration.mdx) — provider setup and fully local Tier 2.
+- [`TIER1_VALIDATION.md`](tier1-validation.mdx) — static, security, and quality validation.
+- [`TIER3_LIVE_EVALUATION.md`](tier3-live-evaluation.mdx) — live skill evaluation.
 - [`README.md`](../README.md) — installation and end-to-end examples.

--- a/docs/tier3-live-evaluation.mdx
+++ b/docs/tier3-live-evaluation.mdx
@@ -1,4 +1,7 @@
-# Tier 3: Skill Evaluation with Live Agents
+---
+title: "Tier 3: Live Agent Evaluation"
+description: "Measure whether a skill makes an agent better — generate eval datasets and run with-skill vs. without-skill comparisons in Harbor sandboxes."
+---
 
 Live evaluation answers one question: **does your skill actually make an agent
 better at the task?** Skill Evaluator runs a real agent (such as `codex`,
@@ -117,7 +120,7 @@ cannot replace, alias, or reroute provider/agent/backend credentials through
 
 | Credential | Used for | How to set |
 | --- | --- | --- |
-| Evaluator LLM provider | Dataset generation and standard grading | `SKILL_EVAL_LLM_PROVIDER` plus the provider key; see [CONFIGURATION.md](CONFIGURATION.md) |
+| Evaluator LLM provider | Dataset generation and standard grading | `SKILL_EVAL_LLM_PROVIDER` plus the provider key; see [CONFIGURATION.md](configuration.mdx) |
 | Live agent credential | The agent actually performing the task | Export the agent's credential in the host environment before `doctor`/`evaluate` |
 
 Public NVIDIA Build at [build.nvidia.com](https://build.nvidia.com/) uses the
@@ -578,7 +581,7 @@ required by the selected agent and environment.
 
 ## See Also
 
-- [Configuration](CONFIGURATION.md) — provider, embedding, credential, and telemetry setup.
-- [Installation](INSTALLATION.md) — extras and system requirements.
-- [Tier 1 validation](TIER1_VALIDATION.md) — deterministic and security checks.
-- [Tier 2 deduplication](TIER2_DEDUPLICATION.md) — semantic overlap checks.
+- [Configuration](configuration.mdx) — provider, embedding, credential, and telemetry setup.
+- [Installation](installation.mdx) — extras and system requirements.
+- [Tier 1 validation](tier1-validation.mdx) — deterministic and security checks.
+- [Tier 2 deduplication](tier2-deduplication.mdx) — semantic overlap checks.

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 instances:
-  - url: https://nvidia-skillevaluator.docs.buildwithfern.com/skillevaluator
+  - url: nvidia-skillevaluator.docs.buildwithfern.com/skillevaluator
     custom-domain: docs.nvidia.com/skillevaluator
     multi-source: true
 

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+instances:
+  - url: https://nvidia-skillevaluator.docs.buildwithfern.com/skillevaluator
+    custom-domain: docs.nvidia.com/skillevaluator
+    multi-source: true
+
+title: Skill Evaluator Documentation
+
+global-theme: nvidia
+
+navbar-links:
+  - type: github
+    value: https://github.com/NVIDIA/SkillEvaluator
+
+logo:
+  right-text: Skill Evaluator
+
+navigation:
+  - page: Overview
+    path: ../docs/index.mdx
+    slug: /
+  - section: Documentation
+    skip-slug: true
+    contents:
+      - page: Installation
+        path: ../docs/installation.mdx
+        slug: installation
+      - page: Configuration
+        path: ../docs/configuration.mdx
+        slug: configuration
+      - page: "Tier 1: Static and Security Validation"
+        path: ../docs/tier1-validation.mdx
+        slug: tier1-validation
+      - page: "Tier 2: Semantic Deduplication"
+        path: ../docs/tier2-deduplication.mdx
+        slug: tier2-deduplication
+      - page: "Tier 3: Live Agent Evaluation"
+        path: ../docs/tier3-live-evaluation.mdx
+        slug: tier3-live-evaluation
+      - page: Developer Guide
+        path: ../docs/developer-guide.mdx
+        slug: developer-guide

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,0 +1,4 @@
+{
+  "organization": "nvidia",
+  "version": "5.66.1"
+}

--- a/tests/deduplication/intra_skill/test_intra_skill_validator.py
+++ b/tests/deduplication/intra_skill/test_intra_skill_validator.py
@@ -33,7 +33,7 @@ class TestIntraSkillValidatorProperties:
 
         Eagerly substituting SIMILARITY_DEFAULT_MODEL here overrides
         SKILL_EVAL_EMBEDDING_MODEL inside EmbeddingClient and breaks every
-        non-NVIDIA embedding endpoint (docs/CONFIGURATION.md contract).
+        non-NVIDIA embedding endpoint (docs/configuration.mdx contract).
         """
         assert IntraSkillValidator()._embedding_model is None
         assert IntraSkillValidator(embedding_model="custom-model")._embedding_model == "custom-model"

--- a/tests/embedding/test_client.py
+++ b/tests/embedding/test_client.py
@@ -185,7 +185,7 @@ class TestEmbed:
     def test_env_embedding_model_is_honored_without_explicit_model(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """SKILL_EVAL_EMBEDDING_MODEL wins when no explicit model is given.
 
-        This is the documented contract in docs/CONFIGURATION.md and what
+        This is the documented contract in docs/configuration.mdx and what
         makes custom OpenAI-compatible endpoints (including local servers)
         usable for Tier 2.
         """

--- a/tests/test_oss_packaging.py
+++ b/tests/test_oss_packaging.py
@@ -38,7 +38,7 @@ PUBLIC_REQUIRED_FILES = (
     ".github/workflows/ci.yml",
     ".github/workflows/security.yml",
 )
-PUBLIC_TEXT_SUFFIXES = {"", ".json", ".md", ".py", ".sh", ".toml", ".txt", ".yml", ".yaml", ".j2"}
+PUBLIC_TEXT_SUFFIXES = {"", ".json", ".md", ".mdx", ".py", ".sh", ".toml", ".txt", ".yml", ".yaml", ".j2"}
 PACKAGED_NVIDIA_BUILD_RUNTIME_FILES = {
     "skillevaluator/tier3/harbor/local_agents.py",
     "skillevaluator/tier3/harbor/nvidia_build_bridge.py",
@@ -407,7 +407,7 @@ def test_public_cli_exposes_both_tier_two_workflows_without_a_service() -> None:
 
 def test_public_docs_show_tier_two_collection_and_catalog_workflows() -> None:
     readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
-    guide = (REPO_ROOT / "docs" / "TIER2_DEDUPLICATION.md").read_text(encoding="utf-8")
+    guide = (REPO_ROOT / "docs" / "tier2-deduplication.mdx").read_text(encoding="utf-8")
     public_docs = f"{readme}\n{guide}"
 
     assert "similarity-check ./skills" in public_docs

--- a/tests/test_oss_packaging.py
+++ b/tests/test_oss_packaging.py
@@ -141,7 +141,7 @@ def test_public_sources_exclude_retired_internal_runtime_paths() -> None:
 
 
 def test_public_docs_explain_the_single_nvidia_credential_skillspector_path() -> None:
-    configuration = (REPO_ROOT / "docs" / "CONFIGURATION.md").read_text(encoding="utf-8")
+    configuration = (REPO_ROOT / "docs" / "configuration.mdx").read_text(encoding="utf-8")
 
     assert "SkillSpector's OpenAI-compatible provider path" in configuration
     assert "does not create a second NVIDIA credential name" in configuration
@@ -424,8 +424,8 @@ def test_public_docs_show_tier_two_collection_and_catalog_workflows() -> None:
 
 def test_public_docs_show_external_nvidia_build_harness_paths_only() -> None:
     readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
-    configuration = (REPO_ROOT / "docs" / "CONFIGURATION.md").read_text(encoding="utf-8")
-    tier3 = (REPO_ROOT / "docs" / "TIER3_LIVE_EVALUATION.md").read_text(encoding="utf-8")
+    configuration = (REPO_ROOT / "docs" / "configuration.mdx").read_text(encoding="utf-8")
+    tier3 = (REPO_ROOT / "docs" / "tier3-live-evaluation.mdx").read_text(encoding="utf-8")
     public_docs = f"{readme}\n{configuration}\n{tier3}"
 
     assert "gpt-5.4-mini" in public_docs

--- a/tests/validators/test_similarity.py
+++ b/tests/validators/test_similarity.py
@@ -30,7 +30,7 @@ class TestSimilarityValidatorProperties:
 
         Eagerly substituting SIMILARITY_DEFAULT_MODEL here overrides
         SKILL_EVAL_EMBEDDING_MODEL inside EmbeddingClient and breaks every
-        non-NVIDIA embedding endpoint (docs/CONFIGURATION.md contract).
+        non-NVIDIA embedding endpoint (docs/configuration.mdx contract).
         """
         assert SimilarityValidator()._model is None
         assert SimilarityValidator(model="custom-model")._model == "custom-model"


### PR DESCRIPTION
## Summary

Scaffolds a Fern deployment for the `docs/` folder, mirroring the setup in [NVIDIA/Skills](https://github.com/NVIDIA/Skills). Publishes to `docs.nvidia.com/skillevaluator`.

- **Fern config**: `fern/fern.config.json` (org `nvidia`) and `fern/docs.yml` (nvidia theme, GitHub navbar link, navigation tree).
- **Publish workflow**: `.github/workflows/publish-docs.yml` runs `fern generate --docs` on push to `main` (uses `FERN_TOKEN`).
- **Docs → MDX**: converted the six `docs/*.md` guides to `.mdx` with `title`/`description` frontmatter, using URL-style lowercase-hyphen filenames that match their Fern slugs (`git mv`, history preserved).
- **New pages**: `docs/index.mdx` landing page, `docs/README.md` authoring guide, `docs/AGENTS.md` authoring rules.
- **Cross-links**: updated `.md` → `.mdx` references across the docs and the root README.
- **Node requirement**: documented Node.js 22+ (the Fern CLI's current minimum; the old "18+" was inherited from the reference repo and is EOL).

## Verification

- `fern check` passes (config + link validation).

## Notes

- Requires the `FERN_TOKEN` repository secret and a registered `nvidia-skillevaluator` Fern docs instance + `docs.nvidia.com/skillevaluator` domain (Fern-side setup, outside this repo).
- The publish workflow's `github.run_number > 1` guard intentionally skips the very first run on `main` (mirrors NVIDIA/Skills).

🤖 Generated with [Claude Code](https://claude.com/claude-code)