### PR TITLE
ci: add DCO sign-off check for pull requests

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation. All rights reserved.
+#
+# Verify every commit in a pull request carries a Signed-off-by
+# trailer per the project's DCO requirement (see CONTRIBUTING.md).
+
+name: DCO Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  dco:
+    name: DCO
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR branch with full history
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Verify DCO sign-off on every commit
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          unsigned=()
+          while read -r sha; do
+            if ! git show --format='%(trailers:key=Signed-off-by,valueonly)' -s "$sha" | grep -q .; then
+              subject=$(git show --format='%s' -s "$sha")
+              unsigned+=("$sha $subject")
+            fi
+          done < <(git log --no-merges --format='%H' "$BASE_SHA..$HEAD_SHA")
+
+          if [ ${#unsigned[@]} -gt 0 ]; then
+            echo "::error::Some commits in this PR are missing a Signed-off-by trailer."
+            echo ""
+            echo "Unsigned commits:"
+            printf '  %s\n' "${unsigned[@]}"
+            echo ""
+            echo "To fix, run on your branch:"
+            echo ""
+            echo "  git rebase --signoff origin/main && git push --force-with-lease"
+            echo ""
+            echo "See CONTRIBUTING.md for the full DCO requirement."
+            exit 1
+          fi
+
+          echo "All commits signed off."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to SkillEvaluator are documented in this file.
 
 ### Added
 
+- CI DCO check that fails pull requests whose commits lack a `Signed-off-by`
+  trailer, matching the sign-off requirement in `CONTRIBUTING.md`.
 - Initial public release candidate.
 - Enabled optional semantic-version validation in the default Tier 1 pipeline,
   including a public `--previous-version` monotonic-bump bound.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,8 @@ you confirm that you have the right to contribute it under the
   under the same license, or a compatible license.
 
   - Any contribution which contains commits that are not Signed-Off will not be
-    accepted.
+    accepted. Pull requests are checked in CI by the **DCO** workflow; unsigned
+    commits fail the check.
 
 - To sign off on a commit you simply use the `--signoff` (or `-s`) option when
   committing your changes:


### PR DESCRIPTION
## Summary
- Add a `DCO Check` GitHub Actions workflow (modeled on [NVIDIA/skills](https://github.com/NVIDIA/skills/blob/main/.github/workflows/dco.yml)) that fails PRs when any non-merge commit lacks a `Signed-off-by` trailer.
- Document in `CONTRIBUTING.md` that CI enforces the existing DCO requirement.
- Note the change in `CHANGELOG.md`.

## Follow-up for maintainers
`main` currently has no branch protection rules. After merging, mark **DCO** as a required status check when protection is enabled so unsigned commits cannot bypass review.

## Test plan
- [ ] Confirm this PR’s own commit includes `Signed-off-by` and the new **DCO** check passes
- [ ] Optionally open a throwaway PR with an unsigned commit and confirm **DCO** fails with the rebase remediation hint
- [ ] After merge, add **DCO** as a required check on `main` if/when branch protection is configured