### PR TITLE
fix: upgrade langchain-core for CVE-2026-45134

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -10,4 +10,4 @@ records the exact resolved dependency set used for this release.
 | LLM | Anthropic (MIT), Boto3 (Apache-2.0), LiteLLM (MIT), OpenAI (Apache-2.0), Protobuf (BSD-3-Clause) |
 | Tier 3 | Harbor (Apache-2.0) |
 | Telemetry | OpenTelemetry API, SDK, and OTLP HTTP Exporter (Apache-2.0) |
-| Security | Bandit (Apache-2.0), pip-audit (Apache-2.0), Semgrep (LGPL-2.1), SkillSpector (Apache-2.0) |
+| Security | Bandit (Apache-2.0), LangChain Core (MIT), pip-audit (Apache-2.0), Semgrep (LGPL-2.1), SkillSpector (Apache-2.0) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,8 @@ telemetry = [
 # Static security scanners (floors raised to the established release baseline).
 security = [
     "bandit>=1.9.4",
+    # CVE-2026-45134 / BDSA-2026-10450 fixed floor.
+    "langchain-core>=1.4.9",
     "pip-audit>=2.10.0",
     "protobuf>=6.33.5",
     "semgrep>=1.162.0",

--- a/tests/test_oss_packaging.py
+++ b/tests/test_oss_packaging.py
@@ -444,3 +444,11 @@ def test_public_docs_show_external_nvidia_build_harness_paths_only() -> None:
     assert "direct OpenCode" in public_docs
     assert "Docker or local compatibility bridge" in public_docs
     assert "experimental Claude Code" in public_docs
+
+
+def test_security_extra_enforces_patched_langchain_core() -> None:
+    project = _project()
+    versions = {package["name"]: Version(package["version"]) for package in _lock()["package"]}
+
+    assert "langchain-core>=1.4.9" in project["project"]["optional-dependencies"]["security"]
+    assert versions["langchain-core"] >= Version("1.4.9")

--- a/uv.lock
+++ b/uv.lock
@@ -1232,7 +1232,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.4.8"
+version = "1.4.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
@@ -1245,9 +1245,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/12/e3/bea6d0080acf183332f24dcd74c208aee5857cf8f783c3fb0bd86027d8fb/langchain_core-1.4.8.tar.gz", hash = "sha256:5bf1f8411077c904182ad8f975943d36adcbf579c4e017b3a118b719229ebf9a", size = 957974, upload-time = "2026-06-18T19:39:23.636Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/b9/e937d0a90b26540bff07e7a7c64349f3b29c2dcc36257cd1cd3fdce17f2a/langchain_core-1.4.9.tar.gz", hash = "sha256:f8078901145bed0466755277500a5a22822a7b628808c4c0a28d4fc88895fcf2", size = 967294, upload-time = "2026-07-08T20:06:54.191Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/d6/bdf6f0481cc57ef300d6b1eb48cf1400c0409be715d6eb3cabadd1142a09/langchain_core-1.4.8-py3-none-any.whl", hash = "sha256:d84c28b05e3ba8d4271d0827aad5b592ccdaaf986e76768c23503f0a2045e8aa", size = 557416, upload-time = "2026-06-18T19:39:21.902Z" },
+    { url = "https://files.pythonhosted.org/packages/84/70/ade2fada52772798ef815b6352b59e71b116aa0c32c3aef5be3dc2cbed12/langchain_core-1.4.9-py3-none-any.whl", hash = "sha256:28e3909e2a10cc81504952d795ac0a9e014c0018121ef89d48dd396fa09ec624", size = 558293, upload-time = "2026-07-08T20:06:52.382Z" },
 ]
 
 [[package]]
@@ -2799,6 +2799,7 @@ all = [
     { name = "bandit" },
     { name = "boto3" },
     { name = "harbor" },
+    { name = "langchain-core" },
     { name = "litellm" },
     { name = "openai" },
     { name = "opentelemetry-api" },
@@ -2826,6 +2827,7 @@ llm = [
 ]
 security = [
     { name = "bandit" },
+    { name = "langchain-core" },
     { name = "pip-audit" },
     { name = "protobuf" },
     { name = "semgrep" },
@@ -2863,6 +2865,7 @@ requires-dist = [
     { name = "harbor", marker = "extra == 'tier3'", specifier = "==0.13.2" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27" },
     { name = "jinja2", specifier = ">=3.1" },
+    { name = "langchain-core", marker = "extra == 'security'", specifier = ">=1.4.9" },
     { name = "litellm", marker = "extra == 'llm'", specifier = ">=1.83.10,<1.89.0.dev0" },
     { name = "openai", marker = "extra == 'llm'", specifier = ">=2.21.0" },
     { name = "opentelemetry-api", marker = "extra == 'telemetry'", specifier = ">=1.37.0" },


### PR DESCRIPTION
## Summary
- enforce `langchain-core>=1.4.9` in the security extra for BDSA-2026-10450 / CVE-2026-45134
- refresh the lock without unrelated dependency upgrades
- add third-party attribution and a regression assertion for the advisory floor

## Verification
- `uv lock --check`
- `uv run --no-sync ruff check .`
- `uv run --no-sync pytest -q` (2897 passed, 7 skipped, 3 deselected)
- `uv run --no-sync pytest -q tests/test_oss_packaging.py` (29 passed after the regression assertion)
- `uv build --python 3.13 --no-sources`
- OSS boundary scan and `twine check --strict` on the wheel and sdist
- clean wheel installs for `[tier3,llm]` and `[all]`; `[all]` resolved and imported `langchain-core 1.4.9` and SkillSpector
- public provider doctor and Harbor progress-reporter smoke checks