### PR TITLE
fix(tier3): return structured dataset generation outcomes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,9 @@ All notable changes to Skill Evaluator are documented in this file.
 - Accepted structurally complete SkillSpector finding reports on policy exit 1
   and hardened validation of the external scanner's untrusted JSON contract;
   SkillSpector remains separately installed and unpinned by this distribution.
+- Programmatic dataset generation now returns explicit created, preview, and
+  unchanged outcomes, preserves actionable failures, and no longer mutates
+  process-wide command-line arguments.
 - Security and full-feature installs now work on RHEL 8 and other glibc 2.28
   Linux systems by selecting a compatible Semgrep and pip-audit pair, while
   macOS and Windows retain the newer scanner release lines.

--- a/src/skillevaluator/cli.py
+++ b/src/skillevaluator/cli.py
@@ -1822,21 +1822,24 @@ def create_dataset(
     results_dir: Path | None,
 ) -> None:
     """Create synthetic eval datasets for agent skill evaluation."""
-    from skillevaluator.evaluation import DatasetOptions, EvaluationService
+    from skillevaluator.evaluation import DatasetGenerationError, DatasetOptions, EvaluationService
 
-    EvaluationService().create_dataset(
-        DatasetOptions(
-            skill_path=skill_path,
-            full=full,
-            no_llm=no_llm,
-            dry_run=dry_run,
-            force=force,
-            prompt=prompt,
-            refine=refine,
-            from_results=from_results,
-            results_dir=results_dir,
+    try:
+        EvaluationService().create_dataset(
+            DatasetOptions(
+                skill_path=skill_path,
+                full=full,
+                no_llm=no_llm,
+                dry_run=dry_run,
+                force=force,
+                prompt=prompt,
+                refine=refine,
+                from_results=from_results,
+                results_dir=results_dir,
+            )
         )
-    )
+    except DatasetGenerationError as exc:
+        raise click.ClickException(str(exc)) from exc
 
 
 @cli.command("init-custom-grader")

--- a/src/skillevaluator/evaluation/__init__.py
+++ b/src/skillevaluator/evaluation/__init__.py
@@ -16,9 +16,12 @@ from skillevaluator.evaluation.dimension_judge import (
 )
 from skillevaluator.evaluation.insights_judge import InsightsJudge, build_insights
 from skillevaluator.evaluation.options import DatasetOptions, EvaluationOptions
+from skillevaluator.evaluation.results import DatasetGenerationError, DatasetGenerationResult
 from skillevaluator.evaluation.service import EvaluationService
 
 __all__ = [
+    "DatasetGenerationError",
+    "DatasetGenerationResult",
     "DatasetOptions",
     "DimensionJudge",
     "EvaluationOptions",

--- a/src/skillevaluator/evaluation/results.py
+++ b/src/skillevaluator/evaluation/results.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Public result and error types for dataset generation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+
+class DatasetGenerationError(RuntimeError):
+    """Expected dataset-generation failure safe for API callers to handle."""
+
+
+@dataclass(frozen=True)
+class DatasetGenerationResult:
+    """Structured outcome shared by CLI and programmatic dataset generation."""
+
+    status: Literal["created", "preview", "unchanged"]
+    path: Path
+    dataset: dict[str, Any] | None = None
+    cases_count: int = 0
+
+
+__all__ = ["DatasetGenerationError", "DatasetGenerationResult"]

--- a/src/skillevaluator/evaluation/service.py
+++ b/src/skillevaluator/evaluation/service.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from skillevaluator.evaluation.options import DatasetOptions, EvaluationOptions
+    from skillevaluator.tier3.generate_dataset import DatasetGenerationResult
     from skillevaluator.tier3.harbor.progress import ProgressReporter
 
 
@@ -66,11 +67,11 @@ class EvaluationService:
             return f"Tier 3 evaluation execution status is {label}"
         return None
 
-    def create_dataset(self, options: DatasetOptions) -> None:
-        """Create a synthetic evaluation dataset for a skill."""
+    def create_dataset(self, options: DatasetOptions) -> DatasetGenerationResult:
+        """Create or preview a synthetic dataset and return its outcome."""
         from skillevaluator.tier3.commands import create_dataset as _create_dataset
 
-        _create_dataset(options.skill_path, **options.engine_kwargs())
+        return _create_dataset(options.skill_path, **options.engine_kwargs())
 
     def create_autopilot_dataset(self, skill_path: Path, *, use_llm: bool) -> Path:
         """Create one missing eval case for the CLI autopilot workflow."""

--- a/src/skillevaluator/evaluation/service.py
+++ b/src/skillevaluator/evaluation/service.py
@@ -15,9 +15,12 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+# These lightweight imports intentionally remain available at runtime so API
+# frameworks and callers can resolve the public method annotations.
+from skillevaluator.evaluation.options import DatasetOptions, EvaluationOptions  # noqa: TC001
+from skillevaluator.evaluation.results import DatasetGenerationResult  # noqa: TC001
+
 if TYPE_CHECKING:
-    from skillevaluator.evaluation.options import DatasetOptions, EvaluationOptions
-    from skillevaluator.tier3.generate_dataset import DatasetGenerationResult
     from skillevaluator.tier3.harbor.progress import ProgressReporter
 
 

--- a/src/skillevaluator/tier3/commands.py
+++ b/src/skillevaluator/tier3/commands.py
@@ -13,7 +13,7 @@ import tempfile
 import tomllib
 import webbrowser
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import yaml
 from rich.box import SIMPLE
@@ -23,6 +23,7 @@ from rich.table import Table
 from rich.text import Text
 
 from skillevaluator import __version__
+from skillevaluator.evaluation.results import DatasetGenerationError, DatasetGenerationResult
 from skillevaluator.evaluation.tier3_report import render_agent_eval_html_report
 from skillevaluator.provider_config import ProviderConfigurationError, resolve_llm_provider
 from skillevaluator.tier3.case_ids import safe_child, validate_case_id, validate_case_ids
@@ -53,9 +54,6 @@ from skillevaluator.tier3.results_location import (
     resolve_results_root,
 )
 from skillevaluator.tier3.toml_utils import toml_quote
-
-if TYPE_CHECKING:
-    from skillevaluator.tier3.generate_dataset import DatasetGenerationResult
 
 console = Console()
 
@@ -403,8 +401,8 @@ def create_dataset(
     except SystemExit as exc:
         diagnostic = getattr(exc, "diagnostic", None)
         if isinstance(diagnostic, str) and diagnostic.strip():
-            raise ValueError(diagnostic) from exc
-        raise ValueError(f"Dataset generation failed with exit code {exc.code}") from exc
+            raise DatasetGenerationError(diagnostic) from exc
+        raise DatasetGenerationError(f"Dataset generation failed with exit code {exc.code}") from exc
 
 
 def init_custom_grader(

--- a/src/skillevaluator/tier3/commands.py
+++ b/src/skillevaluator/tier3/commands.py
@@ -9,12 +9,11 @@ import json
 import os
 import shutil
 import subprocess
-import sys
 import tempfile
 import tomllib
 import webbrowser
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import yaml
 from rich.box import SIMPLE
@@ -54,6 +53,9 @@ from skillevaluator.tier3.results_location import (
     resolve_results_root,
 )
 from skillevaluator.tier3.toml_utils import toml_quote
+
+if TYPE_CHECKING:
+    from skillevaluator.tier3.generate_dataset import DatasetGenerationResult
 
 console = Console()
 
@@ -374,7 +376,7 @@ def create_dataset(
     refine: bool = False,
     from_results: Path | None = None,
     results_dir: Path | None = None,
-) -> None:
+) -> DatasetGenerationResult:
     """Generate a synthetic evaluation dataset using the migrated generator."""
     from skillevaluator.tier3 import generate_dataset
 
@@ -396,12 +398,13 @@ def create_dataset(
     if results_dir:
         argv.extend(["--results-dir", str(results_dir.expanduser().resolve())])
 
-    original = sys.argv[:]
     try:
-        sys.argv = ["skillevaluator create-eval-dataset", *argv]
-        generate_dataset.main()
-    finally:
-        sys.argv = original
+        return generate_dataset.main(argv)
+    except SystemExit as exc:
+        diagnostic = getattr(exc, "diagnostic", None)
+        if isinstance(diagnostic, str) and diagnostic.strip():
+            raise ValueError(diagnostic) from exc
+        raise ValueError(f"Dataset generation failed with exit code {exc.code}") from exc
 
 
 def init_custom_grader(

--- a/src/skillevaluator/tier3/generate_dataset.py
+++ b/src/skillevaluator/tier3/generate_dataset.py
@@ -45,8 +45,10 @@ import json
 import os
 import re
 import sys
+from collections.abc import Sequence
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 _INTERACTIVE_RE = re.compile(
     r"interactive|opens?\s+a?\s*browser|waits?\s+for\s+(the\s+)?user|device.code\s+flow",
@@ -852,7 +854,31 @@ def _refine_from_trajectory_template(
     return refined
 
 
-def main():
+@dataclass(frozen=True)
+class DatasetGenerationResult:
+    """Structured outcome shared by CLI and programmatic dataset generation."""
+
+    status: Literal["created", "preview", "unchanged"]
+    path: Path
+    dataset: dict[str, Any] | None = None
+    cases_count: int = 0
+
+
+class DatasetGenerationExit(SystemExit):
+    """CLI-compatible exit that preserves an actionable failure diagnostic."""
+
+    def __init__(self, diagnostic: str, code: int = 1) -> None:
+        super().__init__(code)
+        self.diagnostic = diagnostic
+
+
+def _abort(message: str) -> None:
+    """Print the established CLI error and retain it for in-process callers."""
+    print(f"Error: {message}")
+    raise DatasetGenerationExit(message)
+
+
+def main(argv: Sequence[str] | None = None) -> DatasetGenerationResult:
     parser = argparse.ArgumentParser(
         description="Generate eval dataset for a skill.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -908,19 +934,16 @@ Agent-refined mode (--refine):
         help="With --refine: external results root to search before the legacy skill directory",
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
     skill_path = args.path.resolve()
 
     if not (skill_path / "SKILL.md").exists():
-        print(f"Error: {skill_path} does not contain a SKILL.md")
-        sys.exit(1)
+        _abort(f"{skill_path} does not contain a SKILL.md")
 
     if args.from_results and not args.refine:
-        print("Error: --from-results requires --refine")
-        sys.exit(1)
+        _abort("--from-results requires --refine")
     if args.results_dir and not args.refine:
-        print("Error: --results-dir requires --refine")
-        sys.exit(1)
+        _abort("--results-dir requires --refine")
 
     evals_dir = skill_path / "evals"
     output_path = evals_dir / "evals.json"
@@ -929,7 +952,7 @@ Agent-refined mode (--refine):
     if output_path.exists() and not args.force and not args.refine:
         print(f"Dataset already exists: {output_path}")
         print("Use --force to overwrite.")
-        return
+        return DatasetGenerationResult(status="unchanged", path=output_path)
 
     # Parse skill
     skill = _parse_skill(skill_path, prompt_file=args.prompt)
@@ -988,15 +1011,22 @@ Agent-refined mode (--refine):
         else:
             print("  No trajectory available — using initial cases as-is.")
 
+    dataset = _to_agentskills_dataset(skill["name"], cases)
+
     if args.dry_run:
         print("\nDry run — not saved.")
-        print(json.dumps(_to_agentskills_dataset(skill["name"], cases), indent=2))
-        return
+        print(json.dumps(dataset, indent=2))
+        return DatasetGenerationResult(
+            status="preview",
+            path=output_path,
+            dataset=dataset,
+            cases_count=len(cases),
+        )
 
     # Save
     evals_dir.mkdir(parents=True, exist_ok=True)
     with output_path.open("w", encoding="utf-8") as f:
-        json.dump(_to_agentskills_dataset(skill["name"], cases), f, indent=2, ensure_ascii=False)
+        json.dump(dataset, f, indent=2, ensure_ascii=False)
 
     print(f"\nSaved: {output_path}")
     print(f"  {len(cases)} test case(s)")
@@ -1005,6 +1035,12 @@ Agent-refined mode (--refine):
     else:
         print(f"\nNext: skillevaluator evaluate {skill_path} --agents claude-code --env-mode docker")
         print(f"  Or refine with trajectory: skillevaluator create-eval-dataset {skill_path} --refine --force")
+    return DatasetGenerationResult(
+        status="created",
+        path=output_path,
+        dataset=dataset,
+        cases_count=len(cases),
+    )
 
 
 if __name__ == "__main__":

--- a/src/skillevaluator/tier3/generate_dataset.py
+++ b/src/skillevaluator/tier3/generate_dataset.py
@@ -44,11 +44,14 @@ import asyncio
 import json
 import os
 import re
+import secrets
+import stat
 import sys
 from collections.abc import Sequence
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any
+
+from skillevaluator.evaluation.results import DatasetGenerationError, DatasetGenerationResult
 
 _INTERACTIVE_RE = re.compile(
     r"interactive|opens?\s+a?\s*browser|waits?\s+for\s+(the\s+)?user|device.code\s+flow",
@@ -854,28 +857,30 @@ def _refine_from_trajectory_template(
     return refined
 
 
-@dataclass(frozen=True)
-class DatasetGenerationResult:
-    """Structured outcome shared by CLI and programmatic dataset generation."""
-
-    status: Literal["created", "preview", "unchanged"]
-    path: Path
-    dataset: dict[str, Any] | None = None
-    cases_count: int = 0
-
-
-class DatasetGenerationExit(SystemExit):
-    """CLI-compatible exit that preserves an actionable failure diagnostic."""
-
-    def __init__(self, diagnostic: str, code: int = 1) -> None:
-        super().__init__(code)
-        self.diagnostic = diagnostic
-
-
 def _abort(message: str) -> None:
-    """Print the established CLI error and retain it for in-process callers."""
-    print(f"Error: {message}")
-    raise DatasetGenerationExit(message)
+    """Raise an actionable error shared by CLI and in-process callers."""
+    raise DatasetGenerationError(message)
+
+
+def _write_dataset(output_path: Path, dataset: dict[str, Any]) -> None:
+    """Atomically replace a dataset without corrupting an existing file."""
+    temporary_path: Path | None = None
+    try:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        existing_mode = stat.S_IMODE(output_path.stat().st_mode) if output_path.exists() else None
+        temporary_path = output_path.with_name(f".{output_path.name}.{secrets.token_hex(16)}.tmp")
+        with temporary_path.open("x", encoding="utf-8") as temporary:
+            json.dump(dataset, temporary, indent=2, ensure_ascii=False)
+            temporary.flush()
+            os.fsync(temporary.fileno())
+        if existing_mode is not None:
+            temporary_path.chmod(existing_mode)
+        temporary_path.replace(output_path)
+    except Exception as exc:
+        raise DatasetGenerationError(f"Could not write dataset {output_path}: {exc}") from exc
+    finally:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
 
 
 def main(argv: Sequence[str] | None = None) -> DatasetGenerationResult:
@@ -1024,9 +1029,7 @@ Agent-refined mode (--refine):
         )
 
     # Save
-    evals_dir.mkdir(parents=True, exist_ok=True)
-    with output_path.open("w", encoding="utf-8") as f:
-        json.dump(dataset, f, indent=2, ensure_ascii=False)
+    _write_dataset(output_path, dataset)
 
     print(f"\nSaved: {output_path}")
     print(f"  {len(cases)} test case(s)")
@@ -1044,4 +1047,8 @@ Agent-refined mode (--refine):
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except DatasetGenerationError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc

--- a/tests/test_evaluation_service.py
+++ b/tests/test_evaluation_service.py
@@ -16,9 +16,17 @@ import pytest
 from click.testing import CliRunner
 
 from skillevaluator.cli import cli
-from skillevaluator.evaluation import EvaluationOptions, EvaluationService
+from skillevaluator.evaluation import DatasetOptions, EvaluationOptions, EvaluationService
 
 FIXTURE = Path(__file__).parent / "fixtures" / "skills" / "simple"
+
+
+def test_service_preserves_dataset_generation_failure_diagnostic(tmp_path: Path) -> None:
+    invalid_skill = tmp_path / "not-a-skill"
+    invalid_skill.mkdir()
+
+    with pytest.raises(ValueError, match=rf"{invalid_skill} does not contain a SKILL\.md"):
+        EvaluationService().create_dataset(DatasetOptions(skill_path=invalid_skill, no_llm=True))
 
 
 def test_options_fields_match_engine_signature() -> None:

--- a/tests/test_evaluation_service.py
+++ b/tests/test_evaluation_service.py
@@ -11,6 +11,7 @@ import json
 import shutil
 from pathlib import Path
 from types import SimpleNamespace
+from typing import get_type_hints
 
 import pytest
 from click.testing import CliRunner
@@ -21,12 +22,64 @@ from skillevaluator.evaluation import DatasetOptions, EvaluationOptions, Evaluat
 FIXTURE = Path(__file__).parent / "fixtures" / "skills" / "simple"
 
 
-def test_service_preserves_dataset_generation_failure_diagnostic(tmp_path: Path) -> None:
+def test_dataset_result_and_error_are_public_runtime_types() -> None:
+    from skillevaluator import evaluation
+
+    assert evaluation.DatasetGenerationResult.__module__ == "skillevaluator.evaluation.results"
+    assert evaluation.DatasetGenerationError.__module__ == "skillevaluator.evaluation.results"
+    assert get_type_hints(EvaluationService.create_dataset)["return"] is evaluation.DatasetGenerationResult
+
+
+def test_service_preserves_dataset_generation_failure_without_printing(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from skillevaluator import evaluation
+
     invalid_skill = tmp_path / "not-a-skill"
     invalid_skill.mkdir()
 
-    with pytest.raises(ValueError, match=rf"{invalid_skill} does not contain a SKILL\.md"):
+    with pytest.raises(evaluation.DatasetGenerationError, match=rf"{invalid_skill} does not contain a SKILL\.md"):
         EvaluationService().create_dataset(DatasetOptions(skill_path=invalid_skill, no_llm=True))
+    assert capsys.readouterr() == ("", "")
+
+
+@pytest.mark.parametrize("command", [("create-eval-dataset",), ("tier3", "create-eval-dataset")])
+def test_cli_formats_dataset_generation_failure_without_raw_exception(
+    tmp_path: Path,
+    command: tuple[str, ...],
+) -> None:
+    invalid_skill = tmp_path / "not-a-skill"
+    invalid_skill.mkdir()
+
+    result = CliRunner().invoke(cli, [*command, str(invalid_skill), "--no-llm"])
+
+    assert result.exit_code == 1
+    assert not isinstance(result.exception, ValueError)
+    assert result.output == f"Error: {invalid_skill} does not contain a SKILL.md\n"
+
+
+@pytest.mark.parametrize("dependent_option", ["--from-results", "--results-dir"])
+def test_cli_formats_dataset_option_dependency_failure(
+    tmp_path: Path,
+    dependent_option: str,
+) -> None:
+    skill = tmp_path / "my-skill"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text(
+        "---\nname: my-skill\ndescription: Does useful work\n---\n",
+        encoding="utf-8",
+    )
+    results = tmp_path / "results"
+    results.mkdir()
+
+    result = CliRunner().invoke(
+        cli,
+        ["create-eval-dataset", str(skill), "--no-llm", dependent_option, str(results)],
+    )
+
+    assert result.exit_code == 1
+    assert result.output == f"Error: {dependent_option} requires --refine\n"
 
 
 def test_options_fields_match_engine_signature() -> None:
@@ -37,6 +90,14 @@ def test_options_fields_match_engine_signature() -> None:
 
     sig_params = set(inspect.signature(engine_evaluate).parameters) - {"skill_path", "progress_reporter"}
     option_fields = set(EvaluationOptions.__dataclass_fields__) - {"skill_path"}
+    assert option_fields == sig_params
+
+
+def test_dataset_options_fields_match_engine_signature() -> None:
+    from skillevaluator.tier3.commands import create_dataset as engine_create_dataset
+
+    sig_params = set(inspect.signature(engine_create_dataset).parameters) - {"skill_path"}
+    option_fields = set(DatasetOptions.__dataclass_fields__) - {"skill_path"}
     assert option_fields == sig_params
 
 

--- a/tests/tier3/test_generate_dataset_results.py
+++ b/tests/tier3/test_generate_dataset_results.py
@@ -3,7 +3,9 @@
 
 import json
 import shutil
+import stat
 import sys
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
@@ -19,15 +21,7 @@ def test_discover_trajectories_uses_env_results_root(tmp_path, monkeypatch):
     skill = tmp_path / "my-skill"
     skill.mkdir()
     results_root = tmp_path / "external-results"
-    trial = (
-        results_root
-        / "my-skill"
-        / "latest"
-        / "claude-code"
-        / "with-skill"
-        / "trials"
-        / "case-001"
-    )
+    trial = results_root / "my-skill" / "latest" / "claude-code" / "with-skill" / "trials" / "case-001"
     trial.mkdir(parents=True)
     trajectory = {"steps": [{"type": "assistant", "content": "done"}]}
     trial.joinpath("trajectory.json").write_text(json.dumps(trajectory), encoding="utf-8")
@@ -42,15 +36,7 @@ def test_discover_trajectories_results_dir_overrides_env(tmp_path, monkeypatch):
     skill.mkdir()
     env_root = tmp_path / "env-results"
     cli_root = tmp_path / "cli-results"
-    trial = (
-        cli_root
-        / "my-skill"
-        / "latest"
-        / "claude-code"
-        / "with-skill"
-        / "trials"
-        / "case-001"
-    )
+    trial = cli_root / "my-skill" / "latest" / "claude-code" / "with-skill" / "trials" / "case-001"
     trial.mkdir(parents=True)
     trajectory = {"steps": [{"type": "assistant", "content": "done"}]}
     trial.joinpath("trajectory.json").write_text(json.dumps(trajectory), encoding="utf-8")
@@ -105,12 +91,74 @@ def test_dry_run_refine_does_not_write_dataset_when_no_trajectory(tmp_path, monk
     assert result.dataset is not None
 
 
-def test_main_invalid_skill_preserves_cli_diagnostic(tmp_path, capsys):
-    with pytest.raises(generate_dataset.DatasetGenerationExit) as exc_info:
+def test_main_invalid_skill_raises_domain_error_without_printing(tmp_path, capsys):
+    from skillevaluator.evaluation import DatasetGenerationError
+
+    with pytest.raises(DatasetGenerationError, match=rf"{tmp_path} does not contain a SKILL\.md"):
         generate_dataset.main([str(tmp_path)])
 
-    assert exc_info.value.code == 1
-    assert capsys.readouterr().out == f"Error: {tmp_path} does not contain a SKILL.md\n"
+    assert capsys.readouterr() == ("", "")
+
+
+@pytest.mark.parametrize(("extra_args", "expected_cases"), [([], 1), (["--full"], 4)])
+def test_main_reports_created_dataset_with_written_payload(tmp_path, extra_args, expected_cases):
+    skill = tmp_path / "my-skill"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text(
+        "---\nname: my-skill\ndescription: Does useful work\n---\n",
+        encoding="utf-8",
+    )
+
+    result = generate_dataset.main([str(skill), "--no-llm", *extra_args])
+
+    assert result.status == "created"
+    assert result.path == skill / "evals" / "evals.json"
+    assert result.cases_count == expected_cases
+    assert result.dataset == json.loads(result.path.read_text(encoding="utf-8"))
+
+
+def test_force_write_failure_preserves_existing_dataset(tmp_path, monkeypatch):
+    from skillevaluator.evaluation import DatasetGenerationError
+
+    skill = tmp_path / "my-skill"
+    evals = skill / "evals"
+    evals.mkdir(parents=True)
+    (skill / "SKILL.md").write_text(
+        "---\nname: my-skill\ndescription: Does useful work\n---\n",
+        encoding="utf-8",
+    )
+    output = evals / "evals.json"
+    original = b'{"skill_name":"original","evals":[]}\n'
+    output.write_bytes(original)
+
+    def _partial_dump(_dataset, stream, **_kwargs):
+        stream.write('{"partial":')
+        raise OSError("disk full")
+
+    monkeypatch.setattr(generate_dataset.json, "dump", _partial_dump)
+
+    with pytest.raises(DatasetGenerationError, match="Could not write dataset"):
+        generate_dataset.main([str(skill), "--no-llm", "--force"])
+
+    assert output.read_bytes() == original
+    assert list(evals.iterdir()) == [output]
+
+
+def test_force_write_preserves_existing_dataset_permissions(tmp_path):
+    skill = tmp_path / "my-skill"
+    evals = skill / "evals"
+    evals.mkdir(parents=True)
+    (skill / "SKILL.md").write_text(
+        "---\nname: my-skill\ndescription: Does useful work\n---\n",
+        encoding="utf-8",
+    )
+    output = evals / "evals.json"
+    output.write_text('{"skill_name":"original","evals":[]}\n', encoding="utf-8")
+    output.chmod(0o640)
+
+    generate_dataset.main([str(skill), "--no-llm", "--force"])
+
+    assert stat.S_IMODE(output.stat().st_mode) == 0o640
 
 
 def test_main_reports_existing_dataset_as_unchanged(tmp_path):
@@ -129,6 +177,7 @@ def test_main_reports_existing_dataset_as_unchanged(tmp_path):
     assert result.status == "unchanged"
     assert result.path == output
     assert result.dataset is None
+    assert output.read_text(encoding="utf-8") == '{"skill_name": "my-skill", "evals": []}'
 
 
 def test_command_uses_explicit_argv_without_mutating_process_state(tmp_path, monkeypatch):
@@ -144,6 +193,30 @@ def test_command_uses_explicit_argv_without_mutating_process_state(tmp_path, mon
     assert result is sentinel
     assert observed == [[str(tmp_path.resolve()), "--no-llm", "--dry-run"]]
     assert sys.argv == original_argv
+
+
+def test_concurrent_programmatic_generation_has_no_cross_talk(tmp_path):
+    from skillevaluator.evaluation import DatasetOptions, EvaluationService
+
+    skills = []
+    for name in ("alpha-skill", "beta-skill"):
+        skill = tmp_path / name
+        skill.mkdir()
+        (skill / "SKILL.md").write_text(
+            f"---\nname: {name}\ndescription: Does useful work\n---\n",
+            encoding="utf-8",
+        )
+        skills.append(skill)
+
+    def _generate(skill):
+        return EvaluationService().create_dataset(DatasetOptions(skill_path=skill, no_llm=True))
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(_generate, skills))
+
+    assert [result.status for result in results] == ["created", "created"]
+    assert [result.path.parent.parent for result in results] == skills
+    assert [result.dataset["skill_name"] for result in results] == ["alpha-skill", "beta-skill"]
 
 
 def test_agent_collect_stages_agentskills_dataset(tmp_path, monkeypatch):

--- a/tests/tier3/test_generate_dataset_results.py
+++ b/tests/tier3/test_generate_dataset_results.py
@@ -3,6 +3,9 @@
 
 import json
 import shutil
+import sys
+
+import pytest
 
 from skillevaluator.tier3 import generate_dataset
 from skillevaluator.tier3.generate_dataset import (
@@ -87,20 +90,60 @@ def test_dry_run_refine_does_not_write_dataset_when_no_trajectory(tmp_path, monk
         "---\nname: my-skill\ndescription: Does useful work\n---\n",
         encoding="utf-8",
     )
-    monkeypatch.setattr(
-        "sys.argv",
+    result = generate_dataset.main(
         [
-            "generate_dataset.py",
             str(skill),
             "--no-llm",
             "--dry-run",
             "--refine",
-        ],
+        ]
     )
 
-    generate_dataset.main()
-
     assert not (skill / "evals" / "evals.json").exists()
+    assert result.status == "preview"
+    assert result.cases_count == 1
+    assert result.dataset is not None
+
+
+def test_main_invalid_skill_preserves_cli_diagnostic(tmp_path, capsys):
+    with pytest.raises(generate_dataset.DatasetGenerationExit) as exc_info:
+        generate_dataset.main([str(tmp_path)])
+
+    assert exc_info.value.code == 1
+    assert capsys.readouterr().out == f"Error: {tmp_path} does not contain a SKILL.md\n"
+
+
+def test_main_reports_existing_dataset_as_unchanged(tmp_path):
+    skill = tmp_path / "my-skill"
+    evals = skill / "evals"
+    evals.mkdir(parents=True)
+    (skill / "SKILL.md").write_text(
+        "---\nname: my-skill\ndescription: Does useful work\n---\n",
+        encoding="utf-8",
+    )
+    output = evals / "evals.json"
+    output.write_text('{"skill_name": "my-skill", "evals": []}', encoding="utf-8")
+
+    result = generate_dataset.main([str(skill), "--no-llm"])
+
+    assert result.status == "unchanged"
+    assert result.path == output
+    assert result.dataset is None
+
+
+def test_command_uses_explicit_argv_without_mutating_process_state(tmp_path, monkeypatch):
+    from skillevaluator.tier3 import commands
+
+    observed: list[list[str]] = []
+    sentinel = object()
+    original_argv = sys.argv[:]
+    monkeypatch.setattr(generate_dataset, "main", lambda argv=None: observed.append(list(argv or ())) or sentinel)
+
+    result = commands.create_dataset(tmp_path, no_llm=True, dry_run=True)
+
+    assert result is sentinel
+    assert observed == [[str(tmp_path.resolve()), "--no-llm", "--dry-run"]]
+    assert sys.argv == original_argv
 
 
 def test_agent_collect_stages_agentskills_dataset(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Returns truthful, structured outcomes from Tier 3 dataset generation instead of mutating global CLI arguments or collapsing preview, unchanged, and created states into an untyped exit.

## Source and dependency

- Adapted from internal `2624ba2` in the `0.8.3` line (`ed7ae8e8396ec0788135741192e6d75e4ba23724`).
- Rebased directly onto current public `main`; it no longer depends on #19.

## Changes

- Adds public `DatasetGenerationResult` outcomes: `created`, `preview`, and `unchanged`.
- Adds a public `DatasetGenerationError` for programmatic callers and clean Click errors for both CLI aliases.
- Makes the generation entry point accept explicit arguments and removes process-global `sys.argv` mutation.
- Preserves dry-run and no-change behavior without claiming a dataset was written.
- Writes datasets atomically, preserves existing file permissions, and leaves an existing dataset intact if writing fails.
- Exposes runtime-resolvable public type annotations for API and framework callers.

## Public adaptations and exclusions

- Includes only the in-process public service and CLI contract.
- Excludes the internal API server, routes, schemas, deployment code, and private response models.
- Adds no provider, credential, managed runtime, Milvus, telemetry, or internal documentation behavior.

## Validation

- Complete Python 3.13 suite with coverage: **2958 passed, 7 skipped, 3 deselected**; overall coverage **81%**.
- Focused dataset/service suite: **48 passed**.
- Ruff, `git diff --check`, source plus wheel/sdist OSS-boundary scan, and strict Twine checks: passed.
- Fresh Python 3.13 wheel install: public API/type-hint import, CLI create, dry-run preview, unchanged re-run, invalid-skill error, JSON validation, and stable output digest all passed.
- Rollback, permission preservation, concurrency, both CLI aliases, option dependencies, simple/full output counts, and no `sys.argv` mutation are covered by automated tests.
- No live provider or Harbor run was performed because this change is limited to local `--no-llm` dataset-generation plumbing.

## Risk

- Low-to-moderate and localized to dataset generation.
- CLI success behavior remains compatible; failures are now one clean Click error instead of a raw exception.
- Existing datasets are not rewritten for unchanged or preview outcomes, and forced writes are atomic.