### PR TITLE
fix(reporting): sanitize public benchmark metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ All notable changes to Skill Evaluator are documented in this file.
 
 ### Fixed
 
+- Public benchmark cards now omit policy profiles, redact absolute host paths,
+  and normalize imported internal or retired metadata before publication.
 - Security and full-feature installs now work on RHEL 8 and other glibc 2.28
   Linux systems by selecting a compatible Semgrep and pip-audit pair, while
   macOS and Windows retain the newer scanner release lines.

--- a/src/skillevaluator/cli.py
+++ b/src/skillevaluator/cli.py
@@ -1358,7 +1358,7 @@ def validate(
         from skillevaluator.reporting.naming import BENCHMARK_FILENAME
 
         output_dir.mkdir(parents=True, exist_ok=True)
-        BenchmarkReporter().save(results, output_dir / BENCHMARK_FILENAME)
+        BenchmarkReporter(skill_name=target_path.name).save(results, output_dir / BENCHMARK_FILENAME)
 
     gate_failed = not all(r.passed for r in tier_gate_results)
     if quiet:

--- a/src/skillevaluator/reporting/benchmark.py
+++ b/src/skillevaluator/reporting/benchmark.py
@@ -11,7 +11,7 @@ from datetime import UTC, datetime
 from pathlib import PurePosixPath, PureWindowsPath
 from typing import TYPE_CHECKING, Any
 
-from skillevaluator.constants import DIMENSION_HINTS, DIMENSION_MAPPING
+from skillevaluator.constants import DIMENSION_HINTS, DIMENSION_MAPPING, KEBAB_CASE_PATTERN
 from skillevaluator.reporting.base import ReporterBase, is_advisory_agent_eval_skip, passes_required_gate
 from skillevaluator.tier3_environments import HARBOR_ENV_MODES
 
@@ -46,14 +46,22 @@ _TIER2_VALIDATORS = {
 }
 
 _RETIRED_PRODUCT_NAME = re.compile(r"\b[a-z]*[\s_-]*skills[\s_-]*eval\b", flags=re.IGNORECASE)
+_SKILL_NAME_SENTINEL = "\ue000PUBLICATION_SKILL_NAME\ue001"
 
 
 class BenchmarkReporter(ReporterBase):
     """Render a stable ``BENCHMARK.md`` skill evaluation card."""
 
-    def __init__(self, *, include_timestamp: bool = True, max_findings_shown: int = 5) -> None:
+    def __init__(
+        self,
+        *,
+        include_timestamp: bool = True,
+        max_findings_shown: int = 5,
+        skill_name: str | None = None,
+    ) -> None:
         self.include_timestamp = include_timestamp
         self.max_findings_shown = max_findings_shown
+        self.skill_name = skill_name
 
     @property
     def name(self) -> str:
@@ -68,12 +76,14 @@ class BenchmarkReporter(ReporterBase):
 
     def render_all(self, results: list[ValidationResult]) -> str:
         ae = _agent_eval_payload(results)
-        skill_name = _skill_name(results, ae)
+        skill_name = self.skill_name or _skill_name(results, ae)
+        preserve_skill_name = re.fullmatch(KEBAB_CASE_PATTERN, skill_name) is not None
+        rendered_skill_name = _SKILL_NAME_SENTINEL if preserve_skill_name else skill_name
 
         lines: list[str] = [
             "# Evaluation Report",
             "",
-            (f"Evaluation of the `{skill_name}` skill before publication through Skill Evaluator."),
+            (f"Evaluation of the `{rendered_skill_name}` skill before publication through Skill Evaluator."),
             "",
             (
                 "This benchmark summarizes 3-Tier Evaluation from Skill Evaluator "
@@ -84,7 +94,7 @@ class BenchmarkReporter(ReporterBase):
             "",
         ]
 
-        self._render_evaluation_summary(lines, results, ae, skill_name)
+        self._render_evaluation_summary(lines, results, ae, rendered_skill_name)
         self._render_agents_used(lines, ae)
         self._render_metrics_used(lines, ae)
         self._render_test_tasks(lines, ae)
@@ -93,7 +103,8 @@ class BenchmarkReporter(ReporterBase):
         self._render_tier_summary(lines, "Tier 2: Deduplication Summary", _tier2_results(results))
         self._render_publication_recommendation(lines, results, ae)
 
-        return _publication_safe_text("\n".join(lines).rstrip() + "\n")
+        publication_text = _publication_safe_text("\n".join(lines).rstrip() + "\n")
+        return publication_text.replace(_SKILL_NAME_SENTINEL, skill_name) if preserve_skill_name else publication_text
 
     def _render_evaluation_summary(
         self,
@@ -607,7 +618,7 @@ def _publication_safe_location(finding: Finding) -> str:
     windows_path = PureWindowsPath(file_path)
     if posix_path.is_absolute():
         file_path = posix_path.name
-    elif windows_path.is_absolute():
+    elif windows_path.is_absolute() or windows_path.root:
         file_path = windows_path.name
     if finding.line_number:
         file_path += f":{finding.line_number}"

--- a/src/skillevaluator/reporting/benchmark.py
+++ b/src/skillevaluator/reporting/benchmark.py
@@ -708,7 +708,7 @@ def _publication_safe_inline(value: object, private_labels: tuple[str, ...] = ()
     text = _redact_absolute_paths(text)
     for label in sorted(private_labels, key=len, reverse=True):
         text = re.sub(
-            rf"(?<![\w-]){re.escape(label)}(?![\w-])",
+            re.escape(label),
             "Isolated sandbox",
             text,
             flags=re.IGNORECASE,

--- a/src/skillevaluator/reporting/benchmark.py
+++ b/src/skillevaluator/reporting/benchmark.py
@@ -5,12 +5,15 @@
 
 from __future__ import annotations
 
+import re
 from collections import Counter
 from datetime import UTC, datetime
+from pathlib import PurePosixPath, PureWindowsPath
 from typing import TYPE_CHECKING, Any
 
 from skillevaluator.constants import DIMENSION_HINTS, DIMENSION_MAPPING
 from skillevaluator.reporting.base import ReporterBase, is_advisory_agent_eval_skip, passes_required_gate
+from skillevaluator.tier3_environments import HARBOR_ENV_MODES
 
 if TYPE_CHECKING:
     from skillevaluator.models import Finding, ValidationResult
@@ -41,6 +44,8 @@ _TIER2_VALIDATORS = {
     "context deduplication",
     "intra-skill deduplication",
 }
+
+_RETIRED_PRODUCT_NAME = re.compile(r"\b[a-z]*[\s_-]*skills[\s_-]*eval\b", flags=re.IGNORECASE)
 
 
 class BenchmarkReporter(ReporterBase):
@@ -88,7 +93,7 @@ class BenchmarkReporter(ReporterBase):
         self._render_tier_summary(lines, "Tier 2: Deduplication Summary", _tier2_results(results))
         self._render_publication_recommendation(lines, results, ae)
 
-        return "\n".join(lines).rstrip() + "\n"
+        return _publication_safe_text("\n".join(lines).rstrip() + "\n")
 
     def _render_evaluation_summary(
         self,
@@ -104,15 +109,11 @@ class BenchmarkReporter(ReporterBase):
             date = datetime.now(tz=UTC).date().isoformat()
             lines.append(f"- Evaluation date: {date}")
 
-        profile = _policy_profile(results)
-        if profile:
-            lines.append(f"- Skill Evaluator profile: `{profile}`")
-
         if ae:
             summary = ae.get("summary") or {}
             environment = summary.get("environment") or ae.get("environment")
             if environment:
-                lines.append(f"- Environment: `{environment}`")
+                lines.append(f"- Environment: `{_publication_safe_environment(environment)}`")
 
             dataset_count = _dataset_count(ae)
             if dataset_count is not None:
@@ -307,7 +308,7 @@ class BenchmarkReporter(ReporterBase):
         lines.append("Top findings:")
         lines.append("")
         for finding in _top_findings(findings, limit=self.max_findings_shown):
-            loc = f" (`{finding.location}`)" if finding.file_path else ""
+            loc = f" (`{_publication_safe_location(finding)}`)" if finding.file_path else ""
             lines.append(
                 f"- {finding.severity.value.upper()} {finding.category}/{finding.check_name}: {finding.message}{loc}"
             )
@@ -415,14 +416,6 @@ def _skill_name(results: list[ValidationResult], ae: dict[str, Any] | None) -> s
         if isinstance(quality, dict) and quality.get("skill_name"):
             return str(quality["skill_name"])
     return "skill"
-
-
-def _policy_profile(results: list[ValidationResult]) -> str | None:
-    for result in results:
-        policy = result.metadata.get("policy") if isinstance(result.metadata, dict) else None
-        if isinstance(policy, dict) and policy.get("profile"):
-            return str(policy["profile"])
-    return None
 
 
 def _agents(ae: dict[str, Any] | None) -> dict[str, dict[str, Any]]:
@@ -594,3 +587,28 @@ def _top_findings(findings: list[Finding], *, limit: int) -> list[Finding]:
 
 def _md_cell(value: object) -> str:
     return str(value).replace("|", "\\|")
+
+
+def _publication_safe_text(value: object) -> str:
+    """Remove retired internal product branding from publication output."""
+    return _RETIRED_PRODUCT_NAME.sub("Skill Evaluator", str(value))
+
+
+def _publication_safe_environment(value: object) -> str:
+    """Keep public environment names and generalize unknown imported labels."""
+    environment = str(value).strip()
+    return environment if environment.casefold() in HARBOR_ENV_MODES else "Isolated sandbox"
+
+
+def _publication_safe_location(finding: Finding) -> str:
+    """Render a finding location without publishing an absolute host path."""
+    file_path = str(finding.file_path)
+    posix_path = PurePosixPath(file_path)
+    windows_path = PureWindowsPath(file_path)
+    if posix_path.is_absolute():
+        file_path = posix_path.name
+    elif windows_path.is_absolute():
+        file_path = windows_path.name
+    if finding.line_number:
+        file_path += f":{finding.line_number}"
+    return file_path

--- a/src/skillevaluator/reporting/benchmark.py
+++ b/src/skillevaluator/reporting/benchmark.py
@@ -46,7 +46,11 @@ _TIER2_VALIDATORS = {
 }
 
 _RETIRED_PRODUCT_NAME = re.compile(r"\b[a-z]*[\s_-]*skills[\s_-]*eval\b", flags=re.IGNORECASE)
-_SKILL_NAME_SENTINEL = "\ue000PUBLICATION_SKILL_NAME\ue001"
+_PATH_START = re.compile(r"(?<![A-Za-z0-9:/])(?:[A-Za-z]:[\\/]|\\\\|\\|/)")
+_QUOTED_ABSOLUTE_PATH = re.compile(
+    r"(?P<quote>['\"])(?P<path>(?:[A-Za-z]:[\\/]|\\\\|\\|/)[^'\"\r\n]+)(?P=quote)"
+)
+_TRAILING_PATH_PUNCTUATION = ".,;!?)]}>`'\""
 
 
 class BenchmarkReporter(ReporterBase):
@@ -76,14 +80,13 @@ class BenchmarkReporter(ReporterBase):
 
     def render_all(self, results: list[ValidationResult]) -> str:
         ae = _agent_eval_payload(results)
-        skill_name = self.skill_name or _skill_name(results, ae)
-        preserve_skill_name = re.fullmatch(KEBAB_CASE_PATTERN, skill_name) is not None
-        rendered_skill_name = _SKILL_NAME_SENTINEL if preserve_skill_name else skill_name
+        skill_name = _publication_safe_skill_name(self.skill_name or _skill_name(results, ae))
+        private_labels = _private_environment_labels(ae)
 
         lines: list[str] = [
             "# Evaluation Report",
             "",
-            (f"Evaluation of the `{rendered_skill_name}` skill before publication through Skill Evaluator."),
+            (f"Evaluation of the `{skill_name}` skill before publication through Skill Evaluator."),
             "",
             (
                 "This benchmark summarizes 3-Tier Evaluation from Skill Evaluator "
@@ -94,17 +97,26 @@ class BenchmarkReporter(ReporterBase):
             "",
         ]
 
-        self._render_evaluation_summary(lines, results, ae, rendered_skill_name)
-        self._render_agents_used(lines, ae)
-        self._render_metrics_used(lines, ae)
+        self._render_evaluation_summary(lines, results, ae, skill_name, private_labels)
+        self._render_agents_used(lines, ae, private_labels)
+        self._render_metrics_used(lines, ae, private_labels)
         self._render_test_tasks(lines, ae)
-        self._render_results(lines, ae)
-        self._render_tier_summary(lines, "Tier 1: Static Validation Summary", _tier1_results(results))
-        self._render_tier_summary(lines, "Tier 2: Deduplication Summary", _tier2_results(results))
+        self._render_results(lines, ae, private_labels)
+        self._render_tier_summary(
+            lines,
+            "Tier 1: Static Validation Summary",
+            _tier1_results(results),
+            private_labels,
+        )
+        self._render_tier_summary(
+            lines,
+            "Tier 2: Deduplication Summary",
+            _tier2_results(results),
+            private_labels,
+        )
         self._render_publication_recommendation(lines, results, ae)
 
-        publication_text = _publication_safe_text("\n".join(lines).rstrip() + "\n")
-        return publication_text.replace(_SKILL_NAME_SENTINEL, skill_name) if preserve_skill_name else publication_text
+        return "\n".join(lines).rstrip() + "\n"
 
     def _render_evaluation_summary(
         self,
@@ -112,6 +124,7 @@ class BenchmarkReporter(ReporterBase):
         results: list[ValidationResult],
         ae: dict[str, Any] | None,
         skill_name: str,
+        private_labels: tuple[str, ...],
     ) -> None:
         lines.append("## Evaluation Summary")
         lines.append("")
@@ -121,7 +134,8 @@ class BenchmarkReporter(ReporterBase):
             lines.append(f"- Evaluation date: {date}")
 
         if ae:
-            summary = ae.get("summary") or {}
+            summary_value = ae.get("summary")
+            summary = summary_value if isinstance(summary_value, dict) else {}
             environment = summary.get("environment") or ae.get("environment")
             if environment:
                 lines.append(f"- Environment: `{_publication_safe_environment(environment)}`")
@@ -130,10 +144,11 @@ class BenchmarkReporter(ReporterBase):
             if dataset_count is not None:
                 lines.append(f"- Dataset: {dataset_count} evaluation tasks")
 
-            attempt_policy = ae.get("attempt_policy") or {}
+            attempt_policy_value = ae.get("attempt_policy")
+            attempt_policy = attempt_policy_value if isinstance(attempt_policy_value, dict) else {}
             attempts = attempt_policy.get("max_attempts")
             if attempts is not None:
-                lines.append(f"- Attempts per task: {attempts}")
+                lines.append(f"- Attempts per task: {_publication_safe_inline(attempts, private_labels)}")
 
             pass_threshold = attempt_policy.get("pass_threshold")
             if isinstance(pass_threshold, (int, float)):
@@ -143,23 +158,30 @@ class BenchmarkReporter(ReporterBase):
             combined = _combined_verdict(results, verdict)
             lines.append(f"- Overall verdict: {combined}")
             if skip_message := _advisory_agent_eval_skip_message(results):
-                lines.append(f"- Tier 3 live evaluation: SKIPPED — {skip_message}")
+                lines.append(
+                    "- Tier 3 live evaluation: SKIPPED — "
+                    f"{_publication_safe_inline(skip_message, private_labels)}"
+                )
             if combined == "INCOMPLETE":
-                _render_incomplete_benchmark_notes(lines, results)
+                _render_incomplete_benchmark_notes(lines, results, private_labels)
             elif combined == "FAIL":
                 _render_failed_benchmark_notes(lines)
         else:
             combined = _combined_verdict(results, None)
             lines.append(f"- Overall verdict: {combined}")
             if combined == "INCOMPLETE":
-                _render_incomplete_benchmark_notes(lines, results)
+                _render_incomplete_benchmark_notes(lines, results, private_labels)
             elif combined == "FAIL":
                 _render_failed_benchmark_notes(lines)
             lines.append("- Tier 3 live agent evaluation: not available in this report")
         lines.append("")
 
     @staticmethod
-    def _render_agents_used(lines: list[str], ae: dict[str, Any] | None) -> None:
+    def _render_agents_used(
+        lines: list[str],
+        ae: dict[str, Any] | None,
+        private_labels: tuple[str, ...],
+    ) -> None:
         lines.append("## Agents Used")
         lines.append("")
         agents = _agents(ae)
@@ -167,11 +189,15 @@ class BenchmarkReporter(ReporterBase):
             lines.append("- Tier 3 agent details were not available in this report.")
         else:
             for name, agent in agents.items():
-                lines.append(f"- {_agent_label(name, agent)}")
+                lines.append(f"- {_agent_label(name, agent, private_labels)}")
         lines.append("")
 
     @staticmethod
-    def _render_metrics_used(lines: list[str], ae: dict[str, Any] | None) -> None:
+    def _render_metrics_used(
+        lines: list[str],
+        ae: dict[str, Any] | None,
+        private_labels: tuple[str, ...],
+    ) -> None:
         lines.append("## Metrics Used")
         lines.append("")
         lines.append("Reported benchmark dimensions:")
@@ -188,9 +214,10 @@ class BenchmarkReporter(ReporterBase):
         else:
             labels = _metric_labels(ae)
             for signal in signals:
-                label = labels.get(signal, signal.replace("_", " ").title())
+                safe_signal = _publication_safe_inline(signal, private_labels)
+                label = _publication_safe_label(labels.get(signal, signal.replace("_", " ").title()), private_labels)
                 desc = _SIGNAL_DESCRIPTIONS.get(signal, "captured by the Tier 3 evaluation payload.")
-                lines.append(f"- `{signal}` ({label}): {desc}")
+                lines.append(f"- `{safe_signal}` ({label}): {desc}")
         lines.append("")
 
     @staticmethod
@@ -232,7 +259,11 @@ class BenchmarkReporter(ReporterBase):
         lines.append("")
 
     @staticmethod
-    def _render_results(lines: list[str], ae: dict[str, Any] | None) -> None:
+    def _render_results(
+        lines: list[str],
+        ae: dict[str, Any] | None,
+        private_labels: tuple[str, ...],
+    ) -> None:
         lines.append("## Results")
         lines.append("")
         agents = _agents(ae)
@@ -244,7 +275,7 @@ class BenchmarkReporter(ReporterBase):
         header = [
             "Dimension",
             "Num",
-            *[_agent_label(name, agent) for name, agent in agents.items()],
+            *[_agent_label(name, agent, private_labels) for name, agent in agents.items()],
         ]
         lines.append("| " + " | ".join(_md_cell(cell) for cell in header) + " |")
         lines.append("|---|---:|" + "|".join(["---:"] * len(agents)) + "|")
@@ -265,6 +296,7 @@ class BenchmarkReporter(ReporterBase):
         lines: list[str],
         title: str,
         results: list[ValidationResult],
+        private_labels: tuple[str, ...],
     ) -> None:
         lines.append(f"## {title}")
         lines.append("")
@@ -279,7 +311,8 @@ class BenchmarkReporter(ReporterBase):
         high_count = _severity_count(findings, "high") + _severity_count(findings, "critical")
         if incomplete:
             tools = list(dict.fromkeys(tool for result in incomplete for tool in result.incomplete_scans))
-            status = f"is incomplete because {', '.join(tools)} did not produce trustworthy evidence"
+            safe_tools = [_publication_safe_inline(tool, private_labels) for tool in tools]
+            status = f"is incomplete because {', '.join(safe_tools)} did not produce trustworthy evidence"
         elif failures or high_count:
             status = "reported findings"
         elif findings:
@@ -302,17 +335,19 @@ class BenchmarkReporter(ReporterBase):
             lines.append("Test execution limitations:")
             lines.append("")
             for message in static_test_limitations:
-                lines.append(f"- {message}")
+                lines.append(f"- {_publication_safe_inline(message, private_labels)}")
             lines.append("")
 
         if not findings:
             lines.append("Notable observations:")
             lines.append("")
             for result in results[: self.max_findings_shown]:
+                validator_name = _publication_safe_inline(result.validator_name, private_labels)
                 if result.success_details:
-                    lines.append(f"- {result.validator_name}: {result.success_details[0].message}")
+                    message = _publication_safe_inline(result.success_details[0].message, private_labels)
+                    lines.append(f"- {validator_name}: {message}")
                 else:
-                    lines.append(f"- {result.validator_name}: no findings reported.")
+                    lines.append(f"- {validator_name}: no findings reported.")
             lines.append("")
             return
 
@@ -320,8 +355,11 @@ class BenchmarkReporter(ReporterBase):
         lines.append("")
         for finding in _top_findings(findings, limit=self.max_findings_shown):
             loc = f" (`{_publication_safe_location(finding)}`)" if finding.file_path else ""
+            category = _publication_safe_inline(finding.category, private_labels)
+            check_name = _publication_safe_inline(finding.check_name, private_labels)
+            message = _publication_safe_inline(finding.message, private_labels)
             lines.append(
-                f"- {finding.severity.value.upper()} {finding.category}/{finding.check_name}: {finding.message}{loc}"
+                f"- {finding.severity.value.upper()} {category}/{check_name}: {message}{loc}"
             )
         lines.append("")
 
@@ -407,18 +445,24 @@ def _combined_verdict(results: list[ValidationResult], tier3_verdict: object) ->
     return "PASS"
 
 
-def _render_incomplete_benchmark_notes(lines: list[str], results: list[ValidationResult]) -> None:
+def _render_incomplete_benchmark_notes(
+    lines: list[str],
+    results: list[ValidationResult],
+    private_labels: tuple[str, ...],
+) -> None:
     tools = list(dict.fromkeys(tool for result in results for tool in result.incomplete_scans))
+    safe_tools = [_publication_safe_inline(tool, private_labels) for tool in tools]
     lines.append(
         "Required scanner evidence is incomplete "
-        f"({', '.join(tools)}). **Do not use this benchmark to recommend publication; "
+        f"({', '.join(safe_tools)}). **Do not use this benchmark to recommend publication; "
         "restore the scanners and rerun Skill Evaluator.**"
     )
 
 
 def _skill_name(results: list[ValidationResult], ae: dict[str, Any] | None) -> str:
     if ae:
-        summary = ae.get("summary") or {}
+        summary_value = ae.get("summary")
+        summary = summary_value if isinstance(summary_value, dict) else {}
         candidate = ae.get("skill_name") or summary.get("skill_name")
         if candidate:
             return str(candidate)
@@ -438,12 +482,15 @@ def _agents(ae: dict[str, Any] | None) -> dict[str, dict[str, Any]]:
     return {}
 
 
-def _agent_label(name: str, agent: dict[str, Any]) -> str:
+def _agent_label(name: str, agent: dict[str, Any], private_labels: tuple[str, ...]) -> str:
     display = agent.get("display_name") or agent.get("label") or name
     model = agent.get("model") or agent.get("model_name") or agent.get("llm_model")
+    safe_name = _publication_safe_label(name, private_labels)
+    safe_display = _publication_safe_label(display, private_labels)
     if model:
-        return f"{_human_agent_name(str(display))} (`{model}`)"
-    return f"`{name}`" if display == name else _human_agent_name(str(display))
+        safe_model = _publication_safe_label(model, private_labels)
+        return f"{_human_agent_name(safe_display)} (`{safe_model}`)"
+    return f"`{safe_name}`" if display == name else _human_agent_name(safe_display)
 
 
 def _human_agent_name(name: str) -> str:
@@ -597,12 +644,86 @@ def _top_findings(findings: list[Finding], *, limit: int) -> list[Finding]:
 
 
 def _md_cell(value: object) -> str:
-    return str(value).replace("|", "\\|")
+    return _publication_safe_inline(value).replace("|", "\\|")
 
 
-def _publication_safe_text(value: object) -> str:
-    """Remove retired internal product branding from publication output."""
-    return _RETIRED_PRODUCT_NAME.sub("Skill Evaluator", str(value))
+def _publication_safe_skill_name(value: object) -> str:
+    """Return a canonical target identity or a non-injectable public fallback."""
+    candidate = " ".join(str(value).split())
+    if re.fullmatch(KEBAB_CASE_PATTERN, candidate) is not None:
+        return candidate
+    if _RETIRED_PRODUCT_NAME.fullmatch(candidate):
+        return "Skill Evaluator"
+    return "skill"
+
+
+def _private_environment_labels(ae: dict[str, Any] | None) -> tuple[str, ...]:
+    """Return imported non-public environment labels that must not escape in free text."""
+    if not ae:
+        return ()
+    summary_value = ae.get("summary")
+    summary = summary_value if isinstance(summary_value, dict) else {}
+    candidates = [summary.get("environment"), ae.get("environment")]
+    labels: list[str] = []
+    for value in candidates:
+        label = " ".join(str(value or "").split())
+        if label and label.casefold() not in HARBOR_ENV_MODES and label not in labels:
+            labels.append(label)
+    return tuple(labels)
+
+
+def _publication_safe_label(value: object, private_labels: tuple[str, ...] = ()) -> str:
+    """Sanitize a classified display label and normalize only an exact retired product name."""
+    label = _publication_safe_inline(value, private_labels)
+    return "Skill Evaluator" if _RETIRED_PRODUCT_NAME.fullmatch(label) else label
+
+
+def _publication_safe_inline(value: object, private_labels: tuple[str, ...] = ()) -> str:
+    """Render untrusted metadata as one publication-safe Markdown line."""
+    text = " ".join(str(value).split())
+    text = _redact_absolute_paths(text)
+    for label in sorted(private_labels, key=len, reverse=True):
+        text = re.sub(
+            rf"(?<![\w-]){re.escape(label)}(?![\w-])",
+            "Isolated sandbox",
+            text,
+            flags=re.IGNORECASE,
+        )
+    return text.replace("`", "'")
+
+
+def _redact_absolute_paths(value: str) -> str:
+    """Reduce absolute POSIX and Windows paths embedded in free text to basenames."""
+
+    def redact_quoted(match: re.Match[str]) -> str:
+        path = match.group("path")
+        basename = _absolute_path_basename(path)
+        return f"{match.group('quote')}{basename}{match.group('quote')}" if basename else match.group(0)
+
+    text = _QUOTED_ABSOLUTE_PATH.sub(redact_quoted, value)
+    tokens: list[str] = []
+    for token in text.split(" "):
+        match = _PATH_START.search(token)
+        if not match:
+            tokens.append(token)
+            continue
+        prefix = token[: match.start()]
+        candidate = token[match.start() :]
+        core = candidate.rstrip(_TRAILING_PATH_PUNCTUATION)
+        suffix = candidate[len(core) :]
+        basename = _absolute_path_basename(core)
+        tokens.append(f"{prefix}{basename}{suffix}" if basename else token)
+    return " ".join(tokens)
+
+
+def _absolute_path_basename(value: str) -> str | None:
+    posix_path = PurePosixPath(value)
+    windows_path = PureWindowsPath(value)
+    if posix_path.is_absolute() and not value.startswith("//"):
+        return posix_path.name or "redacted-path"
+    if windows_path.is_absolute() or windows_path.root:
+        return windows_path.name or "redacted-path"
+    return None
 
 
 def _publication_safe_environment(value: object) -> str:
@@ -622,4 +743,4 @@ def _publication_safe_location(finding: Finding) -> str:
         file_path = windows_path.name
     if finding.line_number:
         file_path += f":{finding.line_number}"
-    return file_path
+    return _publication_safe_inline(file_path)

--- a/src/skillevaluator/reporting/benchmark.py
+++ b/src/skillevaluator/reporting/benchmark.py
@@ -59,7 +59,7 @@ _FILE_URI_PATH = re.compile(
     flags=re.IGNORECASE,
 )
 _MARKDOWN_INLINE_SPECIAL = re.compile(r"([\\*_\[\]~])")
-_MARKDOWN_BLOCK_PREFIX = re.compile(r"^(?:#{1,6}|>|[+*-]|\d+[.)])(?=\s)")
+_MARKDOWN_BLOCK_PREFIX = re.compile(r"^(?:#{1,6}|>|[+*-]|\d+[.)])(?=\s|$)")
 _MARKDOWN_THEMATIC_BREAK = re.compile(r"^(?:\s*[-*_]){3,}\s*$")
 _PUBLICATION_URL_SCHEME = re.compile(r"(?P<scheme>https?|ftp)://", flags=re.IGNORECASE)
 _PUBLICATION_WWW_PREFIX = re.compile(r"\bwww\.", flags=re.IGNORECASE)

--- a/src/skillevaluator/reporting/benchmark.py
+++ b/src/skillevaluator/reporting/benchmark.py
@@ -51,10 +51,13 @@ _QUOTED_ABSOLUTE_PATH = re.compile(
     r"(?P<quote>['\"])(?P<path>(?:[A-Za-z]:[\\/]|\\\\|\\|/)[^'\"\r\n]+)(?P=quote)"
 )
 _QUOTED_FILE_URI_PATH = re.compile(
-    r"(?P<quote>['\"])(?:file://)(?P<path>/[^'\"\r\n]+)(?P=quote)",
+    r"(?P<quote>['\"])(?:file:)(?://[^/'\"\r\n]*)?(?P<path>/[^'\"\r\n]+)(?P=quote)",
     flags=re.IGNORECASE,
 )
-_FILE_URI_PATH = re.compile(r"\bfile://(?P<path>/[^\s'\"<>]+)", flags=re.IGNORECASE)
+_FILE_URI_PATH = re.compile(
+    r"\bfile:(?://[^/\s'\"<>]*)?(?P<path>/[^\s'\"<>]+)",
+    flags=re.IGNORECASE,
+)
 _MARKDOWN_INLINE_SPECIAL = re.compile(r"([\\*_\[\]~])")
 _PUBLICATION_URL_SCHEME = re.compile(r"(?P<scheme>https?|ftp)://", flags=re.IGNORECASE)
 _PUBLICATION_WWW_PREFIX = re.compile(r"\bwww\.", flags=re.IGNORECASE)

--- a/src/skillevaluator/reporting/benchmark.py
+++ b/src/skillevaluator/reporting/benchmark.py
@@ -50,6 +50,14 @@ _PATH_START = re.compile(r"(?<![A-Za-z0-9:/])(?:[A-Za-z]:[\\/]|\\\\|\\|/)")
 _QUOTED_ABSOLUTE_PATH = re.compile(
     r"(?P<quote>['\"])(?P<path>(?:[A-Za-z]:[\\/]|\\\\|\\|/)[^'\"\r\n]+)(?P=quote)"
 )
+_QUOTED_FILE_URI_PATH = re.compile(
+    r"(?P<quote>['\"])(?:file://)(?P<path>/[^'\"\r\n]+)(?P=quote)",
+    flags=re.IGNORECASE,
+)
+_FILE_URI_PATH = re.compile(r"\bfile://(?P<path>/[^\s'\"<>]+)", flags=re.IGNORECASE)
+_MARKDOWN_INLINE_SPECIAL = re.compile(r"([\\*_\[\]~])")
+_PUBLICATION_URL_SCHEME = re.compile(r"(?P<scheme>https?|ftp)://", flags=re.IGNORECASE)
+_PUBLICATION_WWW_PREFIX = re.compile(r"\bwww\.", flags=re.IGNORECASE)
 _TRAILING_PATH_PUNCTUATION = ".,;!?)]}>`'\""
 
 
@@ -277,13 +285,13 @@ class BenchmarkReporter(ReporterBase):
             "Num",
             *[_agent_label(name, agent, private_labels) for name, agent in agents.items()],
         ]
-        lines.append("| " + " | ".join(_md_cell(cell) for cell in header) + " |")
+        lines.append("| " + " | ".join(_md_cell(cell, private_labels) for cell in header) + " |")
         lines.append("|---|---:|" + "|".join(["---:"] * len(agents)) + "|")
         for dim_id in DIMENSION_MAPPING:
             row = [dim_id.title(), _dimension_num(ae, dim_id)]
             for agent in agents.values():
                 row.append(_score_lift_cell(_agent_dimension(agent, dim_id)))
-            lines.append("| " + " | ".join(_md_cell(cell) for cell in row) + " |")
+            lines.append("| " + " | ".join(_md_cell(cell, private_labels) for cell in row) + " |")
         lines.append("")
         lines.append(
             "Score values show skill-assisted performance. Values in parentheses show "
@@ -643,8 +651,8 @@ def _top_findings(findings: list[Finding], *, limit: int) -> list[Finding]:
     return sorted(findings, key=lambda f: (order.get(f.severity.value, 99), f.category))[:limit]
 
 
-def _md_cell(value: object) -> str:
-    return _publication_safe_inline(value).replace("|", "\\|")
+def _md_cell(value: object, private_labels: tuple[str, ...] = ()) -> str:
+    return _publication_safe_inline(value, private_labels).replace("|", "\\|")
 
 
 def _publication_safe_skill_name(value: object) -> str:
@@ -689,18 +697,35 @@ def _publication_safe_inline(value: object, private_labels: tuple[str, ...] = ()
             text,
             flags=re.IGNORECASE,
         )
-    return text.replace("`", "'")
+    text = text.replace("`", "'").replace("<", "&lt;").replace(">", "&gt;")
+    text = _PUBLICATION_URL_SCHEME.sub(lambda match: f"{match.group('scheme')}&#58;//", text)
+    text = _PUBLICATION_WWW_PREFIX.sub(lambda match: f"{match.group(0)[:-1]}&#46;", text)
+    text = text.replace("@", "&#64;")
+    return _MARKDOWN_INLINE_SPECIAL.sub(r"\\\1", text)
 
 
 def _redact_absolute_paths(value: str) -> str:
     """Reduce absolute POSIX and Windows paths embedded in free text to basenames."""
+
+    def redact_quoted_file_uri(match: re.Match[str]) -> str:
+        basename = _absolute_path_basename(match.group("path"))
+        return f"{match.group('quote')}{basename}{match.group('quote')}" if basename else match.group(0)
+
+    def redact_file_uri(match: re.Match[str]) -> str:
+        candidate = match.group("path")
+        core = candidate.rstrip(_TRAILING_PATH_PUNCTUATION)
+        suffix = candidate[len(core) :]
+        basename = _absolute_path_basename(core)
+        return f"{basename}{suffix}" if basename else match.group(0)
 
     def redact_quoted(match: re.Match[str]) -> str:
         path = match.group("path")
         basename = _absolute_path_basename(path)
         return f"{match.group('quote')}{basename}{match.group('quote')}" if basename else match.group(0)
 
-    text = _QUOTED_ABSOLUTE_PATH.sub(redact_quoted, value)
+    text = _QUOTED_FILE_URI_PATH.sub(redact_quoted_file_uri, value)
+    text = _FILE_URI_PATH.sub(redact_file_uri, text)
+    text = _QUOTED_ABSOLUTE_PATH.sub(redact_quoted, text)
     tokens: list[str] = []
     for token in text.split(" "):
         match = _PATH_START.search(token)

--- a/src/skillevaluator/reporting/benchmark.py
+++ b/src/skillevaluator/reporting/benchmark.py
@@ -692,13 +692,6 @@ def _publication_safe_label(value: object, private_labels: tuple[str, ...] = ())
     label = _publication_safe_inline(value, private_labels)
     if _RETIRED_PRODUCT_NAME.fullmatch(label):
         return "Skill Evaluator"
-    if _MARKDOWN_BLOCK_PREFIX.match(label) or _MARKDOWN_THEMATIC_BREAK.fullmatch(label):
-        marker_end = label.find(" ")
-        marker_end = len(label) if marker_end < 0 else marker_end
-        if label[:marker_end].rstrip(".)").isdigit():
-            punctuation_index = marker_end - 1
-            return f"{label[:punctuation_index]}\\{label[punctuation_index:]}"
-        return f"\\{label}"
     return label
 
 
@@ -717,7 +710,15 @@ def _publication_safe_inline(value: object, private_labels: tuple[str, ...] = ()
     text = _PUBLICATION_URL_SCHEME.sub(lambda match: f"{match.group('scheme')}&#58;//", text)
     text = _PUBLICATION_WWW_PREFIX.sub(lambda match: f"{match.group(0)[:-1]}&#46;", text)
     text = text.replace("@", "&#64;")
-    return _MARKDOWN_INLINE_SPECIAL.sub(r"\\\1", text)
+    text = _MARKDOWN_INLINE_SPECIAL.sub(r"\\\1", text)
+    if _MARKDOWN_BLOCK_PREFIX.match(text) or _MARKDOWN_THEMATIC_BREAK.fullmatch(text):
+        marker_end = text.find(" ")
+        marker_end = len(text) if marker_end < 0 else marker_end
+        if text[:marker_end].rstrip(".)").isdigit():
+            punctuation_index = marker_end - 1
+            return f"{text[:punctuation_index]}\\{text[punctuation_index:]}"
+        return f"\\{text}"
+    return text
 
 
 def _redact_absolute_paths(value: str) -> str:

--- a/src/skillevaluator/reporting/benchmark.py
+++ b/src/skillevaluator/reporting/benchmark.py
@@ -59,6 +59,8 @@ _FILE_URI_PATH = re.compile(
     flags=re.IGNORECASE,
 )
 _MARKDOWN_INLINE_SPECIAL = re.compile(r"([\\*_\[\]~])")
+_MARKDOWN_BLOCK_PREFIX = re.compile(r"^(?:#{1,6}|>|[+*-]|\d+[.)])(?=\s)")
+_MARKDOWN_THEMATIC_BREAK = re.compile(r"^(?:\s*[-*_]){3,}\s*$")
 _PUBLICATION_URL_SCHEME = re.compile(r"(?P<scheme>https?|ftp)://", flags=re.IGNORECASE)
 _PUBLICATION_WWW_PREFIX = re.compile(r"\bwww\.", flags=re.IGNORECASE)
 _TRAILING_PATH_PUNCTUATION = ".,;!?)]}>`'\""
@@ -507,6 +509,8 @@ def _agent_label(name: str, agent: dict[str, Any], private_labels: tuple[str, ..
 def _human_agent_name(name: str) -> str:
     if name == "claude-code":
         return "Claude Code"
+    if name.startswith("\\"):
+        return name.title()
     return name.replace("_", " ").replace("-", " ").title()
 
 
@@ -686,7 +690,16 @@ def _private_environment_labels(ae: dict[str, Any] | None) -> tuple[str, ...]:
 def _publication_safe_label(value: object, private_labels: tuple[str, ...] = ()) -> str:
     """Sanitize a classified display label and normalize only an exact retired product name."""
     label = _publication_safe_inline(value, private_labels)
-    return "Skill Evaluator" if _RETIRED_PRODUCT_NAME.fullmatch(label) else label
+    if _RETIRED_PRODUCT_NAME.fullmatch(label):
+        return "Skill Evaluator"
+    if _MARKDOWN_BLOCK_PREFIX.match(label) or _MARKDOWN_THEMATIC_BREAK.fullmatch(label):
+        marker_end = label.find(" ")
+        marker_end = len(label) if marker_end < 0 else marker_end
+        if label[:marker_end].rstrip(".)").isdigit():
+            punctuation_index = marker_end - 1
+            return f"{label[:punctuation_index]}\\{label[punctuation_index:]}"
+        return f"\\{label}"
+    return label
 
 
 def _publication_safe_inline(value: object, private_labels: tuple[str, ...] = ()) -> str:

--- a/src/skillevaluator/tier3/result_display.py
+++ b/src/skillevaluator/tier3/result_display.py
@@ -645,7 +645,10 @@ def render_evaluation_result(result: Mapping[str, Any], *, console: Console) -> 
     report_path = result.get("report_path")
     if report_path:
         report_name = Path(str(report_path)).name
-        artifact_rows.append(("📊 HTML report", f"{report_name} · {safe(report_path)}"))
+        safe_name = safe(report_name)
+        safe_path = safe(report_path)
+        report_display = safe_name if str(report_path) == report_name else f"{safe_name} · {safe_path}"
+        artifact_rows.append(("📊 HTML report", report_display))
     output_dir = result.get("run_dir") or result.get("output_dir")
     if output_dir:
         artifact_rows.append(("📁 Output", safe(output_dir)))

--- a/src/skillevaluator/tier3/result_display.py
+++ b/src/skillevaluator/tier3/result_display.py
@@ -10,7 +10,7 @@ import logging
 import math
 import os
 from collections.abc import Mapping
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any
 
 from rich.box import SIMPLE
@@ -644,10 +644,18 @@ def render_evaluation_result(result: Mapping[str, Any], *, console: Console) -> 
     artifact_rows: list[tuple[str, str]] = []
     report_path = result.get("report_path")
     if report_path:
-        report_name = Path(str(report_path)).name
+        raw_report_path = str(report_path)
+        windows_path = PureWindowsPath(raw_report_path)
+        report_name = (
+            windows_path.name
+            if "\\" in raw_report_path or windows_path.drive or windows_path.root
+            else PurePosixPath(raw_report_path).name
+        )
         safe_name = safe(report_name)
         safe_path = safe(report_path)
-        report_display = safe_name if str(report_path) == report_name else f"{safe_name} · {safe_path}"
+        normalized_relative = PurePosixPath(raw_report_path.replace("\\", "/"))
+        basename_only = not normalized_relative.is_absolute() and normalized_relative.parts == (report_name,)
+        report_display = safe_name if basename_only else f"{safe_name} · {safe_path}"
         artifact_rows.append(("📊 HTML report", report_display))
     output_dir = result.get("run_dir") or result.get("output_dir")
     if output_dir:

--- a/src/skillevaluator/tier3/result_display.py
+++ b/src/skillevaluator/tier3/result_display.py
@@ -644,7 +644,8 @@ def render_evaluation_result(result: Mapping[str, Any], *, console: Console) -> 
     artifact_rows: list[tuple[str, str]] = []
     report_path = result.get("report_path")
     if report_path:
-        artifact_rows.append(("📊 HTML report", safe(report_path)))
+        report_name = Path(str(report_path)).name
+        artifact_rows.append(("📊 HTML report", f"{report_name} · {safe(report_path)}"))
     output_dir = result.get("run_dir") or result.get("output_dir")
     if output_dir:
         artifact_rows.append(("📁 Output", safe(output_dir)))

--- a/tests/golden/benchmark_tier1.md
+++ b/tests/golden/benchmark_tier1.md
@@ -42,7 +42,7 @@ Tier 1 validation passed. Skill Evaluator ran 1 checks and found 0 total finding
 
 Notable observations:
 
-- Schema & Repository Governance: Valid author format: Dev One <dev@example.com>
+- Schema & Repository Governance: Valid author format: Dev One &lt;dev&#64;example.com&gt;
 
 ## Tier 2: Deduplication Summary
 
@@ -50,7 +50,7 @@ Tier 2 validation passed with observations. Skill Evaluator ran 1 checks and fou
 
 Top findings:
 
-- LOW CONTENT_DEDUP/partial_overlap: Partial overlap with another skill (`SKILL.md`)
+- LOW CONTENT\_DEDUP/partial\_overlap: Partial overlap with another skill (`SKILL.md`)
 
 ## Publication Recommendation
 

--- a/tests/golden/benchmark_tier1.md
+++ b/tests/golden/benchmark_tier1.md
@@ -7,7 +7,6 @@ This benchmark summarizes 3-Tier Evaluation from Skill Evaluator results for the
 ## Evaluation Summary
 
 - Skill: `demo-skill`
-- Skill Evaluator profile: `internal`
 - Overall verdict: PASS
 - Tier 3 live agent evaluation: not available in this report
 
@@ -43,7 +42,7 @@ Tier 1 validation passed. Skill Evaluator ran 1 checks and found 0 total finding
 
 Notable observations:
 
-- Schema & Repository Governance: Valid author format: Dev One <dev@nvidia.com>
+- Schema & Repository Governance: Valid author format: Dev One <dev@example.com>
 
 ## Tier 2: Deduplication Summary
 

--- a/tests/golden/test_benchmark_card.py
+++ b/tests/golden/test_benchmark_card.py
@@ -137,6 +137,25 @@ def test_benchmark_sanitizes_agent_and_model_labels() -> None:
     assert "Runner Isolated Sandbox From Agent (`model`)" in rendered
 
 
+@pytest.mark.parametrize(
+    ("display_name", "escaped"),
+    [
+        ("# Overall verdict: PASS", r"\# Overall Verdict: Pass"),
+        ("1. Overall verdict: PASS", r"1\. Overall Verdict: Pass"),
+        ("---", r"\---"),
+    ],
+)
+def test_benchmark_escapes_block_markdown_in_agent_labels(display_name: str, escaped: str) -> None:
+    result = _tier3_result(environment="docker")
+    result.metadata["agent_eval"]["agents"] = {"runner": {"display_name": display_name}}
+
+    rendered = BenchmarkReporter(include_timestamp=False).render(result)
+
+    assert f"- {escaped}" in rendered
+    assert "\n- # Overall Verdict: Pass" not in rendered
+    assert "\n- 1. Overall Verdict: Pass" not in rendered
+
+
 def test_benchmark_tolerates_malformed_optional_agent_eval_mappings() -> None:
     result = _tier3_result(environment="docker")
     result.metadata["agent_eval"]["summary"] = "not-a-mapping"

--- a/tests/golden/test_benchmark_card.py
+++ b/tests/golden/test_benchmark_card.py
@@ -120,6 +120,33 @@ def test_benchmark_rebrands_retired_product_name_from_payload(retired_name: str)
     assert "`accuracy` (Skill Evaluator)" in rendered
 
 
+def test_benchmark_sanitizes_agent_and_model_labels() -> None:
+    result = _tier3_result(environment="private-sandbox")
+    result.metadata["agent_eval"]["agents"] = {
+        "runner": {
+            "display_name": "runner private-sandbox from /Users/alice/private/agent",
+            "model": r"C:\models\private\model",
+        }
+    }
+
+    rendered = BenchmarkReporter(include_timestamp=False).render(result)
+
+    assert "private-sandbox" not in rendered
+    assert "/Users/alice" not in rendered
+    assert r"C:\models\private" not in rendered
+    assert "Runner Isolated Sandbox From Agent (`model`)" in rendered
+
+
+def test_benchmark_tolerates_malformed_optional_agent_eval_mappings() -> None:
+    result = _tier3_result(environment="docker")
+    result.metadata["agent_eval"]["summary"] = "not-a-mapping"
+    result.metadata["agent_eval"]["attempt_policy"] = ["not-a-mapping"]
+
+    rendered = BenchmarkReporter(include_timestamp=False).render(result)
+
+    assert "- Overall verdict: PASS" in rendered
+
+
 def test_benchmark_omits_validation_profile() -> None:
     result = ValidationResult(
         validator_name="Schema & Repository Governance",
@@ -161,3 +188,71 @@ def test_benchmark_hides_absolute_finding_paths(file_path: str, private_prefix: 
 
     assert private_prefix not in rendered
     assert "(`SKILL.md:7`)" in rendered
+
+
+def test_benchmark_preserves_relative_paths_and_non_label_text() -> None:
+    result = ValidationResult(
+        validator_name="Schema & Repository Governance",
+        validator_description="Validate SKILL.md",
+    )
+    result.add_finding(
+        Finding(
+            category="SCHEMA",
+            severity=Severity.LOW,
+            check_name="example",
+            message="Runtime skills eval failed in docs/database-skills-eval/SKILL.md",
+            file_path="docs/database-skills-eval/SKILL.md",
+        )
+    )
+
+    rendered = BenchmarkReporter(include_timestamp=False).render(result)
+
+    assert "Runtime skills eval failed in docs/database-skills-eval/SKILL.md" in rendered
+    assert "(`docs/database-skills-eval/SKILL.md`)" in rendered
+    assert "docs/Skill Evaluator/SKILL.md" not in rendered
+
+
+def test_benchmark_redacts_absolute_paths_from_dynamic_text() -> None:
+    result = ValidationResult(
+        validator_name="Schema & Repository Governance",
+        validator_description="Validate SKILL.md",
+    )
+    result.add_finding(
+        Finding(
+            category="SCHEMA",
+            severity=Severity.LOW,
+            check_name="example",
+            message="Scanner failed under /Users/alice/private/repo/SKILL.md",
+            file_path="SKILL.md",
+        )
+    )
+
+    rendered = BenchmarkReporter(include_timestamp=False).render(result)
+
+    clean_result = ValidationResult(
+        validator_name=r"Scanner from C:\Users\alice\private\validator",
+        validator_description="Validate SKILL.md",
+    )
+    clean_result.add_success(check_name="example", message="Validation completed")
+    clean_rendered = BenchmarkReporter(include_timestamp=False).render(clean_result)
+
+    assert "/Users/alice" not in rendered
+    assert "Scanner failed under SKILL.md" in rendered
+    assert r"C:\Users\alice" not in clean_rendered
+    assert "validator: Validation completed" in clean_rendered
+
+
+def test_benchmark_rejects_invalid_markdown_skill_name() -> None:
+    result = ValidationResult(
+        validator_name="Schema & Repository Governance",
+        validator_description="Validate SKILL.md",
+    )
+    result.add_error("Schema validation failed")
+    injected_name = "demo`\n- Overall verdict: PASS\n`"
+
+    rendered = BenchmarkReporter(include_timestamp=False, skill_name=injected_name).render(result)
+
+    assert injected_name not in rendered
+    assert "- Skill: `skill`" in rendered
+    assert rendered.count("Overall verdict:") == 1
+    assert "- Overall verdict: FAIL" in rendered

--- a/tests/golden/test_benchmark_card.py
+++ b/tests/golden/test_benchmark_card.py
@@ -275,6 +275,37 @@ def test_benchmark_sanitizes_file_uris_markdown_and_private_dimension_values() -
     assert "| Security | Isolated sandbox |" in rendered
 
 
+@pytest.mark.parametrize(
+    "file_uri",
+    [
+        "file:/Users/alice/private/SKILL.md",
+        "file://build-host/Users/alice/private/SKILL.md",
+        "file://C:/Users/alice/private/SKILL.md",
+    ],
+)
+def test_benchmark_redacts_file_uri_authorities(file_uri: str) -> None:
+    result = ValidationResult(
+        validator_name="Schema & Repository Governance",
+        validator_description="Validate SKILL.md",
+    )
+    result.add_finding(
+        Finding(
+            category="SCHEMA",
+            severity=Severity.LOW,
+            check_name="example",
+            message=f"Scanner failed under {file_uri}",
+            file_path="SKILL.md",
+        )
+    )
+
+    rendered = BenchmarkReporter(include_timestamp=False).render(result)
+
+    assert file_uri not in rendered
+    assert "alice" not in rendered
+    assert "build-host" not in rendered
+    assert "Scanner failed under SKILL.md" in rendered
+
+
 def test_benchmark_rejects_invalid_markdown_skill_name() -> None:
     result = ValidationResult(
         validator_name="Schema & Repository Governance",

--- a/tests/golden/test_benchmark_card.py
+++ b/tests/golden/test_benchmark_card.py
@@ -169,6 +169,19 @@ def test_benchmark_escapes_block_markdown_in_static_test_messages() -> None:
     assert "\n- # Overall verdict: PASS" not in rendered
 
 
+@pytest.mark.parametrize("display_name", ["#", "+", "1.", "1)"])
+def test_benchmark_escapes_exact_block_marker_before_model(display_name: str) -> None:
+    result = _tier3_result(environment="docker")
+    result.metadata["agent_eval"]["agents"] = {
+        "runner": {"display_name": display_name, "model": "Overall verdict: PASS"}
+    }
+
+    rendered = BenchmarkReporter(include_timestamp=False).render(result)
+
+    assert f"- {display_name} (`Overall verdict: PASS`)" not in rendered
+    assert "Overall verdict: PASS" in rendered
+
+
 def test_benchmark_tolerates_malformed_optional_agent_eval_mappings() -> None:
     result = _tier3_result(environment="docker")
     result.metadata["agent_eval"]["summary"] = "not-a-mapping"

--- a/tests/golden/test_benchmark_card.py
+++ b/tests/golden/test_benchmark_card.py
@@ -242,6 +242,39 @@ def test_benchmark_redacts_absolute_paths_from_dynamic_text() -> None:
     assert "validator: Validation completed" in clean_rendered
 
 
+def test_benchmark_sanitizes_file_uris_markdown_and_private_dimension_values() -> None:
+    result = _tier3_result(environment="private-sandbox")
+    result.metadata["agent_eval"]["agents"] = {
+        "claude-code": {
+            "dimensions": [{"id": "security", "num": "private-sandbox", "with_skill": 1.0}]
+        }
+    }
+    tier1 = ValidationResult(
+        validator_name="Schema & Repository Governance",
+        validator_description="Validate SKILL.md",
+    )
+    tier1.add_finding(
+        Finding(
+            category="[fake](https://attacker.example)",
+            severity=Severity.LOW,
+            check_name="<img src=x onerror=alert(1)>",
+            message="![PASS](https://attacker.example/pass.svg) at file:///Users/alice/private/SKILL.md",
+            file_path="SKILL.md",
+        )
+    )
+
+    rendered = BenchmarkReporter(include_timestamp=False).render_all([tier1, result])
+
+    assert "private-sandbox" not in rendered
+    assert "/Users/alice" not in rendered
+    assert "file:///" not in rendered
+    assert "https://attacker.example" not in rendered
+    assert "\\[fake\\](https&#58;//attacker.example)" in rendered
+    assert "&lt;img src=x onerror=alert(1)&gt;" in rendered
+    assert "!\\[PASS\\](https&#58;//attacker.example/pass.svg) at SKILL.md" in rendered
+    assert "| Security | Isolated sandbox |" in rendered
+
+
 def test_benchmark_rejects_invalid_markdown_skill_name() -> None:
     result = ValidationResult(
         validator_name="Schema & Repository Governance",

--- a/tests/golden/test_benchmark_card.py
+++ b/tests/golden/test_benchmark_card.py
@@ -156,6 +156,19 @@ def test_benchmark_escapes_block_markdown_in_agent_labels(display_name: str, esc
     assert "\n- 1. Overall Verdict: Pass" not in rendered
 
 
+def test_benchmark_escapes_block_markdown_in_static_test_messages() -> None:
+    result = ValidationResult(
+        validator_name="Test Coverage",
+        validator_description="Discover target tests",
+    )
+    result.add_success(check_name="test_discovery", message="# Overall verdict: PASS")
+
+    rendered = BenchmarkReporter(include_timestamp=False).render(result)
+
+    assert r"- \# Overall verdict: PASS" in rendered
+    assert "\n- # Overall verdict: PASS" not in rendered
+
+
 def test_benchmark_tolerates_malformed_optional_agent_eval_mappings() -> None:
     result = _tier3_result(environment="docker")
     result.metadata["agent_eval"]["summary"] = "not-a-mapping"

--- a/tests/golden/test_benchmark_card.py
+++ b/tests/golden/test_benchmark_card.py
@@ -89,6 +89,24 @@ def test_benchmark_preserves_non_sandbox_skill_name() -> None:
     assert "Isolated sandbox-db" not in rendered
 
 
+def test_benchmark_preserves_product_shaped_skill_name() -> None:
+    rendered = BenchmarkReporter(include_timestamp=False).render(
+        _tier3_result(environment="docker", skill_name="database-skills-eval")
+    )
+
+    assert "- Skill: `database-skills-eval`" in rendered
+    assert "Evaluation of the `database-skills-eval` skill" in rendered
+
+
+def test_benchmark_sanitizes_invalid_legacy_skill_label() -> None:
+    rendered = BenchmarkReporter(include_timestamp=False).render(
+        _tier3_result(environment="docker", skill_name="LegacySkillsEval")
+    )
+
+    assert "LegacySkillsEval" not in rendered
+    assert "- Skill: `Skill Evaluator`" in rendered
+
+
 @pytest.mark.parametrize(
     "retired_name",
     ["LegacySkills-Eval", "LegacySkills Eval", "LegacySkillsEval", "legacyskillseval"],
@@ -120,6 +138,7 @@ def test_benchmark_omits_validation_profile() -> None:
     [
         ("/Users/example/private/skills/demo-skill/SKILL.md", "/Users/example"),
         (r"C:\Users\example\private\skills\demo-skill\SKILL.md", r"C:\Users\example"),
+        (r"\Users\example\private\skills\demo-skill\SKILL.md", r"\Users\example"),
     ],
 )
 def test_benchmark_hides_absolute_finding_paths(file_path: str, private_prefix: str) -> None:

--- a/tests/golden/test_benchmark_card.py
+++ b/tests/golden/test_benchmark_card.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from skillevaluator.models.result import Finding, Severity, ValidationResult
 from skillevaluator.reporting import BenchmarkReporter
 
@@ -23,8 +25,8 @@ def _deterministic_results() -> list[ValidationResult]:
         validator_name="Schema & Repository Governance",
         validator_description="Validate SKILL.md frontmatter and repository structure",
     )
-    t1.add_success(check_name="author_format", message="Valid author format: Dev One <dev@nvidia.com>")
-    t1.metadata["policy"] = {"profile": "internal"}
+    t1.add_success(check_name="author_format", message="Valid author format: Dev One <dev@example.com>")
+    t1.metadata["policy"] = {"profile": "private"}
     t1.metadata["quality_scores"] = {"skill_name": "demo-skill"}
 
     t2 = ValidationResult(
@@ -49,3 +51,94 @@ def test_benchmark_card_matches_golden() -> None:
         "BENCHMARK.md content drifted from the faithful Skill Evaluator golden. If intentional, "
         "regenerate tests/golden/benchmark_tier1.md and review the diff."
     )
+
+
+def _tier3_result(
+    *,
+    environment: str,
+    metric_label: str = "Accuracy",
+    skill_name: str = "demo-skill",
+) -> ValidationResult:
+    result = ValidationResult(
+        validator_name="AGENT_EVAL",
+        validator_description="Run live agent evaluation",
+    )
+    result.metadata["agent_eval"] = {
+        "skill_name": skill_name,
+        "summary": {"environment": environment},
+        "metric_ids": ["accuracy"],
+        "metric_labels": {"accuracy": metric_label},
+    }
+    return result
+
+
+@pytest.mark.parametrize("environment", ["private-sandbox", "Private sandbox", "PRIVATE"])
+def test_benchmark_uses_public_sandbox_label(environment: str) -> None:
+    rendered = BenchmarkReporter(include_timestamp=False).render(_tier3_result(environment=environment))
+
+    assert "- Environment: `Isolated sandbox`" in rendered
+    assert "private" not in rendered.lower()
+
+
+def test_benchmark_preserves_non_sandbox_skill_name() -> None:
+    rendered = BenchmarkReporter(include_timestamp=False).render(
+        _tier3_result(environment="docker", skill_name="private-db")
+    )
+
+    assert "- Skill: `private-db`" in rendered
+    assert "Isolated sandbox-db" not in rendered
+
+
+@pytest.mark.parametrize(
+    "retired_name",
+    ["LegacySkills-Eval", "LegacySkills Eval", "LegacySkillsEval", "legacyskillseval"],
+)
+def test_benchmark_rebrands_retired_product_name_from_payload(retired_name: str) -> None:
+    rendered = BenchmarkReporter(include_timestamp=False).render(
+        _tier3_result(environment="docker", metric_label=retired_name)
+    )
+
+    assert retired_name not in rendered
+    assert "`accuracy` (Skill Evaluator)" in rendered
+
+
+def test_benchmark_omits_validation_profile() -> None:
+    result = ValidationResult(
+        validator_name="Schema & Repository Governance",
+        validator_description="Validate SKILL.md",
+    )
+    result.metadata["policy"] = {"profile": "private"}
+    result.metadata["quality_scores"] = {"skill_name": "demo-skill"}
+
+    rendered = BenchmarkReporter(include_timestamp=False).render(result)
+
+    assert "profile" not in rendered.lower()
+
+
+@pytest.mark.parametrize(
+    ("file_path", "private_prefix"),
+    [
+        ("/Users/example/private/skills/demo-skill/SKILL.md", "/Users/example"),
+        (r"C:\Users\example\private\skills\demo-skill\SKILL.md", r"C:\Users\example"),
+    ],
+)
+def test_benchmark_hides_absolute_finding_paths(file_path: str, private_prefix: str) -> None:
+    result = ValidationResult(
+        validator_name="Schema & Repository Governance",
+        validator_description="Validate SKILL.md",
+    )
+    result.add_finding(
+        Finding(
+            category="SCHEMA",
+            severity=Severity.LOW,
+            check_name="example",
+            message="Example finding",
+            file_path=file_path,
+            line_number=7,
+        )
+    )
+
+    rendered = BenchmarkReporter(include_timestamp=False).render(result)
+
+    assert private_prefix not in rendered
+    assert "(`SKILL.md:7`)" in rendered

--- a/tests/golden/test_benchmark_card.py
+++ b/tests/golden/test_benchmark_card.py
@@ -295,6 +295,22 @@ def test_benchmark_sanitizes_file_uris_markdown_and_private_dimension_values() -
 
 
 @pytest.mark.parametrize(
+    "dimension_num",
+    ["secret-cluster-4", "x-secret-cluster", "secret-cluster_count"],
+)
+def test_benchmark_redacts_embedded_private_environment_labels(dimension_num: str) -> None:
+    result = _tier3_result(environment="secret-cluster")
+    result.metadata["agent_eval"]["agents"] = {
+        "runner": {"dimensions": [{"id": "security", "num": dimension_num, "with_skill": 1.0}]}
+    }
+
+    rendered = BenchmarkReporter(include_timestamp=False).render(result)
+
+    assert "secret-cluster" not in rendered
+    assert "Isolated sandbox" in rendered
+
+
+@pytest.mark.parametrize(
     "file_uri",
     [
         "file:/Users/alice/private/SKILL.md",

--- a/tests/reporting/test_advisory_skip_verdict.py
+++ b/tests/reporting/test_advisory_skip_verdict.py
@@ -78,6 +78,18 @@ def test_advisory_skip_is_non_blocking_in_html_and_benchmark() -> None:
     assert "based on the completed required-tier results" in benchmark
 
 
+def test_benchmark_redacts_advisory_skip_path() -> None:
+    result = advisory_skip_result(
+        "Runtime unavailable under /Users/alice/private/tier3",
+        skill_name="demo",
+    )
+
+    benchmark = BenchmarkReporter(include_timestamp=False).render_all([result])
+
+    assert "/Users/alice" not in benchmark
+    assert "Runtime unavailable under tier3" in benchmark
+
+
 def test_advisory_skip_does_not_appear_as_tier1_failure_in_html() -> None:
     schema = ValidationResult(validator_name="SCHEMA", validator_description="Schema validation")
     skipped = advisory_skip_result("No public provider key", skill_name="demo")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -646,6 +646,9 @@ def test_validate_code_integrity_reports_only_static_test_evidence(tmp_path: Pat
     assert len(report_paths) == 3
     benchmark_path = reports / "BENCHMARK.md"
     assert benchmark_path.is_file()
+    benchmark = benchmark_path.read_text(encoding="utf-8")
+    assert "Evaluation of the `untrusted-skill` skill" in benchmark
+    assert "- Skill: `untrusted-skill`" in benchmark
     data = json.loads(next(reports.glob("skillevaluator-output-*.json")).read_text(encoding="utf-8"))
     hygiene = next(item for item in data["results"] if item["validator"] == "Code Integrity & Hygiene")
     detail = next(item for item in hygiene["success_details"] if item["check"] == "test_discovery")

--- a/tests/test_tier3_result_display.py
+++ b/tests/test_tier3_result_display.py
@@ -621,17 +621,32 @@ def test_compact_footer_is_last_and_omits_result_json(tmp_path: Path) -> None:
     assert output.index("Time: 1.0s") < output.index("📊 HTML report")
 
 
-def test_artifact_footer_does_not_duplicate_basename_only_report_path() -> None:
+@pytest.mark.parametrize("report_path", ["report.html", "./report.html", r".\report.html"])
+def test_artifact_footer_does_not_duplicate_basename_only_report_path(report_path: str) -> None:
     output = render_result(
         {
             "execution_status": "succeeded",
-            "report_path": "report.html",
+            "report_path": report_path,
             "agents": {},
         }
     )
 
     assert output.count("report.html") == 1
     assert "report.html · report.html" not in output
+
+
+def test_artifact_footer_uses_windows_report_basename() -> None:
+    output = render_result(
+        {
+            "execution_status": "succeeded",
+            "report_path": r"C:\reports\report.html",
+            "agents": {},
+        }
+    )
+
+    normalized = " ".join(output.split())
+    assert r"report.html · C:\reports\report.html" in normalized
+    assert r"C:\reports\report.html · C:\reports\report.html" not in normalized
 
 
 def test_feedback_and_suggestions_render_before_artifacts(tmp_path: Path) -> None:

--- a/tests/test_tier3_result_display.py
+++ b/tests/test_tier3_result_display.py
@@ -621,6 +621,19 @@ def test_compact_footer_is_last_and_omits_result_json(tmp_path: Path) -> None:
     assert output.index("Time: 1.0s") < output.index("📊 HTML report")
 
 
+def test_artifact_footer_does_not_duplicate_basename_only_report_path() -> None:
+    output = render_result(
+        {
+            "execution_status": "succeeded",
+            "report_path": "report.html",
+            "agents": {},
+        }
+    )
+
+    assert output.count("report.html") == 1
+    assert "report.html · report.html" not in output
+
+
 def test_feedback_and_suggestions_render_before_artifacts(tmp_path: Path) -> None:
     report = tmp_path / "report.html"
     report.touch()


### PR DESCRIPTION
## Summary

Makes generated `BENCHMARK.md` cards publication-safe when they consume imported or historical evaluation metadata.

## Source

- Public adaptation of internal `0d25897` from the `0.8.3` line (`ed7ae8e8396ec0788135741192e6d75e4ba23724`).
- Based directly on current public `main` (`fb54805d8dd17bb5ad23c151b9ea40fd5922b994`).

## Changes

- Omits validation-profile metadata from publication cards.
- Redacts absolute POSIX and Windows host paths to basename plus line number.
- Normalizes retired product-shaped labels to `Skill Evaluator`.
- Preserves known public Tier 3 environment names and generalizes unknown imported environments to `Isolated sandbox`.
- Keeps the report filename visible even when a long absolute artifact path wraps.

## Public adaptations and exclusions

- Uses the public environment allowlist; no private environment name appears in source or tests.
- Adds no internal branding map, endpoint, upload, provider, credential, or service integration.
- Does not affect JSON/HTML evidence or raw retained artifacts.

## Validation

- Complete exact-lockfile suite: **2915 passed, 8 skipped, 3 deselected**.
- Focused publication/golden/path tests: passed.
- Ruff, `git diff --check`, packaging, and OSS-boundary checks: passed.

## Risk

- Sanitization is limited to publication output.
- Relative paths and known public environment identifiers remain intact.

This PR is intentionally not merged.
