### PR TITLE
chore: mark project as uv-managed for nSpect

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,9 @@ Repository = "https://github.com/NVIDIA/SkillEvaluator"
 # Single console script for the consolidated distribution.
 skillevaluator = "skillevaluator.cli:cli"
 
+[tool.uv]
+managed = true
+
 [tool.setuptools.packages.find]
 where = ["src"]
 include = ["skillevaluator*"]


### PR DESCRIPTION
## Summary

- add the explicit `[tool.uv] managed = true` marker required by the nSpect/Black Duck UV detector
- keep the dependency graph and `uv.lock` unchanged

## Context

nSpect currently reports no OSS packages for the GitHub `main` source even though the repository contains `pyproject.toml` and `uv.lock`. NVIDIA nSpect guidance requires the explicit UV-managed marker and a successful frozen dependency-tree command.

## Verification

- `uv lock --check`
- `uv tree --no-dedupe --frozen`
- `uv run --frozen --all-extras pytest -q` (`2897 passed, 7 skipped, 3 deselected`)
- `git diff --exit-code -- uv.lock`
- final diff review: only `pyproject.toml` changed