### PR TITLE
Fix public evaluation and reference-script regressions

### DIFF
--- a/src/skillevaluator/cli.py
+++ b/src/skillevaluator/cli.py
@@ -360,11 +360,18 @@ def _run_agent_eval_or_skip(
             skill_name=target_path.name,
         )
 
-    result = agent_eval_result_from_run(
-        target_path,
-        env_mode=env_mode,
-        engine_result=engine_result if isinstance(engine_result, dict) else None,
-    )
+    try:
+        result = agent_eval_result_from_run(
+            target_path,
+            results_dir=results_dir,
+            env_mode=env_mode,
+            engine_result=engine_result if isinstance(engine_result, dict) else None,
+        )
+    except Exception as exc:
+        return advisory_skip_result(
+            f"Tier 3 result normalization failed: {exc}",
+            skill_name=target_path.name,
+        )
     if result is None:
         return advisory_skip_result(
             "Tier 3 live evaluation produced no parseable results.",

--- a/src/skillevaluator/reporting/base.py
+++ b/src/skillevaluator/reporting/base.py
@@ -341,6 +341,22 @@ def _write_report_atomically(output_path: Path, payload: bytes) -> None:
         _write_report_checked(absolute, payload)
 
 
+def is_advisory_agent_eval_skip(result: ValidationResult) -> bool:
+    """Return whether a Tier 3 result records a non-blocking skipped run."""
+    if result.validator_name != "AGENT_EVAL":
+        return False
+    payload = result.metadata.get("agent_eval", {}) if result.metadata else {}
+    provenance = payload.get("provenance", {}) if isinstance(payload, dict) else {}
+    return bool(
+        isinstance(provenance, dict) and provenance.get("advisory") and provenance.get("reason") == "skipped"
+    )
+
+
+def passes_required_gate(result: ValidationResult) -> bool:
+    """Return whether *result* permits the required validation gate to pass."""
+    return result.passed or is_advisory_agent_eval_skip(result)
+
+
 class ReporterBase(ABC):
     """Abstract base class for validation result reporters.
 

--- a/src/skillevaluator/reporting/benchmark.py
+++ b/src/skillevaluator/reporting/benchmark.py
@@ -10,7 +10,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 from skillevaluator.constants import DIMENSION_HINTS, DIMENSION_MAPPING
-from skillevaluator.reporting.base import ReporterBase
+from skillevaluator.reporting.base import ReporterBase, is_advisory_agent_eval_skip, passes_required_gate
 
 if TYPE_CHECKING:
     from skillevaluator.models import Finding, ValidationResult
@@ -130,6 +130,8 @@ class BenchmarkReporter(ReporterBase):
             verdict = ae.get("verdict") or summary.get("verdict")
             combined = _combined_verdict(results, verdict)
             lines.append(f"- Overall verdict: {combined}")
+            if skip_message := _advisory_agent_eval_skip_message(results):
+                lines.append(f"- Tier 3 live evaluation: SKIPPED — {skip_message}")
             if combined == "INCOMPLETE":
                 _render_incomplete_benchmark_notes(lines, results)
             elif combined == "FAIL":
@@ -338,12 +340,19 @@ class BenchmarkReporter(ReporterBase):
 
         lines.append("## Publication Recommendation")
         lines.append("")
-        lines.append(
-            "The skill is suitable to proceed toward Skill Evaluator publication "
-            "based on this benchmark. Skill owners should keep this file with the "
-            "skill and refresh it when the evaluation dataset, skill behavior, or "
-            "target agents materially change."
-        )
+        if _advisory_agent_eval_skip_message(results):
+            lines.append(
+                "Tier 3 live evaluation was skipped and does not block required validation. "
+                "Publication suitability in this report is based on the completed required-tier "
+                "results; rerun Tier 3 when the live evaluation runtime is available."
+            )
+        else:
+            lines.append(
+                "The skill is suitable to proceed toward Skill Evaluator publication "
+                "based on this benchmark. Skill owners should keep this file with the "
+                "skill and refresh it when the evaluation dataset, skill behavior, or "
+                "target agents materially change."
+            )
         lines.append("")
 
     def get_file_extension(self) -> str:
@@ -366,11 +375,22 @@ def _render_failed_benchmark_notes(lines: list[str]) -> None:
     )
 
 
+def _advisory_agent_eval_skip_message(results: list[ValidationResult]) -> str | None:
+    for result in results:
+        if not is_advisory_agent_eval_skip(result):
+            continue
+        payload = result.metadata.get("agent_eval", {}) if result.metadata else {}
+        provenance = payload.get("provenance", {}) if isinstance(payload, dict) else {}
+        message = provenance.get("message") if isinstance(provenance, dict) else None
+        return str(message or "Live evaluation did not run.")
+    return None
+
+
 def _combined_verdict(results: list[ValidationResult], tier3_verdict: object) -> str:
     """Return one report verdict with incomplete evidence taking precedence."""
     if any(result.is_incomplete for result in results):
         return "INCOMPLETE"
-    if not all(result.passed for result in results) or str(tier3_verdict or "pass").lower() == "fail":
+    if not all(passes_required_gate(result) for result in results) or str(tier3_verdict or "pass").lower() == "fail":
         return "FAIL"
     return "PASS"
 

--- a/src/skillevaluator/reporting/html.py
+++ b/src/skillevaluator/reporting/html.py
@@ -31,7 +31,7 @@ from jinja2 import BaseLoader, Environment
 
 from skillevaluator import __version__
 from skillevaluator.constants import TIER3_LIFT_FAIL_THRESHOLD, TIER3_LIFT_PASS_THRESHOLD
-from skillevaluator.reporting.base import ReporterBase
+from skillevaluator.reporting.base import ReporterBase, is_advisory_agent_eval_skip, passes_required_gate
 from skillevaluator.reporting.harbor_viewer import normalize_agent_eval_harbor_links
 
 if TYPE_CHECKING:
@@ -768,13 +768,15 @@ class HTMLReporter(ReporterBase):
     def _compute_tier_summary(results: list[ValidationResult]) -> dict[str, Any]:
         """Compact stats for a single tier — what the hero chip displays.
 
-        Returns ``passed`` (boolean), ``passed_count`` / ``total`` (validator
-        counts), ``issue_count`` (sum of findings), and per-severity totals.
+        Returns ``passed`` (boolean), executed/pass/skip counts,
+        ``issue_count`` (sum of findings), and per-severity totals.
         ``total == 0`` lets the template hide the chip entirely without an
         extra "did this tier run?" predicate.
         """
         total = len(results)
         passed_count = sum(1 for r in results if r.passed)
+        advisory_skipped_count = sum(1 for r in results if is_advisory_agent_eval_skip(r))
+        failed_count = sum(1 for r in results if not passes_required_gate(r))
         issue_count = 0
         critical = high = medium = low = 0
         for r in results:
@@ -792,9 +794,10 @@ class HTMLReporter(ReporterBase):
         return {
             "total": total,
             "passed_count": passed_count,
-            "failed_count": total - passed_count,
+            "advisory_skipped_count": advisory_skipped_count,
+            "failed_count": failed_count,
             "issue_count": issue_count,
-            "all_passed": total > 0 and passed_count == total,
+            "all_passed": total > 0 and failed_count == 0,
             "incomplete_count": sum(1 for r in results if r.is_incomplete),
             "critical": critical,
             "high": high,
@@ -809,7 +812,7 @@ class HTMLReporter(ReporterBase):
                 "validator_name": result.validator_name,
                 "validator_description": result.validator_description,
                 "passed": result.passed,
-                "status": result.status,
+                "status": "skipped" if is_advisory_agent_eval_skip(result) else result.status,
                 "incomplete_scans": result.incomplete_scans,
                 "summary": {
                     "files_scanned": result.summary.files_scanned,
@@ -853,20 +856,67 @@ class HTMLReporter(ReporterBase):
             output.append(result_dict)
         return output
 
+    @staticmethod
+    def _tier3_report_data(results: list[ValidationResult]) -> dict[str, Any] | None:
+        """Return canonical Tier 3 data, with a visible fallback for bare results."""
+        for result in results:
+            payload = result.metadata.get("agent_eval") if result.metadata else None
+            if isinstance(payload, dict) and payload:
+                return normalize_agent_eval_harbor_links(payload)
+
+        if not results:
+            return None
+
+        # A validator failure should remain visible even if normalization
+        # failed before canonical ``agent_eval`` metadata could be attached.
+        result = results[0]
+        verdict = "pass" if result.passed else "fail"
+        execution_status = "succeeded" if result.passed else "failed"
+        messages = [*result.errors, *result.warnings, *result.messages]
+        message = messages[0] if messages else "Tier 3 did not provide canonical evaluation details."
+        return {
+            "schema_version": "2.0",
+            "summary": {
+                "schema_version": "2.0",
+                "verdict": verdict,
+                "execution_status": execution_status,
+                "execution_errors": list(result.errors),
+            },
+            "skill_name": "",
+            "verdict": verdict,
+            "overall_score": None,
+            "overall_lift": None,
+            "execution_status": execution_status,
+            "execution_errors": list(result.errors),
+            "agents_run": [],
+            "agents": {},
+            "dimensions": [],
+            "evaluators": {},
+            "evaluator_cards": [],
+            "cases": [],
+            "suggestions": messages,
+            "metric_ids": [],
+            "metric_labels": {},
+            "dataset": [],
+            "provenance": {"source": "validation_result", "message": message},
+        }
+
     def render(self, result: ValidationResult) -> str:
         return self.render_all([result])
 
     def render_all(self, results: list[ValidationResult]) -> str:
-        all_passed = all(r.passed for r in results)
+        all_passed = all(passes_required_gate(r) for r in results)
         has_incomplete = any(r.is_incomplete for r in results)
         overall_status = "incomplete" if has_incomplete else "passed" if all_passed else "failed"
         total_errors = sum(r.summary.errors for r in results)
         total_warnings = sum(r.summary.warnings for r in results)
         passed_count = sum(1 for r in results if r.passed)
-        failed_count = len(results) - passed_count
+        advisory_skipped_count = sum(1 for r in results if is_advisory_agent_eval_skip(r))
+        failed_count = sum(1 for r in results if not passes_required_gate(r))
         total_issues = total_errors + total_warnings
         total_validators = len(results)
-        pass_percentage = round((passed_count / total_validators * 100) if total_validators > 0 else 0, 1)
+        executed_count = total_validators - advisory_skipped_count
+        pass_percentage = round((passed_count / executed_count * 100) if executed_count > 0 else 0, 1)
 
         timestamp = ""
         if self.include_timestamp:
@@ -918,10 +968,12 @@ class HTMLReporter(ReporterBase):
         tier1_summary = self._compute_tier_summary(tier1_results)
         tier2_summary = self._compute_tier_summary(tier2_results)
         tier3_summary = self._compute_tier_summary(tier3_results)
+        tier3_data = self._tier3_report_data(tier3_results)
 
-        # Preserve the existing Tier 3 presentation while excluding every
-        # Tier 2 validator from Tier 1's skill- and validator-centric views.
-        tier1_display_results = [result for result in results if not is_tier2_validator_name(result.validator_name)]
+        # Keep the Tier 1 dashboard scoped to Tier 1. Tier 2 and Tier 3 have
+        # dedicated tabs; including an advisory Tier 3 skip here would make
+        # the dashboard report a failure even though it does not gate Tier 1.
+        tier1_display_results = tier1_results
         tier1_skills = self._reorganize_by_skill(tier1_display_results)
         tier1_top_issues = self._compute_top_issues(tier1_skills)
         tier1_contributors = self._extract_contributors(tier1_skills, tier1_display_results)
@@ -1008,14 +1060,6 @@ class HTMLReporter(ReporterBase):
             first_key = next(iter(skills_by_name))
             skills_by_name[first_key]["quality"] = single_qs
 
-        # Extract Tier 3 agent evaluation data if present
-        tier3_data: dict[str, Any] | None = None
-        for r in results:
-            ae = r.metadata.get("agent_eval") if r.metadata else None
-            if ae:
-                tier3_data = normalize_agent_eval_harbor_links(ae)
-                break
-
         report_data = {
             "title": self.title,
             "timestamp": timestamp,
@@ -1028,6 +1072,7 @@ class HTMLReporter(ReporterBase):
                 "incomplete_scans": list(dict.fromkeys(tool for result in results for tool in result.incomplete_scans)),
                 "total_validators": total_validators,
                 "passed_count": passed_count,
+                "advisory_skipped_count": advisory_skipped_count,
                 "failed_count": failed_count,
                 "total_issues": total_issues,
                 "pass_percentage": pass_percentage,

--- a/src/skillevaluator/reporting/json_reporter.py
+++ b/src/skillevaluator/reporting/json_reporter.py
@@ -18,7 +18,7 @@ import json
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
-from skillevaluator.reporting.base import ReporterBase
+from skillevaluator.reporting.base import ReporterBase, is_advisory_agent_eval_skip, passes_required_gate
 
 if TYPE_CHECKING:
     from skillevaluator.models import ValidationResult
@@ -60,7 +60,8 @@ class JSONReporter(ReporterBase):
         """Render all results to JSON with overall summary."""
         from skillevaluator.reporting.html import HTMLReporter
 
-        all_passed = all(r.passed for r in results)
+        all_passed = all(passes_required_gate(r) for r in results)
+        advisory_skip_count = sum(1 for r in results if is_advisory_agent_eval_skip(r))
         incomplete_scans = list(dict.fromkeys(tool for result in results for tool in result.incomplete_scans))
         overall_status = "incomplete" if incomplete_scans else "passed" if all_passed else "failed"
         total_errors = sum(r.summary.errors for r in results)
@@ -89,6 +90,7 @@ class JSONReporter(ReporterBase):
             "overall_status": overall_status,
             "incomplete_scans": incomplete_scans,
             "total_validators": len(results),
+            "total_advisory_skipped": advisory_skip_count,
             "total_errors": total_errors,
             "total_warnings": total_warnings,
             "severity_counts": {
@@ -130,7 +132,7 @@ class JSONReporter(ReporterBase):
             "validator": result.validator_name,
             "description": result.validator_description,
             "passed": result.passed,
-            "status": result.status,
+            "status": "skipped" if is_advisory_agent_eval_skip(result) else result.status,
             "incomplete_scans": result.incomplete_scans,
             "summary": {
                 "files_scanned": result.summary.files_scanned,

--- a/src/skillevaluator/reporting/markdown.py
+++ b/src/skillevaluator/reporting/markdown.py
@@ -18,7 +18,7 @@ import html
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
-from skillevaluator.reporting.base import ReporterBase
+from skillevaluator.reporting.base import ReporterBase, is_advisory_agent_eval_skip, passes_required_gate
 from skillevaluator.reporting.harbor_viewer import (
     harbor_evidence_link_text,
     normalize_harbor_viewer_for_display,
@@ -97,8 +97,9 @@ class MarkdownReporter(ReporterBase):
         lines.append("")
 
         # Overall status
-        all_passed = all(r.passed for r in results)
+        all_passed = all(passes_required_gate(r) for r in results)
         has_incomplete = any(r.is_incomplete for r in results)
+        advisory_skip_count = sum(1 for r in results if is_advisory_agent_eval_skip(r))
         status = "⚠️ INCOMPLETE" if has_incomplete else "✅ PASSED" if all_passed else "❌ FAILED"
         lines.append(f"**Status:** {status}")
 
@@ -112,10 +113,14 @@ class MarkdownReporter(ReporterBase):
         lines.append("")
         lines.append("| Metric | Value |")
         lines.append("|--------|-------|")
-        lines.append(f"| Validators Run | {len(results)} |")
+        lines.append(f"| Validator Results | {len(results)} |")
         lines.append(f"| ✅ Passed | {sum(1 for r in results if r.status == 'passed')} |")
-        lines.append(f"| ❌ Failed | {sum(1 for r in results if r.status == 'failed')} |")
+        lines.append(
+            f"| ❌ Failed | {sum(1 for r in results if r.status == 'failed' and not is_advisory_agent_eval_skip(r))} |"
+        )
         lines.append(f"| ⚠️ Incomplete | {sum(1 for r in results if r.is_incomplete)} |")
+        if advisory_skip_count:
+            lines.append(f"| ⏭️ Advisory skips | {advisory_skip_count} |")
 
         total_errors = sum(r.summary.errors for r in results)
         total_warnings = sum(r.summary.warnings for r in results)
@@ -263,9 +268,12 @@ class MarkdownReporter(ReporterBase):
         """Render a single validation result."""
         qs = result.metadata.get("quality_scores")
 
+        advisory_skip = is_advisory_agent_eval_skip(result)
         if result.is_incomplete:
             status_emoji = "⚠️ INCOMPLETE"
             lines.append(f"### {status_emoji} {result.validator_name}")
+        elif advisory_skip:
+            lines.append(f"### ⏭️ SKIPPED {result.validator_name}")
         elif qs and qs.get("grade"):
             grade = qs["grade"]
             status_emoji = "✅" if result.passed else "❌"
@@ -293,6 +301,11 @@ class MarkdownReporter(ReporterBase):
 
         if result.is_incomplete:
             self._render_incomplete(result, lines)
+        elif advisory_skip:
+            payload = result.metadata.get("agent_eval", {}) if result.metadata else {}
+            provenance = payload.get("provenance", {}) if isinstance(payload, dict) else {}
+            message = provenance.get("message") if isinstance(provenance, dict) else None
+            lines.append(f"- {message or 'Live evaluation did not run.'}")
         elif result.passed:
             self._render_success(result, lines)
             if result.findings:

--- a/src/skillevaluator/reporting/templates/report.html.j2
+++ b/src/skillevaluator/reporting/templates/report.html.j2
@@ -1227,6 +1227,11 @@
 </head>
 <body>
     {% set has_tier3 = tier3 is defined and tier3 %}
+    {% set tier3_summary_data = (tier3.get('summary') or {}) if has_tier3 else {} %}
+    {% set tier3_provenance_data = (tier3.get('provenance') or {}) if has_tier3 else {} %}
+    {% set tier3_execution_status = (tier3.get('execution_status') or tier3_summary_data.get('execution_status')) if has_tier3 else none %}
+    {% set tier3_is_skipped = tier3_execution_status == 'skipped' or (tier3_provenance_data.get('advisory') and tier3_provenance_data.get('reason') == 'skipped') %}
+    {% set tier3_skip_message = tier3_provenance_data.get('message') or 'Live evaluation did not run.' %}
     <div class="main-header">
         <div class="header-content">
             <div class="logo-section">
@@ -1296,6 +1301,15 @@
                 -#}
                 {% if has_tier3 %}
                 {% set tier3_environment = (tier3.summary.environment if tier3.summary is defined and tier3.summary else None) or tier3.environment %}
+                {% if tier3_is_skipped %}
+                <div>
+                    <div class="agent-hero-score score-warn">SKIPPED</div>
+                    <div class="agent-hero-detail">
+                        <div><strong>Reason:</strong> {{ tier3_skip_message }}</div>
+                        <div>Tier 3 is advisory and does not block required validation.</div>
+                    </div>
+                </div>
+                {% else %}
                 <div>
                     <div class="agent-hero-score {{ 'score-pass' if hero_score is not none and hero_score >= 0.8 else ('score-warn' if hero_score is not none and hero_score >= 0.6 else 'score-fail') }}">{{ "%.2f" | format(hero_score) if hero_score is not none else "N/A" }}</div>
                     <div class="agent-hero-detail">
@@ -1306,6 +1320,7 @@
                         {% if tier3.get('overall_lift') is not none %}<div><strong>Overall lift:</strong> {{ "%+.2f" | format(tier3.get('overall_lift')) }}</div>{% endif %}
                     </div>
                 </div>
+                {% endif %}
                 {% else %}
                 <div>
                     <div class="agent-hero-score {{ 'score-pass' if all_passed else 'score-fail' }}">{{ pass_percentage }}%</div>
@@ -1386,7 +1401,8 @@
                 {% endif %}
                 {% if has_tier3 %}
                 {% set tier3_verdict = (tier3.verdict or 'unknown') | lower %}
-                {% set t3_class = 'pass' if tier3_verdict == 'pass' else ('fail' if tier3_verdict == 'fail' else 'warn') %}
+                {% set tier3_display_verdict = 'SKIPPED' if tier3_is_skipped else tier3_verdict | upper %}
+                {% set t3_class = 'skipped' if tier3_is_skipped else ('pass' if tier3_verdict == 'pass' else ('fail' if tier3_verdict == 'fail' else 'warn')) %}
                 <div class="tier-card {{ t3_class }}{% if initial_tab == 'tier3' %} active{% endif %}"
                      role="button"
                      tabindex="0"
@@ -1397,13 +1413,17 @@
                      title="Open Tier 3: Live Agent Evaluation">
                     <div class="tier-card-head">
                         <span class="tier-card-label">Tier 3</span>
-                        <span class="tier-card-verdict">{{ tier3_verdict | upper }}</span>
+                        <span class="tier-card-verdict">{{ tier3_display_verdict }}</span>
                     </div>
                     <h3 class="tier-card-title">Live Agent Evaluation</h3>
                     <div class="tier-card-stats">
+                        {% if tier3_is_skipped %}
+                        <span>{{ tier3_skip_message }}</span>
+                        {% else %}
                         <span>score <strong>{{ "%.2f" | format(tier3.overall_score) if tier3.overall_score is not none else "N/A" }}</strong></span>
                         {% if tier3.get('overall_lift') is not none %}<span>lift <strong>{{ "%+.2f" | format(tier3.get('overall_lift')) }}</strong></span>{% endif %}
                         {% if hero_trials %}<span><strong>{{ hero_trials }}</strong> trial(s)</span>{% endif %}
+                        {% endif %}
                     </div>
                     {% if hero_harbor_job_url or hero_harbor_analysis_url %}
                     <div class="tier-card-links" onclick="event.stopPropagation()">
@@ -2239,11 +2259,16 @@
         {# ---------- Overview ---------- #}
         <section class="t3-page active" id="tier3-page-overview">
             <div class="t3-overview-lead">
+                {% if tier3_is_skipped %}
+                <strong>Live evaluation skipped:</strong> {{ tier3_skip_message }}
+                Tier 3 is advisory and does not block required validation.
+                {% else %}
                 <strong>Verdict at a glance:</strong>
                 {{ (tier3.verdict or 'unknown') | upper }} with an overall score of
                 {{ "%.2f" | format(tier3.overall_score) if tier3.overall_score is not none else "N/A" }}.
                 {% if t3_best_name %}Best performing agent is <strong>{{ t3_best_name }}</strong>{% else %}No successfully scored agent is available{% endif %}
                 {% if tier3.get('overall_lift') is not none %} with {{ "%+.2f" | format(tier3.get('overall_lift')) }} skill lift{% endif %}.
+                {% endif %}
             </div>
             {% if t3_harbor_job_url or t3_harbor_analysis_url %}
             <div class="t3-harbor-panel">
@@ -2260,7 +2285,7 @@
             <div class="dashboard">
                 <div class="dashboard-card {{ 'success' if tier3.verdict == 'pass' else ('danger' if tier3.verdict == 'fail' else '') }}">
                     <h3 class="dashboard-card-title">Verdict</h3>
-                    <p class="dashboard-card-value">{{ (tier3.verdict or 'unknown') | upper }}</p>
+                    <p class="dashboard-card-value">{{ 'SKIPPED' if tier3_is_skipped else (tier3.verdict or 'unknown') | upper }}</p>
                     <p class="dashboard-card-subtitle">Evaluation outcome</p>
                 </div>
                 <div class="dashboard-card">

--- a/src/skillevaluator/tier3/harbor/local_environment.py
+++ b/src/skillevaluator/tier3/harbor/local_environment.py
@@ -848,11 +848,24 @@ class SkillEvaluatorLocalEnvironment(BaseEnvironment):
         return rewritten
 
     def _rewrite_raw_paths(self, value: str) -> str:
-        rewritten = value
-        for remote, local in self._path_map():
-            rewritten = rewritten.replace(f"{remote}/", f"{local}{os.sep}")
-            rewritten = rewritten.replace(remote, str(local))
-        return rewritten
+        path_map = dict(self._path_map())
+        if not path_map:
+            return value
+
+        # Match all container roots in one pass so a container-looking segment
+        # in a generated local path is not rewritten a second time. Longer
+        # roots must win (for example, /logs/agent before /logs).
+        remote_roots = sorted(path_map, key=len, reverse=True)
+        pattern = re.compile(
+            rf"(?<![A-Za-z0-9_.\-/])(?P<root>{'|'.join(re.escape(root) for root in remote_roots)})"
+            r"(?P<separator>/|(?=$|[^A-Za-z0-9_.-]))"
+        )
+
+        def replace(match: re.Match[str]) -> str:
+            separator = os.sep if match.group("separator") else ""
+            return f"{path_map[match.group('root')]}{separator}"
+
+        return pattern.sub(replace, value)
 
     @staticmethod
     def _replace_shell_path(command: str, remote: str, local: Path) -> str:

--- a/src/skillevaluator/tier3/reference_skills/api-caller/scripts/call_api.py
+++ b/src/skillevaluator/tier3/reference_skills/api-caller/scripts/call_api.py
@@ -28,6 +28,8 @@ from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode, urlparse
 from urllib.request import Request, urlopen
 
+_UNSET = object()
+
 
 def _validate_http_url(url: str) -> str:
     """Reject local-file and custom URL schemes before making a request."""
@@ -38,7 +40,7 @@ def _validate_http_url(url: str) -> str:
 
 
 def make_request(
-    url: str, method: str = "GET", data: dict | None = None, headers: dict | None = None, timeout: int = 30
+    url: str, method: str = "GET", data: object = _UNSET, headers: dict | None = None, timeout: int = 30
 ) -> dict:
     """Make an HTTP request and return the response."""
 
@@ -64,7 +66,7 @@ def make_request(
 
         # Prepare body
         body = None
-        if data:
+        if data is not _UNSET:
             body = json.dumps(data).encode("utf-8")
             req_headers["Content-Type"] = "application/json"
 
@@ -157,6 +159,22 @@ def build_url_from_spec(spec: dict, path: str, params: dict) -> str:
     return url
 
 
+def _parse_json_argument(value: str | None, label: str, expected_type: type | None = None) -> object | None:
+    """Parse and type-check a JSON command-line argument."""
+    if value is None:
+        return None
+
+    parsed = json.loads(value)
+    if expected_type is not None and not isinstance(parsed, expected_type):
+        raise ValueError(f"{label} must be a JSON {expected_type.__name__}")
+    return parsed
+
+
+def _print_json(value: dict, *, file=None) -> None:
+    """Print a stable, human-readable JSON object."""
+    print(json.dumps(value, indent=2, default=str), file=file)
+
+
 def main():
     parser = argparse.ArgumentParser(description="Generic API Caller")
     parser.add_argument("--url", help="Direct API endpoint URL")
@@ -173,9 +191,15 @@ def main():
     args = parser.parse_args()
 
     # Parse JSON arguments
-    data = json.loads(args.data) if args.data else None
-    headers = json.loads(args.headers) if args.headers else None
-    params = json.loads(args.params) if args.params else {}
+    try:
+        data = _UNSET if args.data is None else _parse_json_argument(args.data, "--data")
+        headers = _parse_json_argument(args.headers, "--headers", dict)
+        params = _parse_json_argument(args.params, "--params", dict) or {}
+        if headers and not all(isinstance(value, str) for value in headers.values()):
+            raise ValueError("--headers must map header names to string values")
+    except (json.JSONDecodeError, ValueError) as exc:
+        _print_json({"success": False, "error": f"Invalid input: {exc}"}, file=sys.stderr)
+        sys.exit(1)
 
     # Determine URL and method
     url = args.url
@@ -193,7 +217,9 @@ def main():
     if args.spec and args.operation:
         spec = fetch_openapi_spec(args.spec)
         if not spec:
-            print(json.dumps({"success": False, "error": f"Failed to fetch OpenAPI spec from {args.spec}"}, indent=2))
+            _print_json(
+                {"success": False, "error": f"Failed to fetch OpenAPI spec from {args.spec}"}, file=sys.stderr
+            )
             sys.exit(1)
 
         path, spec_method, _operation = find_operation(spec, args.operation)
@@ -205,36 +231,32 @@ def main():
                     if "operationId" in details:
                         available.append(f"{m.upper()} {p} ({details['operationId']})")
 
-            print(
-                json.dumps(
-                    {
-                        "success": False,
-                        "error": f"Operation '{args.operation}' not found in spec",
-                        "available_operations": available[:20],  # Show first 20
-                    },
-                    indent=2,
-                )
+            _print_json(
+                {
+                    "success": False,
+                    "error": f"Operation '{args.operation}' not found in spec",
+                    "available_operations": available[:20],  # Show first 20
+                },
+                file=sys.stderr,
             )
             sys.exit(1)
 
         url = build_url_from_spec(spec, path, params)
         method = spec_method
 
-        print("# Resolved from OpenAPI spec:")
-        print(f"# {method} {url}")
-        print()
+        print(f"Resolved OpenAPI operation: {method} {url}", file=sys.stderr)
 
     if not url:
-        print(
-            json.dumps({"success": False, "error": "No URL provided. Use --url or --spec with --operation"}, indent=2)
+        _print_json(
+            {"success": False, "error": "No URL provided. Use --url or --spec with --operation"}, file=sys.stderr
         )
         sys.exit(1)
 
     # Make the request
     result = make_request(url, method, data, headers, args.timeout)
 
-    # Pretty print result
-    print(json.dumps(result, indent=2, default=str))
+    # Pretty print successful results to stdout and handled failures to stderr.
+    _print_json(result, file=None if result["success"] else sys.stderr)
 
     # Exit with appropriate code
     sys.exit(0 if result["success"] else 1)

--- a/src/skillevaluator/tier3/reference_skills/api-caller/scripts/parse_openapi.py
+++ b/src/skillevaluator/tier3/reference_skills/api-caller/scripts/parse_openapi.py
@@ -133,7 +133,8 @@ def main():
                     "example": "parse_openapi.py https://api.weather.gov/openapi.json points",
                 },
                 indent=2,
-            )
+            ),
+            file=sys.stderr,
         )
         sys.exit(1)
 
@@ -143,7 +144,7 @@ def main():
     # Fetch the spec
     spec = fetch_spec(spec_url)
     if "error" in spec:
-        print(json.dumps(spec, indent=2))
+        print(json.dumps(spec, indent=2), file=sys.stderr)
         sys.exit(1)
 
     # Parse and return operations

--- a/src/skillevaluator/tier3/reference_skills/task-list/scripts/tasks.py
+++ b/src/skillevaluator/tier3/reference_skills/task-list/scripts/tasks.py
@@ -459,10 +459,11 @@ def main():
 
     raw_args = shlex.join(arg_parts)
     result = handle_operation(raw_args)
-    print(result)
-
-    if "Error:" in result:
+    if result.startswith("Error:"):
+        print(result, file=sys.stderr)
         sys.exit(1)
+
+    print(result)
 
 
 if __name__ == "__main__":

--- a/tests/reporting/test_advisory_skip_verdict.py
+++ b/tests/reporting/test_advisory_skip_verdict.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Advisory Tier 3 skips stay visible without failing required validation."""
+
+from __future__ import annotations
+
+import json
+import re
+
+from skillevaluator.evaluation.tier3_report import advisory_skip_result
+from skillevaluator.models import ValidationResult
+from skillevaluator.reporting import BenchmarkReporter, HTMLReporter, JSONReporter, MarkdownReporter
+
+
+def _html_report_data(output: str) -> dict:
+    match = re.search(r'<script id="report-data" type="application/json">(.*?)</script>', output, re.DOTALL)
+    assert match is not None
+    return json.loads(match.group(1))
+
+
+def _html_tab(output: str, tab_id: str) -> str:
+    marker = f'id="tab-{tab_id}"'
+    start = output.index(marker)
+    next_tab = output.find('id="tab-', start + len(marker))
+    report_data = output.find('id="report-data"', start + len(marker))
+    candidates = [position for position in (next_tab, report_data) if position >= 0]
+    end = min(candidates) if candidates else len(output)
+    return output[start:end]
+
+
+def test_advisory_skip_is_non_blocking_in_json() -> None:
+    payload = json.loads(
+        JSONReporter(include_timestamp=False).render_all(
+            [advisory_skip_result("No public provider key", skill_name="demo")]
+        )
+    )
+
+    assert payload["overall_status"] == "passed"
+    assert payload["overall_passed"] is True
+    assert payload["total_advisory_skipped"] == 1
+    assert payload["results"][0]["passed"] is False
+    assert payload["results"][0]["status"] == "skipped"
+
+
+def test_advisory_skip_is_non_blocking_in_markdown() -> None:
+    output = MarkdownReporter(include_timestamp=False).render_all(
+        [advisory_skip_result("No public provider key", skill_name="demo")]
+    )
+
+    assert "**Status:** ✅ PASSED" in output
+    assert "| Validator Results | 1 |" in output
+    assert "| Validators Run |" not in output
+    assert "| ⏭️ Advisory skips | 1 |" in output
+    assert "### ⏭️ SKIPPED AGENT_EVAL" in output
+    assert "❌ FAILED" not in output
+
+
+def test_advisory_skip_is_non_blocking_in_html_and_benchmark() -> None:
+    result = advisory_skip_result("No public provider key", skill_name="demo")
+    html_data = _html_report_data(HTMLReporter(include_timestamp=False).render_all([result]))
+    benchmark = BenchmarkReporter(include_timestamp=False).render_all([result])
+
+    assert html_data["summary"]["status"] == "passed"
+    assert html_data["summary"]["all_passed"] is True
+    assert html_data["summary"]["passed_count"] == 0
+    assert html_data["summary"]["failed_count"] == 0
+    assert html_data["summary"]["advisory_skipped_count"] == 1
+    assert html_data["results"][0]["status"] == "skipped"
+    assert html_data["gating"]["would_block"] is False
+    html = HTMLReporter(include_timestamp=False).render_all([result])
+    assert re.search(r'tier-card-verdict">\s*SKIPPED\s*</span>', html)
+    assert "Live evaluation skipped:</strong> No public provider key" in html
+    assert not re.search(r'tier-card-verdict">\s*NEUTRAL\s*</span>', html)
+    assert "Overall verdict: PASS" in benchmark
+    assert "Overall verdict: FAIL" not in benchmark
+    assert "Tier 3 live evaluation: SKIPPED — No public provider key" in benchmark
+    assert "based on the completed required-tier results" in benchmark
+
+
+def test_advisory_skip_does_not_appear_as_tier1_failure_in_html() -> None:
+    schema = ValidationResult(validator_name="SCHEMA", validator_description="Schema validation")
+    skipped = advisory_skip_result("No public provider key", skill_name="demo")
+
+    output = HTMLReporter(include_timestamp=False).render_all([schema, skipped])
+    html_data = _html_report_data(output)
+    tier1 = _html_tab(output, "tier1")
+
+    assert html_data["summary"]["passed_count"] == 1
+    assert html_data["summary"]["failed_count"] == 0
+    assert html_data["summary"]["advisory_skipped_count"] == 1
+    assert re.search(r"Validators Run</h3>\s*<p[^>]*>1</p>", tier1)
+    assert re.search(r"Failed</h3>\s*<p[^>]*>0</p>", tier1)
+    assert "AGENT_EVAL" not in tier1
+
+
+def test_real_agent_eval_failure_still_fails_required_validation() -> None:
+    result = ValidationResult(validator_name="AGENT_EVAL")
+    result.add_error("Harbor execution failed")
+
+    payload = json.loads(JSONReporter(include_timestamp=False).render_all([result]))
+
+    assert payload["overall_status"] == "failed"
+    assert payload["overall_passed"] is False
+    assert payload["results"][0]["status"] == "failed"
+
+    html = HTMLReporter(include_timestamp=False).render_all([result])
+    tier3 = _html_tab(html, "tier3")
+    assert re.search(r'tier-card-verdict">\s*FAIL\s*</span>', html)
+    assert "Harbor execution failed" in tier3

--- a/tests/test_evaluation_service.py
+++ b/tests/test_evaluation_service.py
@@ -118,6 +118,82 @@ def test_combined_evaluate_keeps_exit_advisory_but_result_false_for_empty_engine
     assert "empty result" in result.metadata["agent_eval"]["execution_errors"][0]
 
 
+def test_combined_evaluate_converts_normalization_error_to_advisory_skip(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from skillevaluator import cli as cli_module
+    from skillevaluator.evaluation import tier3_report
+
+    monkeypatch.setattr(
+        EvaluationService,
+        "evaluate",
+        lambda _self, _options: {"execution_status": "succeeded", "execution_errors": []},
+        raising=True,
+    )
+
+    def _raise_normalizer(*_args, **_kwargs):
+        raise ValueError("corrupt Harbor artifact")
+
+    monkeypatch.setattr(tier3_report, "agent_eval_result_from_run", _raise_normalizer, raising=True)
+
+    result = cli_module._run_agent_eval_or_skip(
+        FIXTURE,
+        agents="codex",
+        env_mode="docker",
+        skip_baseline=True,
+        n_concurrent=1,
+        max_agents=1,
+    )
+
+    assert result.passed is False
+    payload = result.metadata["agent_eval"]
+    assert payload["execution_status"] == "skipped"
+    assert "Tier 3 result normalization failed: corrupt Harbor artifact" in payload["execution_errors"]
+
+
+def test_combined_evaluate_forwards_results_dir_to_normalizer(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from skillevaluator import cli as cli_module
+    from skillevaluator.evaluation import tier3_report
+    from skillevaluator.models.result import ValidationResult
+
+    engine_result = {"execution_status": "succeeded", "execution_errors": []}
+    expected = ValidationResult(validator_name="AGENT_EVAL")
+    expected.add_success("agent_eval", "ok")
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        EvaluationService,
+        "evaluate",
+        lambda _self, _options: engine_result,
+        raising=True,
+    )
+
+    def _normalize(_skill_path: Path, **kwargs) -> ValidationResult:
+        captured.update(kwargs)
+        return expected
+
+    monkeypatch.setattr(tier3_report, "agent_eval_result_from_run", _normalize, raising=True)
+    results_root = tmp_path / "external-results"
+
+    actual = cli_module._run_agent_eval_or_skip(
+        FIXTURE,
+        agents="codex",
+        env_mode="docker",
+        skip_baseline=True,
+        n_concurrent=1,
+        max_agents=1,
+        results_dir=results_root,
+    )
+
+    assert actual is expected
+    assert captured["results_dir"] == results_root
+    assert captured["engine_result"] is engine_result
+    assert captured["env_mode"] == "docker"
+
+
 def test_report_discovery_handles_timestamped_results(tmp_path: Path) -> None:
     results_root = tmp_path / "results"
     skill = tmp_path / "myskill"

--- a/tests/test_harbor_local_environment.py
+++ b/tests/test_harbor_local_environment.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+from pathlib import Path
+
+from skillevaluator.tier3.harbor.local_environment import SkillEvaluatorLocalEnvironment
+
+
+def test_local_environment_rewrites_read_only_uploaded_script_once(tmp_path: Path) -> None:
+    """A read-only template is made writable without rewriting its local path twice."""
+    source = tmp_path / "template_eval.py"
+    source.write_text('print("/tests/eval.py")\n', encoding="utf-8")
+    source.chmod(0o444)
+
+    local_tests = tmp_path / "trial" / "local-environment" / "tests"
+    uploaded = local_tests / "eval.py"
+    uploaded.parent.mkdir(parents=True)
+    shutil.copy2(source, uploaded)
+
+    should_restore_owner_write = not os.access(uploaded, os.W_OK)
+    environment = SkillEvaluatorLocalEnvironment.__new__(SkillEvaluatorLocalEnvironment)
+    environment._path_map = lambda: [("/tests", local_tests)]
+
+    environment._rewrite_uploaded_script(uploaded)
+
+    assert uploaded.read_text(encoding="utf-8") == f'print("{local_tests}{os.sep}eval.py")\n'
+    mode = uploaded.stat().st_mode
+    if should_restore_owner_write:
+        assert mode & stat.S_IWUSR
+    if os.name == "posix":
+        assert not mode & stat.S_IWGRP
+        assert not mode & stat.S_IWOTH
+
+
+def test_raw_path_rewrite_respects_container_root_boundaries(tmp_path: Path) -> None:
+    local_tests = tmp_path / "local" / "tests"
+    environment = SkillEvaluatorLocalEnvironment.__new__(SkillEvaluatorLocalEnvironment)
+    environment._path_map = lambda: [("/tests", local_tests)]
+
+    rewritten = environment._rewrite_raw_paths('"/tests/eval.py" "/tests" "/testsuite" "/tests-v2"')
+
+    assert rewritten == f'"{local_tests}{os.sep}eval.py" "{local_tests}" "/testsuite" "/tests-v2"'
+
+
+def test_raw_path_rewrite_ignores_url_and_local_path_suffixes(tmp_path: Path) -> None:
+    local_tests = tmp_path / "local" / "tests"
+    environment = SkillEvaluatorLocalEnvironment.__new__(SkillEvaluatorLocalEnvironment)
+    environment._path_map = lambda: [("/tests", local_tests)]
+    value = f'"/tests/api" "https://example.invalid/tests/api" "{local_tests}/api"'
+
+    rewritten = environment._rewrite_raw_paths(value)
+
+    assert rewritten == f'"{local_tests}{os.sep}api" "https://example.invalid/tests/api" "{local_tests}/api"'

--- a/tests/test_reference_skill_scripts.py
+++ b/tests/test_reference_skill_scripts.py
@@ -1,0 +1,147 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Behavior tests for bundled Tier 3 reference scripts."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import ClassVar
+
+import pytest
+
+REFERENCE_SKILLS = Path(__file__).parents[1] / "src/skillevaluator/tier3/reference_skills"
+SCRIPTS = {
+    "call_api": REFERENCE_SKILLS / "api-caller/scripts/call_api.py",
+    "parse_openapi": REFERENCE_SKILLS / "api-caller/scripts/parse_openapi.py",
+    "tasks": REFERENCE_SKILLS / "task-list/scripts/tasks.py",
+}
+
+
+class _SuccessfulResponse:
+    """Minimal context-managed response used by request-body tests."""
+
+    status = 200
+    headers: ClassVar[dict[str, str]] = {}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    @staticmethod
+    def read() -> bytes:
+        return b"{}"
+
+
+def _run_script(name: str, *args: str, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    process_env = os.environ.copy()
+    if env:
+        process_env.update(env)
+    return subprocess.run(
+        [sys.executable, str(SCRIPTS[name]), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=process_env,
+    )
+
+
+def _load_script(name: str) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(f"reference_script_{name}", SCRIPTS[name])
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_task_content_containing_error_label_remains_successful(tmp_path: Path) -> None:
+    result = _run_script(
+        "tasks",
+        "add",
+        "--content",
+        "Investigate Error: logs",
+        env={"TASK_LIST_STATE_PATH": str(tmp_path / "todo.md")},
+    )
+
+    assert result.returncode == 0
+    assert result.stdout == "Added [task_1]: Investigate Error: logs\n"
+    assert result.stderr == ""
+
+
+@pytest.mark.parametrize(
+    ("name", "args", "expected_error"),
+    [
+        ("call_api", ("--url", "https://example.invalid", "--headers", "not-json"), "Invalid input"),
+        ("call_api", (), "No URL provided"),
+        ("parse_openapi", (), "Usage:"),
+        ("tasks", ("add",), "Error: Content is required"),
+    ],
+)
+def test_handled_input_failures_write_only_to_stderr(
+    name: str, args: tuple[str, ...], expected_error: str, tmp_path: Path
+) -> None:
+    env = {"TASK_LIST_STATE_PATH": str(tmp_path / "todo.md")} if name == "tasks" else None
+
+    result = _run_script(name, *args, env=env)
+
+    assert result.returncode == 1
+    assert result.stdout == ""
+    assert expected_error in result.stderr
+    assert "Traceback" not in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("body", "encoded"),
+    [
+        ({}, b"{}"),
+        ([], b"[]"),
+        (0, b"0"),
+        (False, b"false"),
+        ("", b'""'),
+        (None, b"null"),
+    ],
+)
+def test_call_api_preserves_explicit_falsey_json_bodies(
+    body: object,
+    encoded: bytes,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_script("call_api")
+    requests: list[object] = []
+
+    def fake_urlopen(request: object, *, timeout: int):
+        assert timeout == 30
+        requests.append(request)
+        return _SuccessfulResponse()
+
+    monkeypatch.setattr(module, "urlopen", fake_urlopen)
+
+    result = module.make_request("https://example.invalid", method="POST", data=body)
+
+    assert result["success"] is True
+    assert len(requests) == 1
+    assert requests[0].data == encoded
+
+
+def test_call_api_omits_body_only_when_data_is_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_script("call_api")
+    requests: list[object] = []
+
+    def fake_urlopen(request: object, *, timeout: int):
+        requests.append(request)
+        return _SuccessfulResponse()
+
+    monkeypatch.setattr(module, "urlopen", fake_urlopen)
+
+    result = module.make_request("https://example.invalid")
+
+    assert result["success"] is True
+    assert len(requests) == 1
+    assert requests[0].data is None


### PR DESCRIPTION
## Summary

- keep Tier 3 normalization failures advisory, and honor an explicitly configured results directory
- make JSON, Markdown, HTML, and benchmark output agree on advisory Tier 3 skips while preserving real failures
- make local Harbor path rewriting single-pass and token-boundary aware
- harden bundled public reference scripts for falsey JSON bodies, malformed input, stderr discipline, and task text containing `Error:`
- add focused regression coverage for each behavior

## Scope

This change is limited to public SkillEvaluator functionality. It does not add plugin-specific coverage, NVIDIA-internal behavior, or Milvus-based inter-skill Tier 2 checks.

## Validation

- `214 passed` across the focused evaluation, reporting, Harbor local-mode, reference-script, and script-lint suites
- `ruff check .` passed
- `git diff --check` passed
- full suite: `1690 passed, 3 skipped`; the remaining 17 failures require host capabilities denied by the managed test environment (`sandbox-exec`, Unix socket creation, or writes under the user home directory)
