### PR TITLE
Fix bridge readiness worker race

### DIFF
--- a/src/skillevaluator/tier3/harbor/nvidia_build_bridge.py
+++ b/src/skillevaluator/tier3/harbor/nvidia_build_bridge.py
@@ -790,6 +790,9 @@ def start_in_process_bridge(
     while True:
         try:
             _check_bridge_health(origin, readiness_token)
+            remaining_startup_time = max(0.0, deadline - time.monotonic())
+            if not server.wait_for_workers(remaining_startup_time):
+                raise RuntimeError("NVIDIA Build bridge readiness request did not drain")
             return handle
         except RuntimeError:
             if not thread.is_alive() or time.monotonic() >= deadline:

--- a/tests/test_harbor_local_mode.py
+++ b/tests/test_harbor_local_mode.py
@@ -378,6 +378,46 @@ def test_local_nvidia_build_bridge_cleanup_preserves_cancellation(
     assert close_finished.is_set()
 
 
+def test_start_in_process_bridge_waits_for_readiness_worker_to_finish(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from skillevaluator.tier3.harbor import nvidia_build_bridge
+
+    release_started = threading.Event()
+    release_allowed = threading.Event()
+    release_lock = threading.Lock()
+    original_release_request = nvidia_build_bridge._BridgeHTTPServer.release_request
+    first_release = True
+
+    def delayed_first_release(server: object, request: object) -> None:
+        nonlocal first_release
+        with release_lock:
+            delay_release = first_release
+            first_release = False
+        if delay_release:
+            release_started.set()
+            release_timer = threading.Timer(1.0, release_allowed.set)
+            release_timer.daemon = True
+            release_timer.start()
+            assert release_allowed.wait(timeout=2)
+        original_release_request(server, request)
+
+    monkeypatch.setattr(nvidia_build_bridge._BridgeHTTPServer, "release_request", delayed_first_release)
+
+    running = nvidia_build_bridge.start_in_process_bridge(
+        api_key="test-readiness-worker-key",
+        build_base_url="http://127.0.0.1:8080/v1",
+        log_path=tmp_path / "nvidia-build-bridge.log",
+        request_transport=lambda _endpoint, _body: b"{}",
+    )
+    try:
+        assert release_started.wait(timeout=1)
+        assert running._server.active_workers == 0
+    finally:
+        release_allowed.set()
+        running.close()
+
+
 def test_local_nvidia_build_bridge_repeated_cancellation_releases_slow_header_state(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary
- wait for the authenticated bridge readiness worker to drain before startup returns
- add a deterministic regression test for the worker-accounting race
- prevent the slow-header cancellation test from intermittently observing both readiness and request workers

## Root cause
The post-merge macOS Tier 3 job could begin the slow-header request while the startup health-check worker was still completing its final bookkeeping. The test then observed two active workers instead of one. This is the same intermittent failure previously seen on the PR branch.

Failed main run: https://github.com/NVIDIA/SkillEvaluator/actions/runs/29454116242

## Verification
- deterministic regression test: passed
- original failing test: 20/20 consecutive passes
- macOS Tier 3 contract suite: 384 passed, 5 skipped, 1 deselected
- complete suite: 2902 passed, 7 skipped, 3 deselected
- Ruff: passed
- git diff --check: passed