### PR TITLE
Add Evaluation Core branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SkillEvaluator
 
-![SkillEvaluator](docs/assets/skillevaluator-wordmark.svg)
+![SkillEvaluator wordmark](docs/assets/skillevaluator-wordmark.svg)
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-green.svg)](LICENSE)
 [![Python](https://img.shields.io/badge/Python-3.12%20%7C%203.13-blue.svg)](https://www.python.org/)

--- a/docs/assets/skillevaluator-logo.svg
+++ b/docs/assets/skillevaluator-logo.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128" role="img" aria-labelledby="se-logo-title se-logo-description" focusable="false">
+  <title id="se-logo-title">SkillEvaluator logo</title>
+  <desc id="se-logo-description">Three concentric evaluation levels surrounding a verified core.</desc>
+  <style>
+    .se-logo-panel { fill: #f2f7ec; stroke: #d7e5cc; }
+    .se-logo-ring-outer { stroke: #b8d3a5; }
+    .se-logo-ring-middle { stroke: #83aa66; }
+    .se-logo-ring-inner { stroke: #315b25; }
+    .se-logo-core { fill: #76b900; stroke: #3e6500; }
+    .se-logo-check { stroke: #fff; }
+
+    @media (prefers-color-scheme: dark) {
+      .se-logo-panel { fill: #152117; stroke: #304631; }
+      .se-logo-ring-outer { stroke: #39523a; }
+      .se-logo-ring-middle { stroke: #6f9264; }
+      .se-logo-ring-inner { stroke: #dbe8d6; }
+      .se-logo-core { fill: #76b900; stroke: #9bdb34; }
+    }
+  </style>
+
+  <g aria-hidden="true">
+    <rect class="se-logo-panel" x="10.5" y="10.5" width="107" height="107" rx="53.5" stroke-width="1"/>
+    <circle class="se-logo-ring-outer" cx="64" cy="64" r="42" fill="none" stroke-width="5"/>
+    <circle class="se-logo-ring-middle" cx="64" cy="64" r="30" fill="none" stroke-width="5"/>
+    <circle class="se-logo-ring-inner" cx="64" cy="64" r="18" fill="none" stroke-width="5"/>
+    <circle class="se-logo-core" cx="64" cy="64" r="12" stroke-width="1.8"/>
+    <path class="se-logo-check" d="m57.5 64 4.4 4.6 8.8-9.3" fill="none" stroke-width="2.8" stroke-linecap="round" stroke-linejoin="round"/>
+    <circle class="se-logo-core" cx="97" cy="38" r="5" stroke-width="1.4"/>
+    <circle class="se-logo-core" cx="34" cy="82" r="5" stroke-width="1.4"/>
+  </g>
+</svg>

--- a/docs/assets/skillevaluator-wordmark.svg
+++ b/docs/assets/skillevaluator-wordmark.svg
@@ -1,13 +1,39 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="560" height="200" viewBox="0 0 560 200" role="img" aria-label="SkillEvaluator">
+<svg xmlns="http://www.w3.org/2000/svg" width="440" height="128" viewBox="0 0 440 128" role="img" aria-labelledby="se-title se-description" focusable="false">
+  <title id="se-title">SkillEvaluator</title>
+  <desc id="se-description">A progressive evaluation core paired with the SkillEvaluator name.</desc>
   <style>
-    .w { fill: #76B900; font-family: 'SF Mono', 'Menlo', 'Consolas', 'Courier New', monospace; font-size: 24px; font-weight: 700; white-space: pre; }
-    .sub { fill: #76B900; font-family: 'SF Mono', 'Menlo', 'Consolas', 'Courier New', monospace; font-size: 22px; font-weight: 700; letter-spacing: 0.4em; }
+    .se-panel { fill: #f2f7ec; stroke: #d7e5cc; }
+    .se-ring-outer { stroke: #b8d3a5; }
+    .se-ring-middle { stroke: #83aa66; }
+    .se-ring-inner { stroke: #315b25; }
+    .se-core { fill: #76b900; stroke: #3e6500; }
+    .se-check { stroke: #fff; }
+    .se-skill { fill: #183a10; }
+    .se-evaluator { fill: #3e6500; }
+
+    @media (prefers-color-scheme: dark) {
+      .se-panel { fill: #152117; stroke: #304631; }
+      .se-ring-outer { stroke: #39523a; }
+      .se-ring-middle { stroke: #6f9264; }
+      .se-ring-inner { stroke: #dbe8d6; }
+      .se-core { fill: #76b900; stroke: #9bdb34; }
+      .se-skill { fill: #f4f7f2; }
+      .se-evaluator { fill: #8fd018; }
+    }
   </style>
-  <text x="10" y="32" class="w" xml:space="preserve">███████╗██╗  ██╗██╗██╗     ██╗     </text>
-  <text x="10" y="58" class="w" xml:space="preserve">██╔════╝██║ ██╔╝██║██║     ██║     </text>
-  <text x="10" y="84" class="w" xml:space="preserve">███████╗█████╔╝ ██║██║     ██║     </text>
-  <text x="10" y="110" class="w" xml:space="preserve">╚════██║██╔═██╗ ██║██║     ██║     </text>
-  <text x="10" y="136" class="w" xml:space="preserve">███████║██║  ██╗██║███████╗███████╗</text>
-  <text x="10" y="162" class="w" xml:space="preserve">╚══════╝╚═╝  ╚═╝╚═╝╚══════╝╚══════╝</text>
-  <text x="540" y="190" class="sub" text-anchor="end">EVALUATOR</text>
+
+  <g aria-hidden="true" transform="translate(16 16) scale(.75)">
+    <rect class="se-panel" x="10.5" y="10.5" width="107" height="107" rx="53.5" stroke-width="1"/>
+    <circle class="se-ring-outer" cx="64" cy="64" r="42" fill="none" stroke-width="5"/>
+    <circle class="se-ring-middle" cx="64" cy="64" r="30" fill="none" stroke-width="5"/>
+    <circle class="se-ring-inner" cx="64" cy="64" r="18" fill="none" stroke-width="5"/>
+    <circle class="se-core" cx="64" cy="64" r="12" stroke-width="1.8"/>
+    <path class="se-check" d="m57.5 64 4.4 4.6 8.8-9.3" fill="none" stroke-width="2.8" stroke-linecap="round" stroke-linejoin="round"/>
+    <circle class="se-core" cx="97" cy="38" r="5" stroke-width="1.4"/>
+    <circle class="se-core" cx="34" cy="82" r="5" stroke-width="1.4"/>
+  </g>
+
+  <text x="132" y="79" font-family="Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="45" font-weight="750" letter-spacing="-1.35">
+    <tspan class="se-skill">Skill</tspan><tspan class="se-evaluator">Evaluator</tspan>
+  </text>
 </svg>

--- a/docs/assets/skillevaluator-wordmark.svg
+++ b/docs/assets/skillevaluator-wordmark.svg
@@ -1,24 +1,19 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="440" height="128" viewBox="0 0 440 128" role="img" aria-labelledby="se-title se-description" focusable="false">
   <title id="se-title">SkillEvaluator</title>
-  <desc id="se-description">A progressive evaluation core paired with the SkillEvaluator name.</desc>
+  <desc id="se-description">A progressive evaluation core paired with the SkillEvaluator name on a dark background.</desc>
   <style>
-    .se-panel { fill: #f2f7ec; stroke: #d7e5cc; }
-    .se-ring-outer { stroke: #b8d3a5; }
-    .se-ring-middle { stroke: #83aa66; }
-    .se-ring-inner { stroke: #315b25; }
-    .se-core { fill: #76b900; stroke: #3e6500; }
+    .se-background { fill: #0d1117; stroke: #273129; }
+    .se-panel { fill: #152117; stroke: #304631; }
+    .se-ring-outer { stroke: #39523a; }
+    .se-ring-middle { stroke: #6f9264; }
+    .se-ring-inner { stroke: #dbe8d6; }
+    .se-core { fill: #76b900; stroke: #9bdb34; }
     .se-check { stroke: #fff; }
-    .se-skill { fill: #fff; paint-order: stroke fill; stroke: #183a10; stroke-width: 1.1px; stroke-linejoin: round; }
+    .se-skill { fill: #fff; }
     .se-evaluator { fill: #76b900; }
-
-    @media (prefers-color-scheme: dark) {
-      .se-panel { fill: #152117; stroke: #304631; }
-      .se-ring-outer { stroke: #39523a; }
-      .se-ring-middle { stroke: #6f9264; }
-      .se-ring-inner { stroke: #dbe8d6; }
-      .se-core { fill: #76b900; stroke: #9bdb34; }
-    }
   </style>
+
+  <rect class="se-background" x=".5" y=".5" width="439" height="127" rx="20" stroke-width="1"/>
 
   <g aria-hidden="true" transform="translate(16 16) scale(.75)">
     <rect class="se-panel" x="10.5" y="10.5" width="107" height="107" rx="53.5" stroke-width="1"/>

--- a/docs/assets/skillevaluator-wordmark.svg
+++ b/docs/assets/skillevaluator-wordmark.svg
@@ -8,8 +8,8 @@
     .se-ring-inner { stroke: #315b25; }
     .se-core { fill: #76b900; stroke: #3e6500; }
     .se-check { stroke: #fff; }
-    .se-skill { fill: #183a10; }
-    .se-evaluator { fill: #3e6500; }
+    .se-skill { fill: #fff; paint-order: stroke fill; stroke: #183a10; stroke-width: 1.1px; stroke-linejoin: round; }
+    .se-evaluator { fill: #76b900; }
 
     @media (prefers-color-scheme: dark) {
       .se-panel { fill: #152117; stroke: #304631; }
@@ -17,8 +17,6 @@
       .se-ring-middle { stroke: #6f9264; }
       .se-ring-inner { stroke: #dbe8d6; }
       .se-core { fill: #76b900; stroke: #9bdb34; }
-      .se-skill { fill: #f4f7f2; }
-      .se-evaluator { fill: #8fd018; }
     }
   </style>
 


### PR DESCRIPTION
## Summary

- replace the ASCII-art README wordmark with the selected Evaluation Core design
- add a matching standalone SkillEvaluator logo
- improve light/dark-mode rendering and SVG accessibility metadata
- clarify the README image alt text

## Why

The Evaluation Core design represents progressively deeper evaluation converging on a verified result. Using the same visual language for the wordmark and standalone logo gives SkillEvaluator a consistent public identity.

## Impact

Documentation and branding only; there are no runtime or API changes.

## Validation

- `xmllint --noout docs/assets/skillevaluator-wordmark.svg docs/assets/skillevaluator-logo.svg`
- `git diff --check HEAD^ HEAD`
- rendered both SVGs locally for visual verification
