### PR TITLE
feat(validate): add explicit Tier 2 and Tier 3 gating controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ All notable changes to Skill Evaluator are documented in this file.
 
 ### Changed
 
+- Added explicit `--block-on-dedup` and `--block-on-agent-eval` controls with
+  backward-compatible public defaults, Tier 3 source preflight, and consistent
+  gating metadata across CLI, JSON, Markdown, and HTML reports.
 - Changed the public OpenAI default to `gpt-5.4-mini` and the NVIDIA Build
   default to `nvidia/nemotron-3-nano-30b-a3b`; OpenCode, Codex, and experimental
   Claude Code now resolve that Build default without redundant model flags.

--- a/README.md
+++ b/README.md
@@ -96,11 +96,13 @@ flowchart LR
 Deterministic checks run offline after their scanner binaries are installed —
 this is the everyday command and a ready-made CI gate (`validate` exits
 non-zero when a check fails or required scanner evidence is incomplete). Plain
-`validate` also runs the Tier 2 dedup pass by default, skipping it
-gracefully when no key is configured:
+`validate` also runs the blocking Tier 2 dedup pass by default, skipping it
+gracefully when no key is configured. Use `--no-block-on-dedup` to keep Tier 2
+findings advisory without disabling the scan:
 
 ```bash
 skillevaluator validate ./my-skill --no-dedup   # all offline checks
+skillevaluator validate ./my-skill --no-block-on-dedup
 skillevaluator security-scan ./my-skill         # one category at a time
 skillevaluator rubric-eval ./my-skill           # LLM-as-judge scoring — the one Tier 1 command that needs a provider key
 ```
@@ -201,6 +203,11 @@ instead. Set `SKILLEVALUATOR_LOCAL_STRICT_READS=1` for deny-all reads with only
 selected runtime/system exceptions. On Linux/macOS, unsandboxed local execution
 requires explicitly opting into trusted mode. Cloud backends are available
 through the same `--env-mode` flag.
+
+When attached to the combined pipeline with `validate --tier3`, Tier 3 is
+advisory by default. Add `--block-on-agent-eval` to make Tier 3 findings or an
+invalid task source fail the validation exit code. Reports record the effective
+gating choice for each tier.
 
 `claude` is accepted as a convenience alias in agent lists, model overrides,
 and `evals/config.yml`. Skill Evaluator canonicalizes it to `claude-code`, so

--- a/docs/tier1-validation.mdx
+++ b/docs/tier1-validation.mdx
@@ -42,7 +42,7 @@ Tier 1 is exposed through one umbrella command and five standalone commands:
 
 | Command | Purpose |
 | --- | --- |
-| `validate` | Run the selected Tier 1 checks, Tier 2 deduplication by default, and optional advisory Tier 3 evaluation |
+| `validate` | Run blocking Tier 1 and Tier 2 checks by default, with optional Tier 3 evaluation |
 | `quality-check` | Score skill quality across four weighted categories |
 | `rubric-eval` | Run the nine-criterion LLM-as-judge rubric |
 | `security-scan` | Run SkillSpector static scanning and optional LLM analysis |
@@ -63,9 +63,10 @@ skillevaluator validate ./my-skill --llm      # + LLM security analysis
 ```
 
 `validate` is the umbrella command: Tier 1 checks gate the exit code (non-zero
-on failure or incomplete required scanner evidence), Tier 2 dedup runs by
-default and degrades gracefully without embedding access, and Tier 3 can be
-attached with `--agent-eval` as an advisory pass.
+on failure or incomplete required scanner evidence), Tier 2 dedup runs and
+gates by default, and Tier 3 can be attached with `--agent-eval` as an advisory
+pass. Use `--no-block-on-dedup` to make Tier 2 advisory, or
+`--block-on-agent-eval` to make Tier 3 gate.
 
 ## Skill Detection and Selection
 
@@ -409,7 +410,8 @@ skillevaluator validate ./my-skill -r cli,json,html -o reports/
 
 ## Using validate in CI
 
-`validate` returns a non-zero exit code when a Tier 1 gate fails, and the
+`validate` returns a non-zero exit code when a Tier 1 or default Tier 2 gate
+fails. Tier 3 remains advisory unless `--block-on-agent-eval` is supplied. The
 Markdown report can be posted directly as a PR comment:
 
 ```yaml

--- a/docs/tier3-live-evaluation.mdx
+++ b/docs/tier3-live-evaluation.mdx
@@ -92,13 +92,15 @@ runs; `report.html`, `result.json`, and collected summaries remain. Pass
 
 | Use case | Command | When to use |
 | --- | --- | --- |
-| Full validation | `skillevaluator validate ./my-skill --agent-eval` | Add advisory Tier 3 results after the standard validation stages |
+| Full validation | `skillevaluator validate ./my-skill --agent-eval` | Add Tier 3 results after the standard validation stages |
 | Focused evaluation | `skillevaluator tier3 evaluate ./my-skill --agents codex` | Iterate on datasets, agents, environments, and grading settings |
 
 Tier 3 remains advisory when attached to `validate`: it is included in the
-combined reports but does not change the validation exit code. Focused live
-evaluation still requires the provider and agent credentials needed by the
-selected setup.
+combined reports but does not change the validation exit code. Add
+`--block-on-agent-eval` to make a failed run or missing/invalid task source
+block. The JSON, HTML, and Markdown reports record the effective policy digest,
+per-tier gating mode, and Tier 3 applicability. Focused live evaluation still
+requires the provider and agent credentials needed by the selected setup.
 
 ## Prerequisites and Credentials
 

--- a/src/skillevaluator/cli.py
+++ b/src/skillevaluator/cli.py
@@ -429,16 +429,32 @@ def _run_agent_eval_or_skip(
     copy_repo: bool = False,
     timeout_multiplier: float | None = None,
     harbor_keep_jobs: bool = False,
+    block_on_agent_eval: bool = False,
+    validate_source: bool = True,
     progress_reporter=None,
 ) -> ValidationResult:
     """Run Tier 3 live agent evaluation and fold the result into the combined report.
 
     Returns an ``AGENT_EVAL`` :class:`ValidationResult` carrying the canonical
-    ``metadata["agent_eval"]`` payload on success, or a non-blocking advisory
-    result describing why Tier 3 could not run. Tier 3 is always advisory: it is
-    reported in the combined HTML/JSON/BENCHMARK.md but never gates the
-    ``validate`` exit code.
+    ``metadata["agent_eval"]`` payload on success, or a structured result
+    describing why Tier 3 could not run. Tier 3 remains advisory by default,
+    and callers can opt into blocking behavior.
     """
+    if validate_source:
+        from skillevaluator.evaluation.tier3_report import dataset_required_result
+        from skillevaluator.tier3.evals_spec import validate_tier3_source
+
+        source_kind, source_checks = validate_tier3_source(target_path)
+        source_errors = [check for check in source_checks if check.status in {"missing", "error"}]
+        if source_errors:
+            return dataset_required_result(
+                target_path / "evals" / "evals.json",
+                source_errors,
+                blocking=block_on_agent_eval,
+                skill_name=target_path.name,
+                source_kind=source_kind,
+            )
+
     from skillevaluator.evaluation import EvaluationOptions, EvaluationService
     from skillevaluator.evaluation.tier3_report import (
         advisory_skip_result,
@@ -471,8 +487,9 @@ def _run_agent_eval_or_skip(
         else:
             engine_result = service.evaluate(options)
     except Exception as exc:
-        # Tier 3 is advisory: degrade any evaluation error to a non-blocking
-        # note rather than aborting the whole validate pipeline.
+        # Preserve a reportable Tier 3 result rather than aborting after the
+        # earlier tiers have already completed. The caller's gating metadata
+        # decides whether this failure is advisory or blocking.
         return advisory_skip_result(
             f"Tier 3 live evaluation skipped: {exc}",
             skill_name=target_path.name,
@@ -731,9 +748,9 @@ def _finish_pipeline_view(
 
     if not gate_failed:
         ran = sum(1 for block in view.blocks if block.status not in ("pending", "skip"))
-        advisory_failed = any(block.status == "fail" and block.number == 3 for block in view.blocks)
+        advisory_failed = any(block.status == "fail" and block.number in {2, 3} for block in view.blocks)
         if advisory_failed:
-            headline = "gating tiers passed · Tier 3 reported errors (advisory — see report)"
+            headline = "gating tiers passed · advisory tier reported findings (see report)"
         else:
             headline = f"all {ran} tier{'s' if ran != 1 else ''} passed"
             lift = summary.get("overall_lift")
@@ -746,7 +763,11 @@ def _finish_pipeline_view(
     if failed:
         first = failed[0].validator_name or "validation"
         extra = f" (+{len(failed) - 1} more)" if len(failed) > 1 else ""
-        headline = f"{first}{extra} failed"
+        tier_no = int(
+            (failed[0].metadata.get("gating") or {}).get("tier")
+            or 1
+        )
+        headline = f"{first}{extra} failed in Tier {tier_no}"
     else:
         headline = "validation failed"
     rerun = _rerun_hint(target_path, agent_eval)
@@ -902,13 +923,27 @@ def _print_run_banner(target_path: Path, content_type: str, profile: str | None)
     "gracefully without public embedding access. Use --no-tier2 (or --no-dedup) to disable.",
 )
 @click.option(
+    "--block-on-dedup/--no-block-on-dedup",
+    default=None,
+    cls=GroupedOption,
+    help_group=_TIER2_GROUP,
+    help="Make Tier 2 findings gate the exit code. Default: blocking.",
+)
+@click.option(
     "--tier3",
     "--agent-eval",
     "agent_eval",
     is_flag=True,
     cls=GroupedOption,
     help_group=_TIER3_GROUP,
-    help="Also run Tier 3 live agent evaluation (requires evals/evals.json).",
+    help="Also run Tier 3 live agent evaluation (requires a valid eval dataset or native Harbor source).",
+)
+@click.option(
+    "--block-on-agent-eval/--no-block-on-agent-eval",
+    default=None,
+    cls=GroupedOption,
+    help_group=_TIER3_GROUP,
+    help="Make Tier 3 findings gate the exit code. Default: advisory.",
 )
 @click.option(
     "--autopilot",
@@ -1058,7 +1093,9 @@ def validate(
     external: bool,
     policy_path: Path | None,
     dedup: bool,
+    block_on_dedup: bool | None,
     agent_eval: bool,
+    block_on_agent_eval: bool | None,
     autopilot: bool,
     agents: str,
     env_mode: str,
@@ -1082,8 +1119,9 @@ def validate(
     """Validate a skill, rule, workflow, or plugin (Tier 1, with optional Tier 2/Tier 3).
 
     Runs Tier 1 static, security, and quality checks (which gate the exit code),
-    plus Tier 2 deduplication by default. Add --agent-eval for advisory Tier 3
-    live agent evaluation. Reports are written per --report and --output-dir.
+    plus blocking Tier 2 deduplication by default. Add --agent-eval for
+    advisory Tier 3 live evaluation, or --block-on-agent-eval to make it gate.
+    Reports are written per --report and --output-dir.
 
     A plugin (a bundle-reference ``agent_plugin.yaml``/``.yml`` manifest or a
     contained ``.claude-plugin/plugin.json`` manifest) is auto-detected and
@@ -1113,6 +1151,9 @@ def validate(
         policy = resolve_policy(profile=profile_name, policy_path=policy_path)
     except (FileNotFoundError, ValueError) as exc:
         raise click.ClickException(str(exc)) from exc
+
+    block_on_dedup_effective = True if block_on_dedup is None else block_on_dedup
+    block_on_agent_eval_effective = False if block_on_agent_eval is None else block_on_agent_eval
 
     resolved_type = content_type if content_type != "auto" else detect_content_type(target_path)
 
@@ -1211,6 +1252,8 @@ def validate(
         apply_policy(results, policy)
     tier1_ok, tier1_rows = summarize_tier1(results, lineup=check_lineup)
     view.tier_done(0, failed=not tier1_ok, rows=tier1_rows)
+    tier1_gate_results = list(results)
+    tier2_gate_results: list[ValidationResult] = []
 
     if dedup and not (fail_fast and not continue_on_failure and tier1_raw_failed):
         if not quiet:
@@ -1219,6 +1262,7 @@ def validate(
         view.tier_progress(tier2_index, [stage_hint_row("stages", "chunk · embed · cluster · llm-judge")])
         tier2_results = _run_dedup_or_skip(target_path)
         results.extend(tier2_results)
+        tier2_gate_results.extend(tier2_results)
         if quiet:
             apply_policy(tier2_results, policy)
         tier2_ran, tier2_ok, tier2_rows, tier2_skip = summarize_tier2(tier2_results)
@@ -1229,12 +1273,9 @@ def validate(
     elif dedup:
         view.tier_skip(tier2_index, "skipped after Tier 1 failure (fail-fast)")
 
-    # Tier 1 (and Tier 2) gate the exit code; Tier 3 is advisory. Snapshot the
-    # gating set before Tier 3 is appended so a non-PASS live-eval verdict is
-    # reported in the combined report but never changes the exit code
-    # emit_reports applies the policy in
-    # place, so these same objects carry the finalized pass/fail afterward.
-    tier_gate_results = list(results)
+    # Preserve the pre-Tier 3 results for progressive output. Final gate
+    # membership is resolved from the explicit tri-state options below.
+    tier_gate_results = [*tier1_gate_results, *tier2_gate_results]
 
     # Flush Tier 1 + Tier 2 results to the terminal BEFORE the long-running
     # Tier 3 agent evaluation so they stay visible in CI logs even when Tier 3
@@ -1308,6 +1349,8 @@ def validate(
             copy_repo=copy_repo,
             timeout_multiplier=timeout_multiplier,
             harbor_keep_jobs=harbor_keep_jobs,
+            block_on_agent_eval=block_on_agent_eval_effective,
+            validate_source=resolved_type == CONTENT_TYPE_SKILL,
             progress_reporter=reporter,
         )
         results.append(tier3_result)
@@ -1321,6 +1364,37 @@ def validate(
             view.tier_done(tier3_index, failed=not tier3_ok, rows=[*tier3_config_rows[3:], *tier3_rows])
         else:
             view.tier_skip(tier3_index, tier3_skip)
+
+    for result in tier1_gate_results:
+        result.metadata["gating"] = {"tier": 1, "blocking": True}
+    for result in tier2_gate_results:
+        result.metadata["gating"] = {
+            "tier": 2,
+            "blocking": block_on_dedup_effective and not bool(result.metadata.get("advisory_tier2")),
+        }
+    if tier3_result is not None:
+        source_kind = "plugin"
+        if resolved_type == CONTENT_TYPE_SKILL:
+            from skillevaluator.tier3.evals_spec import validate_tier3_source
+
+            source_kind, _source_checks = validate_tier3_source(target_path)
+        tier3_result.metadata.setdefault(
+            "tier3_applicability",
+            {
+                "applicability": "required",
+                "reason_code": "tier3_source_present",
+                "source_kind": source_kind,
+            },
+        )
+        agent_eval_payload = tier3_result.metadata.get("agent_eval")
+        if isinstance(agent_eval_payload, dict):
+            agent_eval_payload.setdefault("applicability", "required")
+            agent_eval_payload.setdefault("reason_code", "tier3_source_present")
+            agent_eval_payload.setdefault("source_kind", source_kind)
+        tier3_result.metadata["gating"] = {"tier": 3, "blocking": block_on_agent_eval_effective}
+
+    # Reporters and the exit gate consume the same finalized result objects.
+    apply_policy(results, policy)
 
     content_label = {
         CONTENT_TYPE_SKILL: "Skill",
@@ -1360,11 +1434,18 @@ def validate(
         output_dir.mkdir(parents=True, exist_ok=True)
         BenchmarkReporter().save(results, output_dir / BENCHMARK_FILENAME)
 
-    gate_failed = not all(r.passed for r in tier_gate_results)
+    effective_gate_results = list(tier1_gate_results)
+    if block_on_dedup_effective:
+        effective_gate_results.extend(
+            result for result in tier2_gate_results if not (result.metadata or {}).get("advisory_tier2")
+        )
+    if tier3_result is not None and block_on_agent_eval_effective:
+        effective_gate_results.append(tier3_result)
+    gate_failed = not all(result.passed for result in effective_gate_results)
     if quiet:
         _finish_pipeline_view(
             view,
-            tier_gate_results=tier_gate_results,
+            tier_gate_results=effective_gate_results,
             tier3_result=tier3_result,
             gate_failed=gate_failed,
             output_dir=output_dir,

--- a/src/skillevaluator/evaluation/tier3_report.py
+++ b/src/skillevaluator/evaluation/tier3_report.py
@@ -33,7 +33,7 @@ from skillevaluator.constants import (
     DIMENSION_HINTS,
     DIMENSION_MAPPING,
 )
-from skillevaluator.models.result import ValidationResult
+from skillevaluator.models.result import Finding, Severity, ValidationResult
 
 # Verdict labels mirror Skill Evaluator's AGENT_EVAL_VERDICT_* values so the ported
 # reporters classify the overall outcome identically.
@@ -261,6 +261,96 @@ def advisory_skip_result(message: str, *, skill_name: str | None = None) -> Vali
     # The caller keeps Tier 3 outside the CLI exit gate.  The result itself must
     # still tell reporters that no live evaluation succeeded.
     result.passed = False
+    return result
+
+
+def dataset_required_result(
+    dataset_path: Path,
+    checks: list[Any],
+    *,
+    blocking: bool,
+    skill_name: str,
+    source_kind: str,
+) -> ValidationResult:
+    """Return a policy-aware outcome for an unusable Tier 3 task source."""
+    suggestion = f"Create or fix the Tier 3 source under {dataset_path.parent} and rerun validation."
+    if blocking:
+        message = "Tier 3 is configured as blocking, but no valid Tier 3 task source was found."
+        severity = Severity.HIGH
+        verdict = VERDICT_FAIL
+        applicability = "required"
+        execution_status = "failed"
+    else:
+        message = (
+            "Tier 3 was requested but no valid task source was found. "
+            "Tier 3 is advisory unless --block-on-agent-eval is enabled."
+        )
+        severity = Severity.LOW
+        verdict = VERDICT_NEUTRAL
+        applicability = "not_required"
+        execution_status = "not_applicable"
+
+    serialized_checks = [
+        {
+            "path": str(getattr(check, "path", "")),
+            "status": str(getattr(check, "status", "error")),
+            "message": str(getattr(check, "message", check)),
+        }
+        for check in checks
+    ]
+    result = ValidationResult(
+        validator_name=_AGENT_EVAL_VALIDATOR,
+        validator_description=_AGENT_EVAL_DESCRIPTION,
+    )
+    result.add_finding(
+        Finding(
+            category="AGENT_EVAL",
+            severity=severity,
+            check_name="eval_dataset_required",
+            message=message,
+            file_path=str(dataset_path),
+            suggestion=suggestion,
+            metadata={"source_kind": source_kind, "source_validation": serialized_checks},
+        )
+    )
+    payload = _advisory_agent_eval_payload(message, skill_name=skill_name)
+    payload.update(
+        {
+            "verdict": verdict,
+            "execution_status": execution_status,
+            "applicability": applicability,
+            "reason_code": "eval_dataset_required",
+            "source_kind": source_kind,
+            "suggestions": [suggestion],
+        }
+    )
+    payload["summary"].update(
+        {
+            "verdict": verdict,
+            "execution_status": execution_status,
+            "applicability": applicability,
+            "reason_code": "eval_dataset_required",
+        }
+    )
+    payload["provenance"].update(
+        {
+            "source": "tier3_source_preflight",
+            "reason": "eval_dataset_required",
+            "advisory": not blocking,
+            "source_kind": source_kind,
+            "source_validation": serialized_checks,
+        }
+    )
+    result.metadata.update(
+        {
+            "agent_eval": payload,
+            "tier3_applicability": {
+                "applicability": applicability,
+                "reason_code": "eval_dataset_required",
+                "source_kind": source_kind,
+            },
+        }
+    )
     return result
 
 

--- a/src/skillevaluator/reporting/base.py
+++ b/src/skillevaluator/reporting/base.py
@@ -354,10 +354,10 @@ def is_advisory_agent_eval_skip(result: ValidationResult) -> bool:
 
 def passes_required_gate(result: ValidationResult) -> bool:
     """Return whether *result* permits the required validation gate to pass."""
-    if result.passed or is_advisory_agent_eval_skip(result):
-        return True
     gating = result.metadata.get("gating") if isinstance(result.metadata, dict) else None
-    return bool(isinstance(gating, dict) and not gating.get("blocking", True))
+    if isinstance(gating, dict):
+        return bool(result.passed or not gating.get("blocking", True))
+    return bool(result.passed or is_advisory_agent_eval_skip(result))
 
 
 class ReporterBase(ABC):

--- a/src/skillevaluator/reporting/base.py
+++ b/src/skillevaluator/reporting/base.py
@@ -354,7 +354,10 @@ def is_advisory_agent_eval_skip(result: ValidationResult) -> bool:
 
 def passes_required_gate(result: ValidationResult) -> bool:
     """Return whether *result* permits the required validation gate to pass."""
-    return result.passed or is_advisory_agent_eval_skip(result)
+    if result.passed or is_advisory_agent_eval_skip(result):
+        return True
+    gating = result.metadata.get("gating") if isinstance(result.metadata, dict) else None
+    return bool(isinstance(gating, dict) and not gating.get("blocking", True))
 
 
 class ReporterBase(ABC):

--- a/src/skillevaluator/reporting/cli.py
+++ b/src/skillevaluator/reporting/cli.py
@@ -23,7 +23,7 @@ from rich.markup import escape as rich_escape
 from rich.panel import Panel
 from rich.table import Table
 
-from skillevaluator.reporting.base import ReporterBase
+from skillevaluator.reporting.base import ReporterBase, passes_required_gate
 from skillevaluator.reporting.harbor_viewer import (
     harbor_evidence_link_text,
     normalize_harbor_viewer_for_display,
@@ -117,7 +117,7 @@ class CLIReporter(ReporterBase):
         console.print()
 
         # Print detailed results for failures
-        failed = [r for r in results if not r.passed and not self._is_advisory_agent_eval_skip(r)]
+        failed = [r for r in results if not passes_required_gate(r)]
         if failed:
             console.print(
                 Panel.fit(
@@ -129,7 +129,7 @@ class CLIReporter(ReporterBase):
             for result in failed:
                 self.render_result(result, console)
 
-        non_blocking = [result for result in results if result.passed and result.findings]
+        non_blocking = [result for result in results if passes_required_gate(result) and result.findings]
         if non_blocking:
             console.print(
                 Panel.fit(
@@ -143,7 +143,7 @@ class CLIReporter(ReporterBase):
 
         # Print overall status
         advisory_skips = [result for result in results if self._is_advisory_agent_eval_skip(result)]
-        required_passed = all(result.passed or self._is_advisory_agent_eval_skip(result) for result in results)
+        required_passed = all(passes_required_gate(result) for result in results)
         if any(result.is_incomplete for result in results):
             console.print("\n[bold yellow][INCOMPLETE] Validation evidence is incomplete[/bold yellow]\n")
         elif required_passed:

--- a/src/skillevaluator/reporting/html.py
+++ b/src/skillevaluator/reporting/html.py
@@ -1100,34 +1100,70 @@ class HTMLReporter(ReporterBase):
             "failed_skills": tier1_display_total_skills - tier1_display_passed_skills,
         }
 
-        # Tier 1 and Tier 2 gate the CLI exit code; Tier 3 remains advisory.
-        # Use each result's finalized ``passed`` state for ``would_block`` so
-        # policy-remapped findings and validator errors match the actual CLI.
-        blocking_results = tier1_results + tier2_results
-        blocking_critical = tier1_summary["critical"] + tier2_summary["critical"]
-        blocking_high = tier1_summary["high"] + tier2_summary["high"]
-        blocking_medium = tier1_summary["medium"] + tier2_summary["medium"]
-        blocking_low = tier1_summary["low"] + tier2_summary["low"]
-        advisory_critical = tier3_summary["critical"]
-        advisory_high = tier3_summary["high"]
-        advisory_medium = tier3_summary["medium"]
-        advisory_low = tier3_summary["low"]
+        # Keep report gating aligned with the exact policy used for the CLI
+        # exit code. Results produced outside ``validate`` retain the public
+        # defaults: Tier 1/Tier 2 block and Tier 3 is advisory.
+        blocking_results: list[ValidationResult] = []
+        advisory_results: list[ValidationResult] = []
+        blocking_tiers: list[str] = []
+        advisory_tiers: list[str] = []
+        for tier_name, tier_results, default_blocking in (
+            ("tier1", tier1_results, True),
+            ("tier2", tier2_results, True),
+            ("tier3", tier3_results, False),
+        ):
+            if not tier_results:
+                (blocking_tiers if default_blocking else advisory_tiers).append(tier_name)
+                continue
+            tier_blocks = False
+            tier_advises = False
+            for result in tier_results:
+                result_gating = result.metadata.get("gating") if isinstance(result.metadata, dict) else None
+                is_blocking = (
+                    bool(result_gating.get("blocking", default_blocking))
+                    if isinstance(result_gating, dict)
+                    else default_blocking
+                )
+                if is_blocking:
+                    blocking_results.append(result)
+                    tier_blocks = True
+                else:
+                    advisory_results.append(result)
+                    tier_advises = True
+            if tier_blocks:
+                blocking_tiers.append(tier_name)
+            if tier_advises:
+                advisory_tiers.append(tier_name)
+
+        def _severity_totals(tier_results: list[ValidationResult]) -> dict[str, int]:
+            totals = {"critical": 0, "high": 0, "medium": 0, "low": 0}
+            for result in tier_results:
+                for finding in result.findings:
+                    severity = (
+                        finding.severity.value
+                        if hasattr(finding.severity, "value")
+                        else str(finding.severity).lower()
+                    )
+                    if severity in totals:
+                        totals[severity] += 1
+            return totals
+
+        blocking_totals = _severity_totals(blocking_results)
+        advisory_totals = _severity_totals(advisory_results)
+        blocking_critical = blocking_totals["critical"]
+        blocking_high = blocking_totals["high"]
+        blocking_medium = blocking_totals["medium"]
+        blocking_low = blocking_totals["low"]
+        advisory_critical = advisory_totals["critical"]
+        advisory_high = advisory_totals["high"]
+        advisory_medium = advisory_totals["medium"]
+        advisory_low = advisory_totals["low"]
         gating = {
-            "blocking_tiers": ["tier1", "tier2"],
-            "advisory_tiers": ["tier3"],
-            "blocking": {
-                "critical": blocking_critical,
-                "high": blocking_high,
-                "medium": blocking_medium,
-                "low": blocking_low,
-            },
-            "advisory": {
-                "critical": advisory_critical,
-                "high": advisory_high,
-                "medium": advisory_medium,
-                "low": advisory_low,
-            },
-            "blocking_findings": blocking_critical + blocking_high,
+            "blocking_tiers": blocking_tiers,
+            "advisory_tiers": advisory_tiers,
+            "blocking": blocking_totals,
+            "advisory": advisory_totals,
+            "blocking_findings": blocking_totals["critical"] + blocking_totals["high"],
             "would_block": any(not result.passed for result in blocking_results),
         }
 

--- a/src/skillevaluator/reporting/json_reporter.py
+++ b/src/skillevaluator/reporting/json_reporter.py
@@ -104,6 +104,29 @@ class JSONReporter(ReporterBase):
             "results": [self._result_to_dict(r) for r in results],
         }
 
+        policy = next(
+            (
+                result.metadata.get("policy")
+                for result in results
+                if isinstance(result.metadata.get("policy"), dict)
+            ),
+            None,
+        )
+        if policy is not None:
+            data["policy"] = policy
+
+        gating_by_tier: dict[str, dict[str, Any]] = {}
+        for result in results:
+            gating = result.metadata.get("gating")
+            if not isinstance(gating, dict) or gating.get("tier") is None:
+                continue
+            tier = str(gating["tier"])
+            tier_entry = gating_by_tier.setdefault(tier, {"blocking": False, "validators": []})
+            tier_entry["blocking"] = bool(tier_entry["blocking"] or gating.get("blocking"))
+            tier_entry["validators"].append(result.validator_name)
+        if gating_by_tier:
+            data["gating"] = {"tiers": gating_by_tier}
+
         # Quality summary from any QUALITY validator results
         quality_results = [r.metadata["quality_scores"] for r in results if r.metadata.get("quality_scores")]
         if quality_results:
@@ -120,6 +143,16 @@ class JSONReporter(ReporterBase):
         tier3_results = [r.metadata["agent_eval"] for r in results if r.metadata.get("agent_eval")]
         if tier3_results:
             data["tier3"] = tier3_results[0]
+            applicability = next(
+                (
+                    result.metadata.get("tier3_applicability")
+                    for result in results
+                    if isinstance(result.metadata.get("tier3_applicability"), dict)
+                ),
+                None,
+            )
+            if applicability is not None:
+                data["tier3_applicability"] = applicability
 
         if self.include_timestamp:
             data["generated_at"] = datetime.now(tz=UTC).isoformat()
@@ -187,6 +220,10 @@ class JSONReporter(ReporterBase):
         rubric = result.metadata.get("rubric_eval")
         if rubric:
             data["rubric_eval"] = rubric
+
+        gating = result.metadata.get("gating")
+        if isinstance(gating, dict):
+            data["gating"] = gating
 
         return data
 

--- a/src/skillevaluator/reporting/markdown.py
+++ b/src/skillevaluator/reporting/markdown.py
@@ -103,6 +103,19 @@ class MarkdownReporter(ReporterBase):
         status = "⚠️ INCOMPLETE" if has_incomplete else "✅ PASSED" if all_passed else "❌ FAILED"
         lines.append(f"**Status:** {status}")
 
+        policy = next(
+            (
+                result.metadata.get("policy")
+                for result in results
+                if isinstance(result.metadata.get("policy"), dict)
+            ),
+            None,
+        )
+        if policy is not None:
+            lines.append(f"**Profile:** {policy.get('profile', 'external')}")
+            if policy.get("digest"):
+                lines.append(f"**Policy digest:** `{policy['digest']}`")
+
         if self.include_timestamp:
             timestamp = datetime.now(tz=UTC).strftime("%B %d, %Y at %I:%M %p UTC")
             lines.append(f"**Generated:** {timestamp}")

--- a/src/skillevaluator/tier3/evals_spec.py
+++ b/src/skillevaluator/tier3/evals_spec.py
@@ -372,6 +372,65 @@ def validate_skillevaluators(skill_path: Path) -> list[CheckResult]:
     return results
 
 
+def validate_tier3_source(skill_path: Path) -> tuple[str, list[CheckResult]]:
+    """Resolve and validate the Tier 3 source selected by a skill."""
+    from skillevaluator.tier3.dataset_utils import find_eval_file
+    from skillevaluator.tier3.evals_config import EvalsConfigError, load_evals_config
+
+    try:
+        config, config_path = load_evals_config(skill_path)
+    except EvalsConfigError as exc:
+        return "invalid", [CheckResult("evals/config.yml", "error", str(exc))]
+
+    configured = str((config.get("harbor") or {}).get("task_source") or "auto")
+    evals_file = find_eval_file(skill_path)
+    native_dir = skill_path / "evals" / "harbor"
+
+    if configured == "auto":
+        if evals_file is not None:
+            source = "evals_json"
+        elif native_dir.is_dir():
+            source = "native_harbor"
+        else:
+            return "missing", [
+                CheckResult(
+                    "evals/",
+                    "error",
+                    "No Tier 3 task source found. Add evals/evals.{json,jsonl,yaml,yml} "
+                    "or an evals/harbor native task source.",
+                )
+            ]
+    else:
+        source = configured
+
+    if source == "evals_json":
+        if evals_file is None:
+            selected_at = str(config_path) if config_path else "the default configuration"
+            return source, [
+                CheckResult(
+                    "evals/evals.json",
+                    "error",
+                    f"Tier 3 source evals_json was selected by {selected_at}, but no supported eval dataset exists.",
+                )
+            ]
+        results = [CheckResult(str(evals_file.relative_to(skill_path)), "ok", "Tier 3 eval dataset found.")]
+        _validate_dataset_contents(evals_file, results)
+        return source, results
+
+    if source == "native_harbor":
+        if not native_dir.is_dir():
+            return source, [
+                CheckResult(
+                    "evals/harbor/",
+                    "error",
+                    "Tier 3 source native_harbor was selected, but evals/harbor does not exist.",
+                )
+            ]
+        return source, validate_harbor_contract(skill_path)
+
+    return "invalid", [CheckResult("evals/config.yml", "error", f"Unsupported Tier 3 task source: {source}")]
+
+
 def validate_harbor_contract(skill_path: Path) -> list[CheckResult]:
     """Validate the BYOT Harbor task contract without mutating user files."""
     results: list[CheckResult] = []

--- a/src/skillevaluator/validators/policy.py
+++ b/src/skillevaluator/validators/policy.py
@@ -21,6 +21,8 @@ overlay), or the ``SKILLEVALUATOR_PROFILE`` environment variable.
 
 from __future__ import annotations
 
+import hashlib
+import json
 import os
 import re
 from collections.abc import Iterable
@@ -64,9 +66,22 @@ class ValidationPolicy:
     """
 
     profile: str = DEFAULT_PROFILE_NAME
+    audience: str = "external"
     author_email_regex: re.Pattern[str] | None = None
     severity_overrides: dict[str, Severity] = field(default_factory=dict)
     source: Path | None = None
+
+    @property
+    def digest(self) -> str:
+        """Return a stable digest for the effective, source-independent policy."""
+        payload = {
+            "profile": self.profile,
+            "audience": self.audience,
+            "author_email_regex": self.author_email_regex.pattern if self.author_email_regex else None,
+            "severity_overrides": {key: value.value for key, value in sorted(self.severity_overrides.items())},
+        }
+        canonical = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+        return f"sha256:{hashlib.sha256(canonical).hexdigest()}"
 
     @property
     def author_shape_regex(self) -> re.Pattern[str]:
@@ -101,6 +116,8 @@ class ValidationPolicy:
         """Serialize for inclusion in reports (read-only summary)."""
         return {
             "profile": self.profile,
+            "audience": self.audience,
+            "digest": self.digest,
             "author_email_regex": (self.author_email_regex.pattern if self.author_email_regex else None),
             "severity_overrides": {k: v.value for k, v in self.severity_overrides.items()},
             "source": str(self.source) if self.source else None,
@@ -192,6 +209,7 @@ def _policy_from_data(
 
     return ValidationPolicy(
         profile=profile_name,
+        audience="external",
         author_email_regex=author_email_regex,
         severity_overrides=severity_overrides,
         source=source,
@@ -247,6 +265,7 @@ def load_policy_file(
 
     return ValidationPolicy(
         profile=custom.profile,
+        audience=base.audience,
         author_email_regex=(custom.author_email_regex if overlay_sets_email_regex else base.author_email_regex),
         severity_overrides=merged_overrides,
         source=path,

--- a/tests/golden/cli_surface.json
+++ b/tests/golden/cli_surface.json
@@ -1611,6 +1611,18 @@
               "type": "boolean"
             },
             {
+              "is_flag": true,
+              "name": "block_on_dedup",
+              "opts": [
+                "--block-on-dedup"
+              ],
+              "param_type": "option",
+              "secondary_opts": [
+                "--no-block-on-dedup"
+              ],
+              "type": "boolean"
+            },
+            {
               "default": "False",
               "is_flag": true,
               "name": "agent_eval",
@@ -1619,6 +1631,18 @@
                 "--tier3"
               ],
               "param_type": "option",
+              "type": "boolean"
+            },
+            {
+              "is_flag": true,
+              "name": "block_on_agent_eval",
+              "opts": [
+                "--block-on-agent-eval"
+              ],
+              "param_type": "option",
+              "secondary_opts": [
+                "--no-block-on-agent-eval"
+              ],
               "type": "boolean"
             },
             {
@@ -2954,6 +2978,18 @@
           "type": "boolean"
         },
         {
+          "is_flag": true,
+          "name": "block_on_dedup",
+          "opts": [
+            "--block-on-dedup"
+          ],
+          "param_type": "option",
+          "secondary_opts": [
+            "--no-block-on-dedup"
+          ],
+          "type": "boolean"
+        },
+        {
           "default": "False",
           "is_flag": true,
           "name": "agent_eval",
@@ -2962,6 +2998,18 @@
             "--tier3"
           ],
           "param_type": "option",
+          "type": "boolean"
+        },
+        {
+          "is_flag": true,
+          "name": "block_on_agent_eval",
+          "opts": [
+            "--block-on-agent-eval"
+          ],
+          "param_type": "option",
+          "secondary_opts": [
+            "--no-block-on-agent-eval"
+          ],
           "type": "boolean"
         },
         {

--- a/tests/reporting/test_advisory_skip_verdict.py
+++ b/tests/reporting/test_advisory_skip_verdict.py
@@ -108,3 +108,32 @@ def test_real_agent_eval_failure_still_fails_required_validation() -> None:
     tier3 = _html_tab(html, "tier3")
     assert re.search(r'tier-card-verdict">\s*FAIL\s*</span>', html)
     assert "Harbor execution failed" in tier3
+
+
+def test_explicit_advisory_gating_keeps_failed_result_non_blocking() -> None:
+    result = ValidationResult(validator_name="AGENT_EVAL")
+    result.add_error("Harbor execution failed")
+    result.metadata["gating"] = {"tier": 3, "blocking": False}
+
+    payload = json.loads(JSONReporter(include_timestamp=False).render_all([result]))
+    html_data = _html_report_data(HTMLReporter(include_timestamp=False).render_all([result]))
+
+    assert payload["overall_status"] == "passed"
+    assert payload["overall_passed"] is True
+    assert payload["gating"]["tiers"]["3"]["blocking"] is False
+    assert html_data["summary"]["status"] == "passed"
+    assert html_data["gating"]["would_block"] is False
+
+
+def test_explicit_blocking_gating_promotes_tier3_failure() -> None:
+    result = ValidationResult(validator_name="AGENT_EVAL")
+    result.add_error("Harbor execution failed")
+    result.metadata["gating"] = {"tier": 3, "blocking": True}
+
+    payload = json.loads(JSONReporter(include_timestamp=False).render_all([result]))
+    html_data = _html_report_data(HTMLReporter(include_timestamp=False).render_all([result]))
+
+    assert payload["overall_status"] == "failed"
+    assert payload["gating"]["tiers"]["3"]["blocking"] is True
+    assert html_data["summary"]["status"] == "failed"
+    assert html_data["gating"]["would_block"] is True

--- a/tests/reporting/test_advisory_skip_verdict.py
+++ b/tests/reporting/test_advisory_skip_verdict.py
@@ -137,3 +137,21 @@ def test_explicit_blocking_gating_promotes_tier3_failure() -> None:
     assert payload["gating"]["tiers"]["3"]["blocking"] is True
     assert html_data["summary"]["status"] == "failed"
     assert html_data["gating"]["would_block"] is True
+
+
+def test_explicit_blocking_gating_overrides_legacy_advisory_skip_shape() -> None:
+    result = advisory_skip_result("Harbor runtime unavailable", skill_name="demo")
+    result.metadata["gating"] = {"tier": 3, "blocking": True}
+
+    payload = json.loads(JSONReporter(include_timestamp=False).render_all([result]))
+    html_data = _html_report_data(HTMLReporter(include_timestamp=False).render_all([result]))
+    markdown = MarkdownReporter(include_timestamp=False).render_all([result])
+    benchmark = BenchmarkReporter(include_timestamp=False).render_all([result])
+
+    assert payload["overall_status"] == "failed"
+    assert payload["overall_passed"] is False
+    assert payload["gating"]["tiers"]["3"]["blocking"] is True
+    assert html_data["summary"]["status"] == "failed"
+    assert html_data["gating"]["would_block"] is True
+    assert "**Status:** ❌ FAILED" in markdown
+    assert "Overall verdict: FAIL" in benchmark

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import json
 import shutil
 from pathlib import Path
 
@@ -505,10 +506,101 @@ def test_run_agent_eval_partial_run_returns_ran_with_errors(monkeypatch, tmp_pat
         skip_baseline=False,
         n_concurrent=None,
         max_agents=None,
+        validate_source=False,
     )
     assert result.passed is False
     assert "1 of 2 agents crashed" in result.errors
     assert (result.metadata or {}).get("execution_status") != "skipped"
+
+
+def test_validate_tier2_default_is_blocking_and_can_be_advisory(monkeypatch) -> None:
+    from skillevaluator import cli as cli_module
+    from skillevaluator.models.result import ValidationResult
+
+    tier1 = ValidationResult(validator_name="SCHEMA")
+    tier1.add_success("schema", "ok")
+
+    def _tier2(*_args, **_kwargs) -> list[ValidationResult]:
+        result = ValidationResult(validator_name="Context Deduplication")
+        result.add_error("dedup failed")
+        return [result]
+
+    monkeypatch.setattr(cli_module, "run_validation", lambda *_args, **_kwargs: [tier1])
+    monkeypatch.setattr(cli_module, "_run_dedup_or_skip", _tier2)
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        blocking = runner.invoke(cli, ["validate", str(FIXTURE), "--checks", "schema"])
+        advisory = runner.invoke(
+            cli,
+            ["validate", str(FIXTURE), "--checks", "schema", "--no-block-on-dedup"],
+        )
+
+    assert blocking.exit_code != 0
+    assert advisory.exit_code == 0, advisory.output
+
+
+def test_validate_missing_tier3_source_respects_blocking_flag(monkeypatch, tmp_path: Path) -> None:
+    from skillevaluator import cli as cli_module
+    from skillevaluator.evaluation import EvaluationService
+    from skillevaluator.models.result import ValidationResult
+
+    skill = tmp_path / "source-skill"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text("---\nname: source-skill\ndescription: test\n---\n")
+    tier1 = ValidationResult(validator_name="SCHEMA")
+    tier1.add_success("schema", "ok")
+    monkeypatch.setattr(cli_module, "run_validation", lambda *_args, **_kwargs: [tier1])
+    monkeypatch.setattr(
+        EvaluationService,
+        "evaluate",
+        lambda *_args, **_kwargs: pytest.fail("source preflight must run before live evaluation"),
+    )
+
+    runner = CliRunner()
+    advisory = runner.invoke(
+        cli,
+        [
+            "validate",
+            str(skill),
+            "--no-tier2",
+            "--tier3",
+            "--verbose",
+            "--report",
+            "json",
+            "--output-dir",
+            str(tmp_path / "advisory"),
+        ],
+    )
+    blocking = runner.invoke(
+        cli,
+        [
+            "validate",
+            str(skill),
+            "--no-tier2",
+            "--tier3",
+            "--block-on-agent-eval",
+            "--verbose",
+            "--report",
+            "json",
+            "--output-dir",
+            str(tmp_path / "blocking"),
+        ],
+    )
+
+    assert advisory.exit_code == 0, advisory.output
+    assert blocking.exit_code != 0
+
+    advisory_report = json.loads(next((tmp_path / "advisory").glob("*.json")).read_text())
+    blocking_report = json.loads(next((tmp_path / "blocking").glob("*.json")).read_text())
+    assert advisory_report["tier3_applicability"]["applicability"] == "not_required"
+    assert advisory_report["tier3"]["verdict"] == "neutral"
+    assert advisory_report["gating"]["tiers"]["3"]["blocking"] is False
+    assert advisory_report["overall_status"] == "passed"
+    assert blocking_report["tier3_applicability"]["applicability"] == "required"
+    assert blocking_report["tier3"]["verdict"] == "fail"
+    assert blocking_report["gating"]["tiers"]["3"]["blocking"] is True
+    assert blocking_report["overall_status"] == "failed"
 
 
 def test_validate_quiet_honors_explicit_report_formats() -> None:

--- a/tests/test_evaluation_service.py
+++ b/tests/test_evaluation_service.py
@@ -557,6 +557,7 @@ def test_combined_evaluate_keeps_exit_advisory_but_result_false_for_empty_engine
         skip_baseline=True,
         n_concurrent=1,
         max_agents=1,
+        validate_source=False,
     )
 
     assert result.passed is False
@@ -589,6 +590,7 @@ def test_combined_evaluate_converts_normalization_error_to_advisory_skip(
         skip_baseline=True,
         n_concurrent=1,
         max_agents=1,
+        validate_source=False,
     )
 
     assert result.passed is False
@@ -632,6 +634,7 @@ def test_combined_evaluate_forwards_results_dir_to_normalizer(
         n_concurrent=1,
         max_agents=1,
         results_dir=results_root,
+        validate_source=False,
     )
 
     assert actual is expected

--- a/tests/tier3/test_tier3_source.py
+++ b/tests/tier3/test_tier3_source.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from skillevaluator.tier3.evals_spec import validate_tier3_source
+
+
+def _skill(tmp_path: Path) -> Path:
+    skill = tmp_path / "source-skill"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text("---\nname: source-skill\ndescription: test\n---\n")
+    return skill
+
+
+def test_source_preflight_reports_missing_source(tmp_path: Path) -> None:
+    source, checks = validate_tier3_source(_skill(tmp_path))
+
+    assert source == "missing"
+    assert any(check.status == "error" for check in checks)
+
+
+def test_source_preflight_accepts_yaml_dataset(tmp_path: Path) -> None:
+    skill = _skill(tmp_path)
+    evals = skill / "evals"
+    evals.mkdir()
+    (evals / "evals.yaml").write_text(
+        "skill_name: source-skill\n"
+        "evals:\n"
+        "  - id: source-001\n"
+        "    prompt: do the thing\n"
+        "    expected_output: the thing is done\n"
+    )
+
+    source, checks = validate_tier3_source(skill)
+
+    assert source == "evals_json"
+    assert not [check for check in checks if check.status in {"missing", "error"}]
+
+
+def test_source_preflight_rejects_empty_dataset(tmp_path: Path) -> None:
+    skill = _skill(tmp_path)
+    evals = skill / "evals"
+    evals.mkdir()
+    (evals / "evals.json").write_text(json.dumps({"skill_name": "source-skill", "evals": []}))
+
+    source, checks = validate_tier3_source(skill)
+
+    assert source == "evals_json"
+    assert any(check.status == "error" and "empty" in check.message.lower() for check in checks)
+
+
+def test_configured_native_source_fails_when_directory_is_missing(tmp_path: Path) -> None:
+    skill = _skill(tmp_path)
+    evals = skill / "evals"
+    evals.mkdir()
+    (evals / "config.yml").write_text("schema_version: 1\nharbor:\n  task_source: native_harbor\n")
+
+    source, checks = validate_tier3_source(skill)
+
+    assert source == "native_harbor"
+    assert any(check.status == "error" and check.path == "evals/harbor/" for check in checks)

--- a/tests/validators/test_policy.py
+++ b/tests/validators/test_policy.py
@@ -56,3 +56,19 @@ def test_policy_validation_and_resolution() -> None:
     )
     with pytest.raises(FileNotFoundError):
         load_profile("missing-profile")
+
+
+def test_public_policy_serialization_has_stable_digest() -> None:
+    policy = default_policy()
+    data = policy.to_dict()
+
+    assert data["audience"] == "external"
+    assert data["digest"].startswith("sha256:")
+    assert policy.digest == default_policy().digest
+
+
+def test_policy_digest_excludes_source_path() -> None:
+    first = ValidationPolicy(profile="external", source=Path("/tmp/one.yaml"))
+    second = ValidationPolicy(profile="external", source=Path("/tmp/two.yaml"))
+
+    assert first.digest == second.digest


### PR DESCRIPTION
## Landing status

This PR merged into the staging branch `naren/tier3-provider-preflight`, **not** into `main`. Its base PR #19 is closed and was intentionally not merged, so the flags and reporting contract below are not available from the current GitHub release line.

Follow-up #49 replays the reviewed gating commits onto current `main`, adds the current Fern and repository documentation, and supersedes this PR for the release line. Review and merge #49 rather than attempting to retarget this already-merged stacked PR.

## Summary

Adds explicit Tier 2 and Tier 3 gating controls and makes CLI, JSON, Markdown, and HTML consume the same finalized gating policy.

## Source and dependency

- Public adaptation of internal `d2ae260` from the `0.8.3` line (`ed7ae8e8396ec0788135741192e6d75e4ba23724`).
- Stacked on #19 for Tier 3 source/contract support.

## Public-compatible behavior

- Tier 1 always blocks.
- Tier 2 remains blocking by default; `--no-block-on-dedup` makes it advisory.
- Tier 3 remains advisory by default; `--block-on-agent-eval` makes it blocking.
- Validates selected YAML/JSON or native Harbor task sources before live execution.
- Records per-tier gating, Tier 3 applicability, public profile metadata, and a source-independent policy digest.

## Adaptations and exclusions

- Does not port internal/external audience switching or internal profile defaults.
- Preserves the existing public exit-code behavior unless users opt into/out of the new controls.
- Adds no managed runtime, internal provider, private endpoint, Milvus, or server behavior.

## Validation

- Complete exact-lockfile suite: **3338 passed, 8 skipped, 3 deselected**.
- Focused flag, source-preflight, policy-digest, and reporter-consistency tests: passed.
- Ruff, CLI golden, `git diff --check`, packaging, and OSS-boundary checks: passed.

## Risk controls

- Reports and process exit use the same result objects after policy application.
- Missing/invalid Tier 3 sources are advisory unless explicitly configured to block.
- Network/runtime failures remain visible even when advisory.
