### PR TITLE
fix(tier2): exclude generated artifacts from path budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,9 @@ All notable changes to Skill Evaluator are documented in this file.
   filename patterns, `execution_performed=false`, and
   `coverage_measured=false`; projects must run tests and measure coverage in a
   trusted environment or explicit sandbox.
+
+### Fixed
+
+- Tier 2 content collection now prunes configured evaluation and version
+  artifact directories before enforcing the discovered-path limit, so excluded
+  generated results cannot cause false path-count failures.

--- a/src/skillevaluator/deduplication/utils/skill_collector.py
+++ b/src/skillevaluator/deduplication/utils/skill_collector.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import logging
 import os
 import stat
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from itertools import islice
 from pathlib import Path
@@ -437,8 +437,43 @@ def _collect_files_anchored(
     candidates: list[_CandidateFile] = []
     declared_total_bytes = 0
 
+    def _raise_traversal_error(error: OSError) -> None:
+        raise error
+
+    def _iter_paths(root: Path) -> Iterator[Path]:
+        # Prune the excluded dirs DURING traversal, not just when filtering
+        # the discovered list: generated artifacts (evals/results snapshots)
+        # must not consume the path budget, or a well-used skill fails the
+        # path-count limit on content it was never going to scan.
+        for dirpath, dirnames, filenames in os.walk(root, onerror=_raise_traversal_error):
+            base = Path(dirpath)
+            kept: list[str] = []
+            for name in dirnames:
+                directory = base / name
+                rel_path = directory.relative_to(root).as_posix()
+                if name in excluded:
+                    logger.debug("Skipping excluded path: %s", rel_path)
+                    continue
+                # ``os.walk(..., followlinks=False)`` does not follow normal
+                # symlinks, but Windows directory junctions are separate
+                # reparse points and may still be traversed. Reject every
+                # retained redirect before allowing the walk to recurse.
+                if _is_link_or_reparse(directory, rel_path):
+                    raise SkillCollectionError(
+                        "unsafe_path",
+                        f"Refusing symbolic link or reparse point: {rel_path}",
+                        rel_path=rel_path,
+                        suggestion="Replace the link with a regular directory stored inside the skill directory.",
+                    )
+                kept.append(name)
+            dirnames[:] = kept
+            for name in kept:
+                yield base / name
+            for name in filenames:
+                yield base / name
+
     try:
-        discovered_paths = list(islice(skill_root.rglob("*"), CONTENT_DEDUP_MAX_DISCOVERED_PATHS + 1))
+        discovered_paths = list(islice(_iter_paths(skill_root), CONTENT_DEDUP_MAX_DISCOVERED_PATHS + 1))
     except OSError as e:
         raise SkillCollectionError(
             "path_access_error",

--- a/tests/deduplication/utils/test_skill_collector.py
+++ b/tests/deduplication/utils/test_skill_collector.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import logging
 import os
 import stat
+import subprocess
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -271,10 +272,12 @@ class TestCollectFilesSafety:
         assert exc_info.value.metadata == {"actual": 3, "limit": 2}
 
     def test_directory_traversal_error_is_actionable(self, skill_root: Path, monkeypatch) -> None:
-        def deny_traversal(_path: Path, _pattern: str):
-            raise PermissionError("permission denied")
+        def deny_traversal(_root: Path, *, onerror=None, **_kwargs):
+            assert onerror is not None
+            onerror(PermissionError("permission denied"))
+            return iter(())
 
-        monkeypatch.setattr(Path, "rglob", deny_traversal)
+        monkeypatch.setattr(os, "walk", deny_traversal)
 
         with pytest.raises(SkillCollectionError) as exc_info:
             collect_files(skill_root)
@@ -298,6 +301,67 @@ class TestCollectFilesSafety:
         assert exc_info.value.rel_path == "references/outside.md"
         assert "symbolic link or reparse point" in str(exc_info.value)
         assert "replace" in exc_info.value.suggestion.lower()
+
+    def test_rejects_reparse_directory_before_descending(self, skill_root: Path) -> None:
+        target = skill_root / "reparse-directory"
+        target.mkdir()
+        (target / "private.md").write_text("private host content")
+        original_lstat = Path.lstat
+
+        def guarded_walk(root: Path, **_kwargs):
+            yield root, [target.name], []
+            raise AssertionError("walk descended into a reparse directory")
+
+        def fake_lstat(path: Path):
+            if path == target:
+                return SimpleNamespace(
+                    st_mode=stat.S_IFDIR,
+                    st_file_attributes=stat.FILE_ATTRIBUTE_REPARSE_POINT,
+                )
+            return original_lstat(path)
+
+        with (
+            patch.object(Path, "lstat", fake_lstat),
+            patch.object(os, "walk", guarded_walk),
+            pytest.raises(SkillCollectionError) as exc_info,
+        ):
+            collect_files(skill_root)
+
+        assert exc_info.value.check_name == "unsafe_path"
+        assert exc_info.value.rel_path == "reparse-directory"
+        assert "symbolic link or reparse point" in str(exc_info.value)
+
+    @pytest.mark.skipif(os.name != "nt", reason="directory junctions are Windows-specific")
+    def test_rejects_windows_junction_before_walking_target(
+        self, skill_root: Path, tmp_path: Path, monkeypatch
+    ) -> None:
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "private.md").write_text("private host content")
+        junction = skill_root / "junction"
+        subprocess.run(
+            ["cmd", "/c", "mklink", "/J", str(junction), str(outside)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        real_walk = os.walk
+        visited: list[Path] = []
+
+        def recording_walk(*args, **kwargs):
+            for entry in real_walk(*args, **kwargs):
+                visited.append(Path(entry[0]))
+                yield entry
+
+        monkeypatch.setattr(os, "walk", recording_walk)
+
+        with pytest.raises(SkillCollectionError) as exc_info:
+            collect_files(skill_root)
+
+        assert exc_info.value.check_name == "unsafe_path"
+        assert exc_info.value.rel_path == "junction"
+        assert "symbolic link or reparse point" in str(exc_info.value)
+        assert junction not in visited
 
     def test_rejects_windows_reparse_point_even_when_not_a_symlink(self, skill_root: Path) -> None:
         target = skill_root / "reparse.md"
@@ -587,3 +651,36 @@ class TestCollectFilesExclusions:
         result = collect_files(skill_root, excluded_dirs={"build_cache"})
         rel_paths = sorted(f.rel_path for f in result)
         assert rel_paths == ["SKILL.md"]
+
+
+class TestPathBudgetExcludesArtifacts:
+    def test_path_limit_ignores_generated_artifact_trees(self, tmp_path: Path, monkeypatch) -> None:
+        # Live regression: a well-used skill accumulates thousands of trial
+        # artifacts under evals/results/. They are excluded content and must
+        # not consume the path-count budget (managing-calendar failed Tier 2
+        # with "more than 4096 paths" on generated files it never scans).
+        monkeypatch.setattr(skill_collector, "CONTENT_DEDUP_MAX_DISCOVERED_PATHS", 8)
+        skill = tmp_path / "busy-skill"
+        skill.mkdir()
+        (skill / "SKILL.md").write_text("# Busy skill\n\nAuthored content.", encoding="utf-8")
+        trials = skill / "evals" / "results" / "20260101_000000" / "trials"
+        trials.mkdir(parents=True)
+        for index in range(10):
+            (trials / f"artifact-{index}.json").write_text("{}", encoding="utf-8")
+
+        result = collect_files(skill)
+
+        assert [f.rel_path for f in result] == ["SKILL.md"]
+
+    def test_path_limit_still_applies_to_authored_content(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setattr(skill_collector, "CONTENT_DEDUP_MAX_DISCOVERED_PATHS", 8)
+        skill = tmp_path / "huge-skill"
+        (skill / "docs").mkdir(parents=True)
+        for index in range(10):
+            (skill / "docs" / f"note-{index}.md").write_text("hi", encoding="utf-8")
+
+        with pytest.raises(SkillCollectionError) as exc_info:
+            collect_files(skill)
+
+        assert exc_info.value.check_name == "path_count_limit"
+        assert exc_info.value.metadata == {"actual": 9, "limit": 8}

--- a/tests/reporting/test_reporters.py
+++ b/tests/reporting/test_reporters.py
@@ -216,6 +216,25 @@ class TestCLIReporter:
 
         assert "[/red]" in plain_output
 
+    def test_failed_tier2_scan_is_reported_as_an_error_not_a_duplicate(self, tmp_path: Path, monkeypatch) -> None:
+        from skillevaluator.deduplication.intra_skill.intra_skill_validator import IntraSkillValidator
+        from skillevaluator.deduplication.utils import skill_collector
+
+        monkeypatch.setattr(skill_collector, "CONTENT_DEDUP_MAX_DISCOVERED_PATHS", 2)
+        skill = tmp_path / "over-budget"
+        skill.mkdir()
+        for name in ("SKILL.md", "a.bin", "b.bin"):
+            (skill / name).write_text("content", encoding="utf-8")
+
+        result = IntraSkillValidator().validate(skill)
+        assert result.findings[0].check_name == "path_count_limit"
+
+        output = re.sub(r"\x1b\[[0-9;]*m", "", CLIReporter().render_all([result]))
+
+        assert "Errors:" in output
+        assert "Skill tree contains more than 2 paths." in output
+        assert "duplicates found" not in output.lower()
+
     def test_render_escapes_markup_in_success_details(self) -> None:
         result = ValidationResult(
             validator_name="SIMILARITY",


### PR DESCRIPTION
## Summary

- Prune `CONTENT_DEDUP_EXCLUDED_DIRS` during traversal so generated evaluation results and version snapshots do not consume the 4,096-path Tier 2 discovery budget.
- Keep the path limit for authored content, preserve actionable traversal failures, and reject symbolic-link or Windows reparse-point directories before recursion.
- Use the current upstream `CLIReporter` architecture and pin that a real structured path-limit failure is reported as an error, never as a duplicate finding.

This implementation is a single new commit built directly on the current `NVIDIA/SkillEvaluator:main`; it does not carry the personal staging branch history or restore the removed `console_ui` module.

## Verification

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] Added or updated focused tests
- [x] Updated documentation for user-visible changes
- [x] Ran `make lint`
- [x] Ran `make test` — 1,963 passed, 4 skipped on macOS
- [x] Ran `make build`
- [x] Did not add credentials, private datasets, or proprietary benchmark content
- [x] Built wheel and sdist; `twine check --strict` passed for both
- [x] Reproduced against the original busy skill tree: 85,386 total paths, 10 retained after excluded-directory pruning, and 7 authored scannable files collected
- [x] Independent edge-case review completed; Windows junction traversal issue found during review was fixed and re-reviewed as ready

The real Windows junction regression test is included but is skipped on macOS; the repository cross-platform CI job provides the live Windows execution.

## Release Impact

- [ ] No user-visible release note needed
- [x] Updated `CHANGELOG.md`