### PR TITLE
docs: add third-party installation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ automatically provisions Python 3.13; if uv is not installed yet, follow its
 uv tool install --python 3.13 "skillevaluator[all] @ git+https://github.com/NVIDIA/SkillEvaluator.git"
 ```
 
+This project will download and install additional third-party open source software projects. Review the license terms of these open source projects before use.
+
 The `all` bundle includes the Tier 1 Python scanners, Tier 2, Tier 3 with
 Harbor, LLM clients, and telemetry. System-level tools remain explicit:
 Gitleaks is required for a complete Tier 1 security result, Docker is required

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -4,6 +4,8 @@ The quickest install is the one-liner from the
 [README quickstart](../README.md#quickstart) — everything on this page is for
 tailoring it: smaller installs, plain pip, and Docker.
 
+This project will download and install additional third-party open source software projects. Review the license terms of these open source projects before use.
+
 ## Requirements
 
 - [uv](https://docs.astral.sh/uv/getting-started/installation/) for the


### PR DESCRIPTION
## Summary

- Adds the exact OSRB-requested third-party installation disclosure to the README Quickstart.
- Mirrors the disclosure in the dedicated installation guide.
- Keeps the notice in the README used as the wheel long description so package consumers see it in release metadata.

## OSRB tracking

Requested in [NVBug 6282249 comment 19](https://nvbugspro.nvidia.com/bug/6282249/19).

## Validation

- `git diff --check`
- OSS boundary scan of the source tree
- `uv build --python 3.13 --no-sources`
- OSS boundary scan of the built wheel and source distribution
- `twine check --strict dist/*`
- Verified the exact disclosure appears in the built wheel `METADATA`
- Verified the exact disclosure appears in the source distribution README

This is a documentation-only change with no runtime or dependency changes.