### PR TITLE
ci: add coverage-backed SonarQube project configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          fetch-depth: 0
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ matrix.python-version }}
@@ -40,66 +38,9 @@ jobs:
           --cov=skillevaluator
           --cov-report=term-missing
           --cov-report=xml:coverage.xml
-      - name: Upload coverage for SonarQube
-        if: matrix.python-version == '3.12'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: sonarqube-coverage
-          path: coverage.xml
-          if-no-files-found: error
       - name: Run tests
         if: matrix.python-version != '3.12'
         run: uv run pytest -q
-
-  sonarqube:
-    name: SonarQube (NVIDIA network)
-    if: >-
-      github.event_name == 'pull_request' &&
-      github.head_ref == 'ci/christopherk/sonarqube-analysis'
-    needs: test
-    runs-on: [self-hosted, macOS, ARM64, sonar-internal]
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          fetch-depth: 0
-      - name: Verify internal runner toolchain
-        env:
-          RUNNER_TOOL_CACHE: ${{ runner.temp }}/toolcache
-        run: |
-          python3.12 --version
-          mkdir -p "$RUNNER_TOOL_CACHE"
-      - name: Download coverage report
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          name: sonarqube-coverage
-          path: .
-      - name: Normalize SonarQube credentials
-        env:
-          RAW_SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
-          RAW_SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: |
-          python3.12 - <<'PY'
-          import os
-          from pathlib import Path
-          from urllib.parse import urlparse
-
-          host_url = os.environ["RAW_SONAR_HOST_URL"].strip()
-          token = os.environ["RAW_SONAR_TOKEN"].strip()
-          if urlparse(host_url).scheme != "https" or not urlparse(host_url).hostname:
-              raise SystemExit("SONAR_HOST_URL must be a valid HTTPS URL")
-          if not token:
-              raise SystemExit("SONAR_TOKEN is empty")
-
-          with Path(os.environ["GITHUB_ENV"]).open("a", encoding="utf-8") as env_file:
-              env_file.write(f"SONAR_HOST_URL={host_url}\n")
-              env_file.write(f"SONAR_TOKEN={token}\n")
-          PY
-      - name: Analyze with SonarQube
-        env:
-          RUNNER_TOOL_CACHE: ${{ runner.temp }}/toolcache
-        uses: SonarSource/sonarqube-scan-action@7006c4492b2e0ee0f816d36501671557c97f5995 # v8.1.0
-        with:
-          skipSignatureVerification: true
 
   package:
     name: Package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ matrix.python-version }}
@@ -31,7 +33,27 @@ jobs:
         run: python scripts/check_oss_boundary.py --root . --allowlist config/oss_boundary_allowlist.json
       - if: matrix.python-version == '3.12'
         run: uv run ruff check .
-      - run: uv run pytest -q
+      - name: Run tests with coverage
+        if: matrix.python-version == '3.12'
+        run: >-
+          uv run pytest -q
+          --cov=skillevaluator
+          --cov-report=term-missing
+          --cov-report=xml:coverage.xml
+      - name: Run tests
+        if: matrix.python-version != '3.12'
+        run: uv run pytest -q
+      - name: Analyze with SonarQube
+        # Repository secrets are unavailable to forks; keep their test run green
+        # without exposing the Sonar token.
+        if: >-
+          matrix.python-version == '3.12' &&
+          (github.event_name == 'push' ||
+          github.event.pull_request.head.repo.full_name == github.repository)
+        uses: SonarSource/sonarqube-scan-action@7006c4492b2e0ee0f816d36501671557c97f5995 # v8.1.0
+        env:
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
   package:
     name: Package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,13 @@ jobs:
           --cov=skillevaluator
           --cov-report=term-missing
           --cov-report=xml:coverage.xml
+      - name: Upload coverage for SonarQube
+        if: matrix.python-version == '3.12'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: sonarqube-coverage
+          path: coverage.xml
+          if-no-files-found: error
       - name: Run tests
         if: matrix.python-version != '3.12'
         run: uv run pytest -q
@@ -49,6 +56,7 @@ jobs:
     if: >-
       github.event_name == 'pull_request' &&
       github.head_ref == 'ci/christopherk/sonarqube-analysis'
+    needs: test
     runs-on: [self-hosted, macOS, ARM64, sonar-internal]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -59,15 +67,12 @@ jobs:
           RUNNER_TOOL_CACHE: ${{ runner.temp }}/toolcache
         run: |
           python3.12 --version
-          uv --version
           mkdir -p "$RUNNER_TOOL_CACHE"
-      - run: uv sync --all-extras --locked --python 3.12
-      - name: Run tests with coverage
-        run: >-
-          uv run pytest -q
-          --cov=skillevaluator
-          --cov-report=term-missing
-          --cov-report=xml:coverage.xml
+      - name: Download coverage report
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: sonarqube-coverage
+          path: .
       - name: Normalize SonarQube credentials
         env:
           RAW_SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,13 +50,13 @@ jobs:
       github.event_name == 'pull_request' &&
       github.head_ref == 'ci/christopherk/sonarqube-analysis'
     runs-on: [self-hosted, macOS, ARM64, sonar-internal]
-    env:
-      RUNNER_TOOL_CACHE: ${{ runner.temp }}/toolcache
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - name: Verify internal runner toolchain
+        env:
+          RUNNER_TOOL_CACHE: ${{ runner.temp }}/toolcache
         run: |
           python3.12 --version
           uv --version
@@ -90,6 +90,8 @@ jobs:
               env_file.write(f"SONAR_TOKEN={token}\n")
           PY
       - name: Analyze with SonarQube
+        env:
+          RUNNER_TOOL_CACHE: ${{ runner.temp }}/toolcache
         uses: SonarSource/sonarqube-scan-action@7006c4492b2e0ee0f816d36501671557c97f5995 # v8.1.0
 
   package:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,17 +43,30 @@ jobs:
       - name: Run tests
         if: matrix.python-version != '3.12'
         run: uv run pytest -q
-      - name: Analyze with SonarQube
+      - name: Normalize SonarQube credentials
         # Repository secrets are unavailable to forks; keep their test run green
         # without exposing the Sonar token.
         if: >-
           matrix.python-version == '3.12' &&
           (github.event_name == 'push' ||
           github.event.pull_request.head.repo.full_name == github.repository)
-        uses: SonarSource/sonarqube-scan-action@7006c4492b2e0ee0f816d36501671557c97f5995 # v8.1.0
         env:
-          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          RAW_SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+          RAW_SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          {
+            printf 'SONAR_HOST_URL='
+            printf '%s' "$RAW_SONAR_HOST_URL" | tr -d '\r\n'
+            printf '\nSONAR_TOKEN='
+            printf '%s' "$RAW_SONAR_TOKEN" | tr -d '\r\n'
+            printf '\n'
+          } >> "$GITHUB_ENV"
+      - name: Analyze with SonarQube
+        if: >-
+          matrix.python-version == '3.12' &&
+          (github.event_name == 'push' ||
+          github.event.pull_request.head.repo.full_name == github.repository)
+        uses: SonarSource/sonarqube-scan-action@7006c4492b2e0ee0f816d36501671557c97f5995 # v8.1.0
 
   package:
     name: Package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,29 +43,52 @@ jobs:
       - name: Run tests
         if: matrix.python-version != '3.12'
         run: uv run pytest -q
+
+  sonarqube:
+    name: SonarQube (NVIDIA network)
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.head_ref == 'ci/christopherk/sonarqube-analysis'
+    runs-on: [self-hosted, macOS, ARM64, sonar-internal]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
+        with:
+          version: "0.11.27"
+      - run: uv sync --all-extras --locked --python 3.12
+      - name: Run tests with coverage
+        run: >-
+          uv run pytest -q
+          --cov=skillevaluator
+          --cov-report=term-missing
+          --cov-report=xml:coverage.xml
       - name: Normalize SonarQube credentials
-        # Repository secrets are unavailable to forks; keep their test run green
-        # without exposing the Sonar token.
-        if: >-
-          matrix.python-version == '3.12' &&
-          (github.event_name == 'push' ||
-          github.event.pull_request.head.repo.full_name == github.repository)
         env:
           RAW_SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
           RAW_SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
-          {
-            printf 'SONAR_HOST_URL='
-            printf '%s' "$RAW_SONAR_HOST_URL" | tr -d '\r\n'
-            printf '\nSONAR_TOKEN='
-            printf '%s' "$RAW_SONAR_TOKEN" | tr -d '\r\n'
-            printf '\n'
-          } >> "$GITHUB_ENV"
+          python - <<'PY'
+          import os
+          from pathlib import Path
+          from urllib.parse import urlparse
+
+          host_url = os.environ["RAW_SONAR_HOST_URL"].strip()
+          token = os.environ["RAW_SONAR_TOKEN"].strip()
+          if urlparse(host_url).scheme != "https" or not urlparse(host_url).hostname:
+              raise SystemExit("SONAR_HOST_URL must be a valid HTTPS URL")
+          if not token:
+              raise SystemExit("SONAR_TOKEN is empty")
+
+          with Path(os.environ["GITHUB_ENV"]).open("a", encoding="utf-8") as env_file:
+              env_file.write(f"SONAR_HOST_URL={host_url}\n")
+              env_file.write(f"SONAR_TOKEN={token}\n")
+          PY
       - name: Analyze with SonarQube
-        if: >-
-          matrix.python-version == '3.12' &&
-          (github.event_name == 'push' ||
-          github.event.pull_request.head.repo.full_name == github.repository)
         uses: SonarSource/sonarqube-scan-action@7006c4492b2e0ee0f816d36501671557c97f5995 # v8.1.0
 
   package:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,16 +50,17 @@ jobs:
       github.event_name == 'pull_request' &&
       github.head_ref == 'ci/christopherk/sonarqube-analysis'
     runs-on: [self-hosted, macOS, ARM64, sonar-internal]
+    env:
+      RUNNER_TOOL_CACHE: ${{ runner.temp }}/toolcache
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
-        with:
-          python-version: "3.12"
-      - uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
-        with:
-          version: "0.11.27"
+      - name: Verify internal runner toolchain
+        run: |
+          python3.12 --version
+          uv --version
+          mkdir -p "$RUNNER_TOOL_CACHE"
       - run: uv sync --all-extras --locked --python 3.12
       - name: Run tests with coverage
         run: >-
@@ -72,7 +73,7 @@ jobs:
           RAW_SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
           RAW_SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
-          python - <<'PY'
+          python3.12 - <<'PY'
           import os
           from pathlib import Path
           from urllib.parse import urlparse

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,8 @@ jobs:
         env:
           RUNNER_TOOL_CACHE: ${{ runner.temp }}/toolcache
         uses: SonarSource/sonarqube-scan-action@7006c4492b2e0ee0f816d36501671557c97f5995 # v8.1.0
+        with:
+          skipSignatureVerification: true
 
   package:
     name: Package

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+sonar.projectKey=NBUSW_Enterprise-AI-Automation_Skill-Evaluator_SkillEvaluator
+sonar.projectName=Skill Evaluator
+sonar.sourceEncoding=UTF-8
+
+sonar.sources=src,scripts
+sonar.tests=tests
+sonar.python.version=3.12,3.13
+sonar.python.coverage.reportPaths=coverage.xml
+sonar.qualitygate.wait=true

--- a/src/skillevaluator/model_commands.py
+++ b/src/skillevaluator/model_commands.py
@@ -74,5 +74,8 @@ def _safe_endpoint_origin(base_url: str | None) -> str:
 
 def _safe_terminal_text(value: str) -> str:
     return "".join(
-        character if unicodedata.category(character) not in {"Cc", "Cf", "Cs"} else "�" for character in value
+        character
+        if unicodedata.category(character) not in {"Cc", "Cf", "Cs"}
+        else "\N{REPLACEMENT CHARACTER}"
+        for character in value
     )


### PR DESCRIPTION
## Summary

- add the NVIDIA SonarQube project configuration for Skill Evaluator
- generate XML coverage on the Python 3.12 CI test leg
- keep the terminal replacement character ASCII-safe so Sonar can analyze the source without an encoding warning

## Validation

- real SonarQube analysis completed from an ephemeral NVIDIA-network runner: [CI run 29431189508](https://github.com/NVIDIA/SkillEvaluator/actions/runs/29431189508)
- Sonar quality gate: **PASSED**
- Sonar PR metrics: 70.9% coverage; 0 bugs, vulnerabilities, code smells, and security hotspots
- `uv run pytest -q --cov=skillevaluator --cov-report=term-missing --cov-report=xml:coverage.xml`: 2,898 passed, 7 skipped, 3 deselected; 78.35% pytest line coverage
- `uv run ruff check .`
- `uv run python scripts/check_oss_boundary.py --root . --allowlist config/oss_boundary_allowlist.json`
- workflow YAML parsed successfully and `git diff --check` passed

## Operational note

`sonar.nvidia.com` is not reachable from GitHub-hosted runners. The real validation scan used a temporary ephemeral self-hosted runner on the NVIDIA network; no temporary runner job or signature-verification bypass remains in this PR. Recurring automated scans will require an approved persistent internal runner, Jenkins job, or equivalent NVIDIA-network execution path.

## PLC

- nSpect: `NSPECT-CWUR-RD2T`
- Sonar project: `NBUSW_Enterprise-AI-Automation_Skill-Evaluator_SkillEvaluator`
- Sonar provisioning request: `SCTASK01791823`
