### PR TITLE
fix: replace OSS boundary line allowlist with stable anchors

### DIFF
--- a/config/oss_boundary_allowlist.json
+++ b/config/oss_boundary_allowlist.json
@@ -1,10 +1,10 @@
 {
-  "version": 1,
+  "version": 2,
   "allowlist": [
     {
       "path": "tests/test_oss_packaging.py",
       "rule": "internal-runtime-dependency",
-      "line": 126,
+      "anchor": "public-extra-vector-db",
       "reason": "Negative dependency boundary assertion",
       "expires": "2027-07-08",
       "review_owner": "oss-release-reviewers"
@@ -12,7 +12,7 @@
     {
       "path": "tests/test_oss_packaging.py",
       "rule": "internal-runtime-dependency",
-      "line": 127,
+      "anchor": "public-extra-cluster-runtime",
       "reason": "Negative dependency boundary assertion",
       "expires": "2027-07-08",
       "review_owner": "oss-release-reviewers"
@@ -20,7 +20,7 @@
     {
       "path": "tests/test_oss_packaging.py",
       "rule": "internal-product-name",
-      "line": 128,
+      "anchor": "public-extra-retired-product",
       "reason": "Negative product boundary assertion",
       "expires": "2027-07-08",
       "review_owner": "oss-release-reviewers"
@@ -28,7 +28,7 @@
     {
       "path": "tests/test_oss_packaging.py",
       "rule": "internal-nvidia-credential",
-      "line": 134,
+      "anchor": "source-retired-credential",
       "reason": "Negative credential boundary assertion",
       "expires": "2027-07-08",
       "review_owner": "oss-release-reviewers"
@@ -36,7 +36,7 @@
     {
       "path": "tests/test_oss_packaging.py",
       "rule": "execution-service-integration",
-      "line": 135,
+      "anchor": "source-retired-executor",
       "reason": "Negative execution boundary assertion",
       "expires": "2027-07-08",
       "review_owner": "oss-release-reviewers"
@@ -44,7 +44,7 @@
     {
       "path": "tests/test_oss_packaging.py",
       "rule": "internal-runtime-dependency",
-      "line": 137,
+      "anchor": "source-retired-vector-store",
       "reason": "Negative dependency boundary assertion",
       "expires": "2027-07-08",
       "review_owner": "oss-release-reviewers"
@@ -52,7 +52,7 @@
     {
       "path": "tests/test_oss_packaging.py",
       "rule": "harbor-upload-integration",
-      "line": 456,
+      "anchor": "gitignore-retired-upload-artifact",
       "reason": "Negative upload boundary assertion",
       "expires": "2027-07-08",
       "review_owner": "oss-release-reviewers"
@@ -60,7 +60,7 @@
     {
       "path": "tests/test_oss_packaging.py",
       "rule": "internal-nvidia-credential",
-      "line": 497,
+      "anchor": "docs-retired-credential",
       "reason": "Negative documentation boundary assertion",
       "expires": "2027-07-08",
       "review_owner": "oss-release-reviewers"
@@ -68,7 +68,7 @@
     {
       "path": "tests/test_provider_config.py",
       "rule": "internal-nvidia-credential",
-      "line": 79,
+      "anchor": "provider-retired-credential",
       "reason": "Negative provider credential assertion",
       "expires": "2027-07-08",
       "review_owner": "oss-release-reviewers"
@@ -76,7 +76,7 @@
     {
       "path": "tests/validators/test_security.py",
       "rule": "internal-nvidia-credential",
-      "line": 1409,
+      "anchor": "security-retired-credential",
       "reason": "Negative subprocess credential assertion",
       "expires": "2027-07-08",
       "review_owner": "oss-release-reviewers"

--- a/scripts/check_oss_boundary.py
+++ b/scripts/check_oss_boundary.py
@@ -7,13 +7,16 @@ from __future__ import annotations
 
 import argparse
 import ast
+import io
 import json
 import re
 import shlex
+import stat
 import string
 import subprocess
 import sys
 import tarfile
+import tokenize
 import warnings
 import zipfile
 from collections.abc import Iterable, Iterator
@@ -62,6 +65,8 @@ _BINARY_ROOT_FILES = frozenset({".coverage", ".DS_Store", "Thumbs.db"})
 _PYTHON_SUFFIXES = frozenset({".py", ".pyi", ".pyw"})
 _BASH_ANSI_C_PREFIX = chr(36) + chr(39)
 _BASH_LOCALE_QUOTE_RE = re.compile(r'(?<!\\)\$(?=")')
+_BOUNDARY_ANCHOR_ID_RE = re.compile(r"[a-z][a-z0-9]*(?:-[a-z0-9]+)*\Z")
+_BOUNDARY_ANCHOR_COMMENT_RE = re.compile(r"# oss-boundary-anchor: ([a-z][a-z0-9]*(?:-[a-z0-9]+)*)\Z")
 _HEX_DIGITS = frozenset("0123456789abcdefABCDEF")
 _OCTAL_DIGITS = frozenset("01234567")
 _BASH_COMMON_ESCAPES = {
@@ -92,11 +97,11 @@ class BoundaryFinding(NamedTuple):
 
 
 class BoundaryAllowance(NamedTuple):
-    """One line-specific, justified exception."""
+    """One stable, explicitly anchored, justified exception."""
 
     path: str
     rule: str
-    line: int
+    anchor: str
     reason: str
     expires: date
     review_owner: str
@@ -209,11 +214,13 @@ _AUTHORIZATION_RE = re.compile(
     r"(?i)((?:\"?authorization\"?|auth[_-]?header)\s*[:=]\s*[\"']?(?:bearer|basic)\s+)[^\"'\s,;}]+"
 )
 _MAX_EXCERPT_CHARS = 180
+_SourceSpan = tuple[int, int, int, int]
 
 
 class _ReconstructedCandidate(NamedTuple):
     value: str
     active_token_exempt: bool = False
+    source_span: _SourceSpan | None = None
 
 
 class _StaticReconstructionLimit(ValueError):
@@ -337,6 +344,23 @@ def _character_column(line: str, byte_column: int) -> int:
     return len(line.encode("utf-8")[:byte_column].decode("utf-8"))
 
 
+def _node_source_span(node: ast.AST, lines: list[str]) -> _SourceSpan | None:
+    if (
+        not hasattr(node, "lineno")
+        or node.end_lineno is None
+        or node.end_col_offset is None
+        or node.lineno > len(lines)
+        or node.end_lineno > len(lines)
+    ):
+        return None
+    return (
+        node.lineno,
+        _character_column(lines[node.lineno - 1], node.col_offset),
+        node.end_lineno,
+        _character_column(lines[node.end_lineno - 1], node.end_col_offset),
+    )
+
+
 def _source_ranges_by_line(node: ast.AST, lines: list[str]) -> dict[int, list[tuple[int, int]]]:
     if not hasattr(node, "lineno") or node.end_lineno is None or node.end_col_offset is None:
         return {}
@@ -351,7 +375,7 @@ def _source_ranges_by_line(node: ast.AST, lines: list[str]) -> dict[int, list[tu
 
 def _python_reconstructions(
     text: str,
-) -> tuple[dict[int, set[_ReconstructedCandidate]], dict[int, list[tuple[int, int]]], set[int]]:
+) -> tuple[dict[int, list[_ReconstructedCandidate]], dict[int, list[tuple[int, int]]], set[int]]:
     try:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", SyntaxWarning)
@@ -378,7 +402,7 @@ def _python_reconstructions(
         for line_number, ranges in _source_ranges_by_line(pattern, lines).items():
             defensive_ranges.setdefault(line_number, []).extend(ranges)
 
-    reconstructed: dict[int, set[_ReconstructedCandidate]] = {}
+    reconstructed: dict[int, list[_ReconstructedCandidate]] = {}
     for node in ast.walk(tree):
         try:
             value = _static_string(node)
@@ -387,8 +411,12 @@ def _python_reconstructions(
                 limit_lines.add(node.lineno)
             continue
         if value is not None and hasattr(node, "lineno"):
-            reconstructed.setdefault(node.lineno, set()).add(
-                _ReconstructedCandidate(value, active_token_exempt=id(node) in defensive_node_ids)
+            reconstructed.setdefault(node.lineno, []).append(
+                _ReconstructedCandidate(
+                    value,
+                    active_token_exempt=id(node) in defensive_node_ids,
+                    source_span=_node_source_span(node, lines),
+                )
             )
     return reconstructed, defensive_ranges, limit_lines
 
@@ -498,6 +526,57 @@ def _match_is_inside_ranges(match: re.Match[str], ranges: Iterable[tuple[int, in
     return any(range_start <= start and end <= range_end for range_start, range_end in ranges)
 
 
+def _span_strictly_contains(outer: _SourceSpan, inner: _SourceSpan) -> bool:
+    return outer != inner and outer[:2] <= inner[:2] and inner[2:] <= outer[2:]
+
+
+def _selected_rule_matches(
+    rule: BoundaryRule,
+    candidates: list[_ReconstructedCandidate],
+    *,
+    line_number: int,
+    defensive_ranges: Iterable[tuple[int, int]],
+) -> tuple[re.Match[str], ...]:
+    spanned_matches: dict[_SourceSpan, tuple[re.Match[str], ...]] = {}
+    best_unspanned: tuple[re.Match[str], ...] = ()
+    for index, candidate in enumerate(candidates):
+        if rule.rule_id == "active-internal-token" and candidate.active_token_exempt:
+            continue
+        matches = tuple(
+            match
+            for match in rule.pattern.finditer(candidate.value)
+            if not (
+                rule.rule_id == "active-internal-token"
+                and index == 0
+                and _match_is_inside_ranges(match, defensive_ranges)
+            )
+        )
+        if not matches:
+            continue
+        if index == 0:
+            for match in matches:
+                spanned_matches[(line_number, match.start(), line_number, match.end())] = (match,)
+        elif candidate.source_span is not None:
+            prior = spanned_matches.get(candidate.source_span, ())
+            if len(matches) > len(prior):
+                spanned_matches[candidate.source_span] = matches
+        elif len(matches) > len(best_unspanned):
+            best_unspanned = matches
+
+    if not spanned_matches:
+        return best_unspanned
+
+    precise_matches = tuple(
+        match
+        for span, matches in sorted(spanned_matches.items())
+        if not any(_span_strictly_contains(span, other) for other in spanned_matches)
+        for match in matches
+    )
+    most_matches_in_one_span = max(spanned_matches.values(), key=len)
+    selected = precise_matches if len(precise_matches) >= len(most_matches_in_one_span) else most_matches_in_one_span
+    return best_unspanned if len(best_unspanned) > len(selected) else selected
+
+
 def _shell_failure_finding(path: str, line_number: int, error: _ShellDecodeError) -> BoundaryFinding:
     if isinstance(error, _ShellDecodeLimit):
         return BoundaryFinding(
@@ -542,7 +621,9 @@ def scan_text(path: str, text: str) -> list[BoundaryFinding]:
                 shell_failures.setdefault(failure.rule, failure)
                 continue
             if shell_value is not None and shell_value != candidate.value:
-                candidates.append(_ReconstructedCandidate(shell_value, candidate.active_token_exempt))
+                candidates.append(
+                    _ReconstructedCandidate(shell_value, candidate.active_token_exempt, candidate.source_span)
+                )
         try:
             shell_value = _shell_reconstruction(path, line)
         except _ShellDecodeError as exc:
@@ -553,22 +634,13 @@ def scan_text(path: str, text: str) -> list[BoundaryFinding]:
         if shell_value is not None:
             candidates.append(_ReconstructedCandidate(shell_value))
         for rule in DENY_RULES:
-            selected_match: re.Match[str] | None = None
-            for index, candidate in enumerate(candidates):
-                if rule.rule_id == "active-internal-token" and candidate.active_token_exempt:
-                    continue
-                for match in rule.pattern.finditer(candidate.value):
-                    if (
-                        rule.rule_id == "active-internal-token"
-                        and index == 0
-                        and _match_is_inside_ranges(match, defensive_ranges.get(line_number, ()))
-                    ):
-                        continue
-                    selected_match = match
-                    break
-                if selected_match is not None:
-                    break
-            if selected_match is not None:
+            selected_matches = _selected_rule_matches(
+                rule,
+                candidates,
+                line_number=line_number,
+                defensive_ranges=defensive_ranges.get(line_number, ()),
+            )
+            for selected_match in selected_matches:
                 findings.append(
                     BoundaryFinding(
                         path,
@@ -582,7 +654,7 @@ def scan_text(path: str, text: str) -> list[BoundaryFinding]:
 
 
 def load_allowlist(path: Path | None) -> tuple[BoundaryAllowance, ...]:
-    """Load a strict line-specific allowlist; unknown metadata fails closed."""
+    """Load a strict anchor-specific allowlist; unknown metadata fails closed."""
     if path is None:
         return ()
     try:
@@ -590,28 +662,28 @@ def load_allowlist(path: Path | None) -> tuple[BoundaryAllowance, ...]:
     except (OSError, json.JSONDecodeError) as exc:
         raise ValueError(f"could not load OSS boundary allowlist {path}: {exc}") from exc
 
-    if not isinstance(payload, dict) or set(payload) != {"version", "allowlist"} or payload.get("version") != 1:
-        raise ValueError("OSS boundary allowlist must contain only version=1 and allowlist")
+    if not isinstance(payload, dict) or set(payload) != {"version", "allowlist"} or payload.get("version") != 2:
+        raise ValueError("OSS boundary allowlist must contain only version=2 and allowlist")
     entries = payload.get("allowlist")
     if not isinstance(entries, list):
         raise ValueError("OSS boundary allowlist must be a list")
 
     allowances: list[BoundaryAllowance] = []
-    required = {"path", "rule", "line", "reason", "expires", "review_owner"}
+    required = {"path", "rule", "anchor", "reason", "expires", "review_owner"}
     known_rules = {rule.rule_id for rule in DENY_RULES}
+    seen_anchors: set[str] = set()
     for index, entry in enumerate(entries):
         if not isinstance(entry, dict) or set(entry) != required:
             raise ValueError(
-                f"allowlist entry {index} must contain exactly path, rule, line, reason, expires, and review_owner"
+                f"allowlist entry {index} must contain exactly path, rule, anchor, reason, expires, and review_owner"
             )
         if (
             not isinstance(entry["path"], str)
             or not entry["path"].strip()
             or not isinstance(entry["rule"], str)
             or entry["rule"] not in known_rules
-            or not isinstance(entry["line"], int)
-            or isinstance(entry["line"], bool)
-            or entry["line"] < 1
+            or not isinstance(entry["anchor"], str)
+            or _BOUNDARY_ANCHOR_ID_RE.fullmatch(entry["anchor"]) is None
             or not isinstance(entry["reason"], str)
             or not entry["reason"].strip()
             or not isinstance(entry["expires"], str)
@@ -620,7 +692,7 @@ def load_allowlist(path: Path | None) -> tuple[BoundaryAllowance, ...]:
             or not entry["review_owner"].strip()
         ):
             raise ValueError(
-                f"allowlist entry {index} must contain valid path, rule, line, reason, expires, and review_owner values"
+                f"allowlist entry {index} must contain valid path, rule, anchor, reason, expires, and review_owner values"
             )
         allow_path = PurePosixPath(entry["path"])
         if (
@@ -628,8 +700,19 @@ def load_allowlist(path: Path | None) -> tuple[BoundaryAllowance, ...]:
             or ".." in allow_path.parts
             or not allow_path.parts
             or allow_path.parts[0] != "tests"
+            or allow_path.as_posix() != entry["path"]
+            or allow_path.suffix.lower() not in _PYTHON_SUFFIXES
+            or not allow_path.name.startswith("test_")
         ):
-            raise ValueError(f"allowlist entry {index} is restricted to exact negative test paths")
+            raise ValueError(f"allowlist entry {index} is restricted to exact Python negative test paths")
+        if entry["anchor"] in seen_anchors:
+            raise ValueError(f"allowlist entry {index} duplicates anchor {entry['anchor']!r} for {allow_path}")
+        for rule in DENY_RULES:
+            if rule.pattern.search(entry["anchor"]):
+                raise ValueError(
+                    f"allowlist entry {index} anchor ID matches denied OSS boundary rule {rule.rule_id}"
+                )
+        seen_anchors.add(entry["anchor"])
         try:
             expires = date.fromisoformat(entry["expires"])
         except ValueError as exc:
@@ -640,13 +723,50 @@ def load_allowlist(path: Path | None) -> tuple[BoundaryAllowance, ...]:
             BoundaryAllowance(
                 path=allow_path.as_posix(),
                 rule=entry["rule"],
-                line=entry["line"],
+                anchor=entry["anchor"],
                 reason=entry["reason"].strip(),
                 expires=expires,
                 review_owner=entry["review_owner"].strip(),
             )
         )
     return tuple(allowances)
+
+
+def _boundary_anchors(path: str, text: str) -> dict[int, str]:
+    """Return exact Python comment anchors keyed by their physical line."""
+    archive_member = path.split("!", 1)[1] if "!" in path else path
+    if PurePosixPath(archive_member).suffix.lower() not in _PYTHON_SUFFIXES:
+        return {}
+
+    anchors: dict[int, str] = {}
+    anchor_lines: dict[str, int] = {}
+    try:
+        tokens = tokenize.generate_tokens(io.StringIO(text).readline)
+        for token in tokens:
+            if token.type != tokenize.COMMENT or "oss-boundary-anchor" not in token.string:
+                continue
+            match = _BOUNDARY_ANCHOR_COMMENT_RE.fullmatch(token.string)
+            if match is None:
+                raise ValueError(f"malformed OSS boundary anchor in {path}:{token.start[0]}")
+            if not token.line[: token.start[1]].strip():
+                raise ValueError(f"OSS boundary anchor must follow code in {path}:{token.start[0]}")
+            anchor = match.group(1)
+            if anchor in anchor_lines:
+                raise ValueError(
+                    f"duplicate OSS boundary anchor {anchor!r} in {path}:{anchor_lines[anchor]} and {token.start[0]}"
+                )
+            anchor_lines[anchor] = token.start[0]
+            anchors[token.start[0]] = anchor
+    except (IndentationError, tokenize.TokenError) as exc:
+        raise ValueError(f"could not tokenize Python source {path}: {exc}") from exc
+    if anchors:
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", SyntaxWarning)
+                ast.parse(text)
+        except (SyntaxError, ValueError, RecursionError) as exc:
+            raise ValueError(f"could not parse anchored Python source {path}: {exc}") from exc
+    return anchors
 
 
 def _is_scanned_path(relative_path: str) -> bool:
@@ -702,20 +822,76 @@ def _without_allowances(
     findings: Iterable[BoundaryFinding],
     allowances: Iterable[BoundaryAllowance],
     *,
+    anchors_by_location: dict[tuple[str, int], str] | None = None,
     archive_source_paths: dict[str, str] | None = None,
+    validate_all_allowances: bool = False,
+    validate_all_anchors: bool = False,
+    validate_allowance_paths: set[str] | None = None,
 ) -> list[BoundaryFinding]:
+    findings = tuple(findings)
     entries = tuple(allowances)
+    entries_by_anchor = {(entry.path, entry.anchor): entry for entry in entries}
+    anchors = anchors_by_location or {}
     source_paths = archive_source_paths or {}
 
-    def is_allowed(finding: BoundaryFinding) -> bool:
-        finding_path = finding.path
-        source_path = source_paths.get(finding_path)
+    logical_anchor_lines: dict[tuple[str, str], int] = {}
+    logical_anchor_owners: dict[str, tuple[str, int]] = {}
+    for (actual_path, line), anchor in anchors.items():
+        logical_path = source_paths.get(actual_path, actual_path)
+        anchor_key = (logical_path, anchor)
+        if anchor_key in logical_anchor_lines:
+            raise ValueError(f"duplicate OSS boundary anchor {anchor!r} for {logical_path}")
+        if anchor in logical_anchor_owners:
+            owner_path, owner_line = logical_anchor_owners[anchor]
+            raise ValueError(
+                f"duplicate OSS boundary anchor {anchor!r} in {owner_path}:{owner_line} and {logical_path}:{line}"
+            )
+        logical_anchor_lines[anchor_key] = line
+        logical_anchor_owners[anchor] = (logical_path, line)
+
+    findings_by_anchor: dict[tuple[str, str], list[BoundaryFinding]] = {}
+    for finding in findings:
+        anchor = anchors.get((finding.path, finding.line))
+        if anchor is None:
+            continue
+        logical_path = source_paths.get(finding.path, finding.path)
+        findings_by_anchor.setdefault((logical_path, anchor), []).append(finding)
+
+    paths_to_validate = validate_allowance_paths or set()
+    if validate_all_allowances or validate_all_anchors or validate_allowance_paths is not None:
+        for anchor_key in logical_anchor_lines:
+            if (
+                validate_all_allowances or validate_all_anchors or anchor_key[0] in paths_to_validate
+            ) and anchor_key not in entries_by_anchor:
+                raise ValueError(f"unregistered OSS boundary anchor {anchor_key[1]!r} in {anchor_key[0]}")
         for entry in entries:
-            if finding.rule != entry.rule or finding.line != entry.line:
+            if not validate_all_allowances and entry.path not in paths_to_validate:
                 continue
-            if entry.path in (finding_path, source_path):
-                return True
-        return False
+            anchor_key = (entry.path, entry.anchor)
+            if anchor_key not in logical_anchor_lines:
+                raise ValueError(f"allowlist anchor {entry.anchor!r} is missing from {entry.path}")
+            anchored_findings = findings_by_anchor.get(anchor_key, [])
+            matching_count = sum(finding.rule == entry.rule for finding in anchored_findings)
+            if len(anchored_findings) != 1 or matching_count != 1:
+                raise ValueError(
+                    f"allowlist anchor {entry.anchor!r} in {entry.path} must identify exactly one "
+                    f"{entry.rule} finding and no other findings; found {matching_count} matching and "
+                    f"{len(anchored_findings)} total"
+                )
+
+    def is_allowed(finding: BoundaryFinding) -> bool:
+        anchor = anchors.get((finding.path, finding.line))
+        if anchor is None:
+            return False
+        logical_path = source_paths.get(finding.path, finding.path)
+        entry = entries_by_anchor.get((logical_path, anchor))
+        anchored_findings = findings_by_anchor.get((logical_path, anchor), [])
+        return (
+            entry is not None
+            and entry.rule == finding.rule
+            and len(anchored_findings) == 1
+            and anchored_findings[0] == finding
+        )
 
     return [finding for finding in findings if not is_allowed(finding)]
 
@@ -726,13 +902,22 @@ def scan_repository(root: Path, *, allowlist_path: Path | None = None) -> list[B
     if not root.is_dir():
         raise ValueError(f"repository root is not a directory: {root}")
     findings: list[BoundaryFinding] = []
+    anchors_by_location: dict[tuple[str, int], str] = {}
     for relative, path in _repository_paths(root):
         try:
             text = _decode_text(path.read_bytes(), path=relative)
         except OSError as exc:
             raise ValueError(f"could not read release file {relative}: {exc}") from exc
+        anchors_by_location.update(
+            ((relative, line), anchor) for line, anchor in _boundary_anchors(relative, text).items()
+        )
         findings.extend(scan_text(relative, text))
-    return _without_allowances(findings, load_allowlist(allowlist_path))
+    return _without_allowances(
+        findings,
+        load_allowlist(allowlist_path),
+        anchors_by_location=anchors_by_location,
+        validate_all_allowances=True,
+    )
 
 
 def _validated_archive_member_path(member_name: str, *, expected_root: str | None = None) -> str:
@@ -779,10 +964,18 @@ def _zip_members(path: Path) -> Iterator[tuple[str, str, bytes]]:
         optional_zstandard = getattr(zipfile, "ZIP_ZSTANDARD", None)
         if optional_zstandard is not None:
             supported_compression.add(optional_zstandard)
+        seen_source_paths: set[str] = set()
         for info in infos:
             source_path = _validated_archive_member_path(info.filename)
+            if source_path in seen_source_paths:
+                raise ValueError(f"duplicate archive member path {source_path}")
+            seen_source_paths.add(source_path)
             if info.flag_bits & 0x1:
                 raise ValueError(f"archive contains encrypted ZIP member {info.filename}")
+            if info.create_system == 3:
+                file_type = stat.S_IFMT(info.external_attr >> 16)
+                if file_type not in {0, stat.S_IFREG, stat.S_IFDIR}:
+                    raise ValueError(f"archive contains unsupported ZIP member {info.filename}")
             if not info.is_dir() and info.compress_type not in supported_compression:
                 raise ValueError(f"archive contains unsupported ZIP member {info.filename}")
             if info.is_dir() or not _is_archive_text(info.filename):
@@ -801,8 +994,12 @@ def _tar_members(path: Path) -> Iterator[tuple[str, str, bytes]]:
     with tarfile.open(path, "r:*") as archive:
         member_count = 0
         total_size = 0
+        seen_source_paths: set[str] = set()
         for info in archive:
             source_path = _validated_archive_member_path(info.name, expected_root=expected_root)
+            if source_path in seen_source_paths:
+                raise ValueError(f"duplicate archive member path {source_path or info.name}")
+            seen_source_paths.add(source_path)
             member_count += 1
             if member_count > _MAX_ARCHIVE_MEMBERS:
                 raise ValueError(f"archive exceeds the member count limit of {_MAX_ARCHIVE_MEMBERS}")
@@ -812,7 +1009,11 @@ def _tar_members(path: Path) -> Iterator[tuple[str, str, bytes]]:
                     raise ValueError(
                         f"archive exceeds the aggregate decompressed size limit of {_MAX_ARCHIVE_BYTES} bytes"
                     )
-            if not info.isfile() or not _is_archive_text(info.name):
+            if info.isdir():
+                continue
+            if not info.isfile():
+                raise ValueError(f"archive contains unsupported TAR member {info.name}")
+            if not _is_archive_text(info.name):
                 continue
             if info.size > _MAX_MEMBER_BYTES:
                 raise ValueError(f"archive member {info.name} exceeds the scan limit")
@@ -824,21 +1025,31 @@ def _tar_members(path: Path) -> Iterator[tuple[str, str, bytes]]:
 def scan_archive(path: Path, *, allowlist_path: Path | None = None) -> list[BoundaryFinding]:
     """Scan a wheel or source distribution in memory without extracting it."""
     path = path.resolve()
+    allowances = load_allowlist(allowlist_path)
     try:
         members = _zip_members(path) if zipfile.is_zipfile(path) else _tar_members(path)
         findings: list[BoundaryFinding] = []
+        anchors_by_location: dict[tuple[str, int], str] = {}
         archive_source_paths: dict[str, str] = {}
         for member_name, source_path, data in members:
             finding_path = f"{path}!{member_name}"
             archive_source_paths[finding_path] = source_path
             text = _decode_text(data, path=finding_path)
+            anchors_by_location.update(
+                ((finding_path, line), anchor) for line, anchor in _boundary_anchors(finding_path, text).items()
+            )
             findings.extend(scan_text(finding_path, text))
     except (OSError, tarfile.TarError, zipfile.BadZipFile) as exc:
         raise ValueError(f"could not scan distribution {path}: {exc}") from exc
+    present_source_paths = set(archive_source_paths.values())
+    configured_present_paths = {entry.path for entry in allowances if entry.path in present_source_paths}
     return _without_allowances(
         findings,
-        load_allowlist(allowlist_path),
+        allowances,
+        anchors_by_location=anchors_by_location,
         archive_source_paths=archive_source_paths,
+        validate_all_anchors=True,
+        validate_allowance_paths=configured_present_paths,
     )
 
 

--- a/tests/test_oss_boundary.py
+++ b/tests/test_oss_boundary.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import shutil
+import stat
 import struct
 import subprocess
 import tarfile
@@ -110,11 +111,12 @@ def test_generic_public_and_defensive_text_is_not_flagged(public_text: str) -> N
     assert _scanner().scan_text("src/public.py", public_text) == []
 
 
-def test_repository_scan_uses_tracked_release_scopes_and_exact_allowlist(tmp_path: Path) -> None:
+def test_repository_scan_uses_tracked_scopes_and_stable_allowlist_anchor(tmp_path: Path) -> None:
     scanner = _scanner()
-    source = tmp_path / "tests" / "negative_fixture.py"
+    source = tmp_path / "tests" / "test_negative_fixture.py"
     source.parent.mkdir()
-    source.write_text(_joined("NVI", "DIA_INFERENCE_KEY=negative-fixture\n"), encoding="utf-8")
+    denied_line = _joined("NVI", "DIA_INFERENCE_KEY=negative-fixture")
+    source.write_text(f"{denied_line}  # oss-boundary-anchor: fixture-credential\n", encoding="utf-8")
     ignored = tmp_path / "scratch" / "ignored.txt"
     ignored.parent.mkdir()
     ignored.write_text(_joined("NVI", "DIA_INFERENCE_KEY=out-of-scope\n"), encoding="utf-8")
@@ -122,12 +124,12 @@ def test_repository_scan_uses_tracked_release_scopes_and_exact_allowlist(tmp_pat
     allowlist.write_text(
         json.dumps(
             {
-                "version": 1,
+                "version": 2,
                 "allowlist": [
                     {
-                        "path": "tests/negative_fixture.py",
+                        "path": "tests/test_negative_fixture.py",
                         "rule": "internal-nvidia-credential",
-                        "line": 1,
+                        "anchor": "fixture-credential",
                         "reason": "mutation fixture proves the deny rule fires",
                         "expires": "2099-12-31",
                         "review_owner": "oss-release-reviewers",
@@ -138,21 +140,244 @@ def test_repository_scan_uses_tracked_release_scopes_and_exact_allowlist(tmp_pat
         encoding="utf-8",
     )
     subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
-    subprocess.run(["git", "add", "tests/negative_fixture.py"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "add", "tests/test_negative_fixture.py"], cwd=tmp_path, check=True)
 
     assert scanner.scan_repository(tmp_path, allowlist_path=allowlist) == []
 
-    payload = json.loads(allowlist.read_text(encoding="utf-8"))
-    payload["allowlist"][0]["line"] = 2
-    allowlist.write_text(json.dumps(payload), encoding="utf-8")
-    findings = scanner.scan_repository(tmp_path, allowlist_path=allowlist)
+    source.write_text(
+        f"unrelated_public_line = True\n{denied_line}  # oss-boundary-anchor: fixture-credential\n",
+        encoding="utf-8",
+    )
 
-    assert [(finding.path, finding.rule, finding.line) for finding in findings] == [
-        ("tests/negative_fixture.py", "internal-nvidia-credential", 1)
-    ]
+    assert scanner.scan_repository(tmp_path, allowlist_path=allowlist) == []
 
 
-def test_allowlist_rejects_missing_reason_and_unknown_metadata(tmp_path: Path) -> None:
+def _write_anchor_allowlist(
+    path: Path,
+    *,
+    allow_path: str = "tests/test_negative.py",
+    rule: str = "internal-nvidia-credential",
+    anchor: str = "fixture-credential",
+) -> Path:
+    path.write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "allowlist": [
+                    {
+                        "path": allow_path,
+                        "rule": rule,
+                        "anchor": anchor,
+                        "reason": "negative fixture proves the deny rule fires",
+                        "expires": "2099-12-31",
+                        "review_owner": "oss-release-reviewers",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_repository_allowlist_requires_a_real_python_comment_anchor(tmp_path: Path) -> None:
+    scanner = _scanner()
+    source = tmp_path / "tests" / "test_negative.py"
+    source.parent.mkdir()
+    source.write_text(
+        'marker = "# oss-boundary-anchor: fixture-credential"\n'
+        + _joined("NVI", "DIA_INFERENCE_KEY=negative-fixture\n"),
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "add", "tests/test_negative.py"], cwd=tmp_path, check=True)
+
+    with pytest.raises(ValueError, match=r"allowlist anchor .* is missing"):
+        scanner.scan_repository(tmp_path, allowlist_path=_write_anchor_allowlist(tmp_path / "allowlist.json"))
+
+
+def test_repository_allowlist_rejects_duplicate_comment_anchors(tmp_path: Path) -> None:
+    scanner = _scanner()
+    denied_line = _joined("NVI", "DIA_INFERENCE_KEY=negative-fixture")
+    source = tmp_path / "tests" / "test_negative.py"
+    source.parent.mkdir()
+    source.write_text(
+        f"{denied_line}  # oss-boundary-anchor: fixture-credential\n"
+        f"{denied_line}  # oss-boundary-anchor: fixture-credential\n",
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "add", "tests/test_negative.py"], cwd=tmp_path, check=True)
+
+    with pytest.raises(ValueError, match="duplicate OSS boundary anchor"):
+        scanner.scan_repository(tmp_path, allowlist_path=_write_anchor_allowlist(tmp_path / "allowlist.json"))
+
+
+def test_repository_allowlist_anchor_must_match_exactly_one_configured_rule(tmp_path: Path) -> None:
+    scanner = _scanner()
+    source = tmp_path / "tests" / "test_negative.py"
+    source.parent.mkdir()
+    source.write_text(
+        _joined("NVI", "DIA_INFERENCE_KEY=negative-fixture") + "  # oss-boundary-anchor: fixture-credential\n",
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "add", "tests/test_negative.py"], cwd=tmp_path, check=True)
+
+    with pytest.raises(ValueError, match=r"exactly one internal-product-name finding.*found 0 matching"):
+        scanner.scan_repository(
+            tmp_path,
+            allowlist_path=_write_anchor_allowlist(
+                tmp_path / "allowlist.json",
+                rule="internal-product-name",
+            ),
+        )
+
+
+def test_repository_allowlist_rejects_two_same_rule_matches_on_the_anchor_line(tmp_path: Path) -> None:
+    scanner = _scanner()
+    credential = _joined("NVI", "DIA_INFERENCE_KEY")
+    source = tmp_path / "tests" / "test_negative.py"
+    source.parent.mkdir()
+    source.write_text(
+        f"first = '{credential}'; second = '{credential}'  # oss-boundary-anchor: fixture-credential\n",
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "add", "tests/test_negative.py"], cwd=tmp_path, check=True)
+
+    with pytest.raises(ValueError, match=r"exactly one internal-nvidia-credential finding.*found 2"):
+        scanner.scan_repository(tmp_path, allowlist_path=_write_anchor_allowlist(tmp_path / "allowlist.json"))
+
+
+def test_repository_allowlist_counts_separately_reconstructed_matches_on_one_line(tmp_path: Path) -> None:
+    scanner = _scanner()
+    credential_expression = _joined("'NVI'", " + 'DIA'", " + '_INFERENCE_KEY'")
+    source = tmp_path / "tests" / "test_negative.py"
+    source.parent.mkdir()
+    source.write_text(
+        f"first = {credential_expression}; second = {credential_expression}  "
+        "# oss-boundary-anchor: fixture-credential\n",
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "add", "tests/test_negative.py"], cwd=tmp_path, check=True)
+
+    with pytest.raises(ValueError, match=r"exactly one internal-nvidia-credential finding.*found 2"):
+        scanner.scan_repository(tmp_path, allowlist_path=_write_anchor_allowlist(tmp_path / "allowlist.json"))
+
+
+def test_repository_allowlist_rejects_other_rule_matches_on_the_anchor_line(tmp_path: Path) -> None:
+    scanner = _scanner()
+    credential = _joined("NVI", "DIA_INFERENCE_KEY")
+    dependency = _joined("py", "mil", "vus")
+    source = tmp_path / "tests" / "test_negative.py"
+    source.parent.mkdir()
+    source.write_text(
+        f"first = '{credential}'; second = '{dependency}'  # oss-boundary-anchor: fixture-credential\n",
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "add", "tests/test_negative.py"], cwd=tmp_path, check=True)
+
+    with pytest.raises(ValueError, match=r"exactly one internal-nvidia-credential finding.*2 total"):
+        scanner.scan_repository(tmp_path, allowlist_path=_write_anchor_allowlist(tmp_path / "allowlist.json"))
+
+
+def test_repository_allowlist_anchor_must_share_the_finding_line(tmp_path: Path) -> None:
+    scanner = _scanner()
+    source = tmp_path / "tests" / "test_negative.py"
+    source.parent.mkdir()
+    source.write_text(
+        "public_value = True  # oss-boundary-anchor: fixture-credential\n"
+        + _joined("NVI", "DIA_INFERENCE_KEY=negative-fixture\n"),
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "add", "tests/test_negative.py"], cwd=tmp_path, check=True)
+
+    with pytest.raises(ValueError, match=r"exactly one internal-nvidia-credential finding.*found 0 matching"):
+        scanner.scan_repository(tmp_path, allowlist_path=_write_anchor_allowlist(tmp_path / "allowlist.json"))
+
+
+def test_repository_allowlist_anchor_must_follow_code_on_the_same_line(tmp_path: Path) -> None:
+    scanner = _scanner()
+    source = tmp_path / "tests" / "test_negative.py"
+    source.parent.mkdir()
+    source.write_text("# oss-boundary-anchor: fixture-credential\n", encoding="utf-8")
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "add", "tests/test_negative.py"], cwd=tmp_path, check=True)
+
+    with pytest.raises(ValueError, match="must follow code"):
+        scanner.scan_repository(tmp_path, allowlist_path=_write_anchor_allowlist(tmp_path / "allowlist.json"))
+
+
+def test_repository_scan_rejects_a_malformed_anchor_comment(tmp_path: Path) -> None:
+    scanner = _scanner()
+    source = tmp_path / "tests" / "test_negative.py"
+    source.parent.mkdir()
+    source.write_text(
+        _joined("NVI", "DIA_INFERENCE_KEY=negative-fixture") + "  # oss-boundary-anchor: Fixture_Credential\n",
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "add", "tests/test_negative.py"], cwd=tmp_path, check=True)
+
+    with pytest.raises(ValueError, match="malformed OSS boundary anchor"):
+        scanner.scan_repository(tmp_path, allowlist_path=_write_anchor_allowlist(tmp_path / "allowlist.json"))
+
+
+def test_repository_scan_fails_closed_when_anchor_tokenization_fails(tmp_path: Path) -> None:
+    scanner = _scanner()
+    source = tmp_path / "tests" / "test_negative.py"
+    source.parent.mkdir()
+    source.write_text(
+        _joined("credential = 'NVI'", " + 'DIA'", " + '_INFERENCE_KEY'")
+        + "  # oss-boundary-anchor: fixture-credential\n"
+        + "unterminated = '''\n",
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "add", "tests/test_negative.py"], cwd=tmp_path, check=True)
+
+    with pytest.raises(ValueError, match="could not tokenize Python source"):
+        scanner.scan_repository(tmp_path, allowlist_path=_write_anchor_allowlist(tmp_path / "allowlist.json"))
+
+
+def test_repository_scan_fails_closed_when_anchored_python_cannot_be_parsed(tmp_path: Path) -> None:
+    scanner = _scanner()
+    credential = _joined("NVI", "DIA_INFERENCE_KEY")
+    source = tmp_path / "tests" / "test_negative.py"
+    source.parent.mkdir()
+    source.write_text(
+        f"first = '{credential}'; second = 'NVI' + 'DIA' + '_INFERENCE_KEY'  "
+        "# oss-boundary-anchor: fixture-credential\n"
+        "broken =\n",
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "add", "tests/test_negative.py"], cwd=tmp_path, check=True)
+
+    with pytest.raises(ValueError, match="could not parse anchored Python source"):
+        scanner.scan_repository(tmp_path, allowlist_path=_write_anchor_allowlist(tmp_path / "allowlist.json"))
+
+
+def test_repository_scan_rejects_duplicate_anchor_ids_across_files(tmp_path: Path) -> None:
+    scanner = _scanner()
+    tests = tmp_path / "tests"
+    tests.mkdir()
+    denied_line = _joined("NVI", "DIA_INFERENCE_KEY=negative-fixture")
+    anchored_line = f"{denied_line}  # oss-boundary-anchor: fixture-credential\n"
+    (tests / "test_negative.py").write_text(anchored_line, encoding="utf-8")
+    (tests / "test_other.py").write_text(anchored_line, encoding="utf-8")
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "add", "tests/test_negative.py", "tests/test_other.py"], cwd=tmp_path, check=True)
+
+    with pytest.raises(ValueError, match="duplicate OSS boundary anchor"):
+        scanner.scan_repository(tmp_path, allowlist_path=_write_anchor_allowlist(tmp_path / "allowlist.json"))
+
+
+def test_allowlist_rejects_legacy_line_number_schema(tmp_path: Path) -> None:
     scanner = _scanner()
     allowlist = tmp_path / "allowlist.json"
     allowlist.write_text(
@@ -161,9 +386,44 @@ def test_allowlist_rejects_missing_reason_and_unknown_metadata(tmp_path: Path) -
                 "version": 1,
                 "allowlist": [
                     {
-                        "path": "tests/negative.py",
+                        "path": "tests/test_negative.py",
                         "rule": "internal-nvidia-credential",
                         "line": 1,
+                        "reason": "legacy line-number exception",
+                        "expires": "2099-12-31",
+                        "review_owner": "oss-release-reviewers",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="version=2"):
+        scanner.load_allowlist(allowlist)
+
+
+def test_allowlist_rejects_anchor_ids_that_match_a_denied_rule(tmp_path: Path) -> None:
+    scanner = _scanner()
+    denied_anchor = _joined("py", "mil", "vus")
+    allowlist = _write_anchor_allowlist(tmp_path / "allowlist.json", anchor=denied_anchor)
+
+    with pytest.raises(ValueError, match="anchor ID matches denied OSS boundary rule"):
+        scanner.load_allowlist(allowlist)
+
+
+def test_allowlist_rejects_missing_reason_and_unknown_metadata(tmp_path: Path) -> None:
+    scanner = _scanner()
+    allowlist = tmp_path / "allowlist.json"
+    allowlist.write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "allowlist": [
+                    {
+                        "path": "tests/test_negative.py",
+                        "rule": "internal-nvidia-credential",
+                        "anchor": "fixture-credential",
                         "ticket": "not-an-approved-field",
                         "expires": "2099-12-31",
                         "review_owner": "oss-release-reviewers",
@@ -174,7 +434,59 @@ def test_allowlist_rejects_missing_reason_and_unknown_metadata(tmp_path: Path) -
         encoding="utf-8",
     )
 
-    with pytest.raises(ValueError, match="path, rule, line, reason, expires, and review_owner"):
+    with pytest.raises(ValueError, match="path, rule, anchor, reason, expires, and review_owner"):
+        scanner.load_allowlist(allowlist)
+
+
+def test_allowlist_rejects_duplicate_anchor_ids_across_paths(tmp_path: Path) -> None:
+    scanner = _scanner()
+    allowlist = tmp_path / "allowlist.json"
+    common = {
+        "rule": "internal-nvidia-credential",
+        "anchor": "fixture-credential",
+        "reason": "negative fixture proves the deny rule fires",
+        "expires": "2099-12-31",
+        "review_owner": "oss-release-reviewers",
+    }
+    allowlist.write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "allowlist": [
+                    {"path": "tests/test_first.py", **common},
+                    {"path": "tests/test_second.py", **common},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="duplicates anchor"):
+        scanner.load_allowlist(allowlist)
+
+
+@pytest.mark.parametrize(
+    ("allow_path", "anchor"),
+    (
+        ("tests/negative.py", "fixture-credential"),
+        ("tests/./test_negative.py", "fixture-credential"),
+        ("tests/test_negative.py", "Fixture_Credential"),
+        ("tests/test_negative.py", "fixture.credential"),
+    ),
+)
+def test_allowlist_rejects_noncanonical_test_paths_and_anchor_ids(
+    tmp_path: Path,
+    allow_path: str,
+    anchor: str,
+) -> None:
+    scanner = _scanner()
+    allowlist = _write_anchor_allowlist(
+        tmp_path / "allowlist.json",
+        allow_path=allow_path,
+        anchor=anchor,
+    )
+
+    with pytest.raises(ValueError, match=r"valid path|negative test paths|anchor"):
         scanner.load_allowlist(allowlist)
 
 
@@ -184,12 +496,12 @@ def test_allowlist_rejects_exceptions_outside_negative_tests(tmp_path: Path) -> 
     allowlist.write_text(
         json.dumps(
             {
-                "version": 1,
+                "version": 2,
                 "allowlist": [
                     {
                         "path": "src/runtime.py",
                         "rule": "internal-nvidia-credential",
-                        "line": 1,
+                        "anchor": "fixture-credential",
                         "reason": "runtime exceptions must never be allowed",
                         "expires": "2099-12-31",
                         "review_owner": "oss-release-reviewers",
@@ -210,12 +522,12 @@ def test_allowlist_rejects_expired_negative_test_exception(tmp_path: Path) -> No
     allowlist.write_text(
         json.dumps(
             {
-                "version": 1,
+                "version": 2,
                 "allowlist": [
                     {
-                        "path": "tests/negative.py",
+                        "path": "tests/test_negative.py",
                         "rule": "internal-nvidia-credential",
-                        "line": 1,
+                        "anchor": "fixture-credential",
                         "reason": "expired mutation fixture",
                         "expires": "2026-07-07",
                         "review_owner": "oss-release-reviewers",
@@ -686,9 +998,12 @@ def test_archive_scan_fails_closed_for_undecodable_unknown_member(tmp_path: Path
 
 def test_sdist_negative_test_uses_exact_source_allowlist_path(tmp_path: Path) -> None:
     scanner = _scanner()
-    source = _joined("credential = 'NVI'", " + 'DIA'", " + '_INFERENCE_KEY'\n").encode()
+    source = (
+        _joined("credential = 'NVI'", " + 'DIA'", " + '_INFERENCE_KEY'")
+        + "  # oss-boundary-anchor: fixture-credential\n"
+    ).encode()
     sdist = tmp_path / "package-1.0.tar.gz"
-    info = tarfile.TarInfo("package-1.0/tests/negative.py")
+    info = tarfile.TarInfo("package-1.0/tests/test_negative.py")
     info.size = len(source)
     with tarfile.open(sdist, "w:gz") as archive:
         archive.addfile(info, BytesIO(source))
@@ -696,12 +1011,12 @@ def test_sdist_negative_test_uses_exact_source_allowlist_path(tmp_path: Path) ->
     allowlist.write_text(
         json.dumps(
             {
-                "version": 1,
+                "version": 2,
                 "allowlist": [
                     {
-                        "path": "tests/negative.py",
+                        "path": "tests/test_negative.py",
                         "rule": "internal-nvidia-credential",
-                        "line": 1,
+                        "anchor": "fixture-credential",
                         "reason": "negative archive fixture",
                         "expires": "2099-12-31",
                         "review_owner": "oss-release-reviewers",
@@ -715,17 +1030,148 @@ def test_sdist_negative_test_uses_exact_source_allowlist_path(tmp_path: Path) ->
     assert scanner.scan_archive(sdist, allowlist_path=allowlist) == []
 
 
+def test_sdist_validates_anchor_when_allowlisted_source_path_is_present(tmp_path: Path) -> None:
+    scanner = _scanner()
+    source = b"public fixture without the configured anchor\n"
+    sdist = tmp_path / "package-1.0.tar.gz"
+    info = tarfile.TarInfo("package-1.0/tests/test_negative.py")
+    info.size = len(source)
+    with tarfile.open(sdist, "w:gz") as archive:
+        archive.addfile(info, BytesIO(source))
+
+    with pytest.raises(ValueError, match=r"allowlist anchor .* is missing"):
+        scanner.scan_archive(sdist, allowlist_path=_write_anchor_allowlist(tmp_path / "allowlist.json"))
+
+
+def test_wheel_does_not_require_allowance_for_an_absent_source_path(tmp_path: Path) -> None:
+    scanner = _scanner()
+    wheel = tmp_path / "package.whl"
+    with zipfile.ZipFile(wheel, "w") as archive:
+        archive.writestr("package/module.py", "public_value = True\n")
+
+    assert scanner.scan_archive(wheel, allowlist_path=_write_anchor_allowlist(tmp_path / "allowlist.json")) == []
+
+
+def test_wheel_uses_the_exact_allowlisted_source_path_and_anchor(tmp_path: Path) -> None:
+    scanner = _scanner()
+    source = (
+        _joined("credential = 'NVI'", " + 'DIA'", " + '_INFERENCE_KEY'")
+        + "  # oss-boundary-anchor: fixture-credential\n"
+    )
+    wheel = tmp_path / "package.whl"
+    with zipfile.ZipFile(wheel, "w") as archive:
+        archive.writestr("tests/test_negative.py", source)
+
+    assert scanner.scan_archive(wheel, allowlist_path=_write_anchor_allowlist(tmp_path / "allowlist.json")) == []
+
+
+def test_wheel_requires_only_allowances_for_source_paths_present_in_the_artifact(tmp_path: Path) -> None:
+    scanner = _scanner()
+    allowlist = tmp_path / "allowlist.json"
+    common = {
+        "rule": "internal-nvidia-credential",
+        "reason": "negative fixture proves the deny rule fires",
+        "expires": "2099-12-31",
+        "review_owner": "oss-release-reviewers",
+    }
+    allowlist.write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "allowlist": [
+                    {"path": "tests/test_negative.py", "anchor": "fixture-credential", **common},
+                    {"path": "tests/test_absent.py", "anchor": "absent-credential", **common},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    source = (
+        _joined("credential = 'NVI'", " + 'DIA'", " + '_INFERENCE_KEY'")
+        + "  # oss-boundary-anchor: fixture-credential\n"
+    )
+    wheel = tmp_path / "package.whl"
+    with zipfile.ZipFile(wheel, "w") as archive:
+        archive.writestr("tests/test_negative.py", source)
+
+    assert scanner.scan_archive(wheel, allowlist_path=allowlist) == []
+
+
+def test_wheel_allowlist_rejects_two_same_rule_matches_on_the_anchor_line(tmp_path: Path) -> None:
+    scanner = _scanner()
+    credential = _joined("NVI", "DIA_INFERENCE_KEY")
+    source = f"first = '{credential}'; second = '{credential}'  # oss-boundary-anchor: fixture-credential\n"
+    wheel = tmp_path / "package.whl"
+    with zipfile.ZipFile(wheel, "w") as archive:
+        archive.writestr("tests/test_negative.py", source)
+
+    with pytest.raises(ValueError, match=r"exactly one internal-nvidia-credential finding.*found 2"):
+        scanner.scan_archive(wheel, allowlist_path=_write_anchor_allowlist(tmp_path / "allowlist.json"))
+
+
+def test_wheel_allowlist_counts_separately_reconstructed_matches_on_one_line(tmp_path: Path) -> None:
+    scanner = _scanner()
+    credential_expression = _joined("'NVI'", " + 'DIA'", " + '_INFERENCE_KEY'")
+    source = (
+        f"first = {credential_expression}; second = {credential_expression}  "
+        "# oss-boundary-anchor: fixture-credential\n"
+    )
+    wheel = tmp_path / "package.whl"
+    with zipfile.ZipFile(wheel, "w") as archive:
+        archive.writestr("tests/test_negative.py", source)
+
+    with pytest.raises(ValueError, match=r"exactly one internal-nvidia-credential finding.*found 2"):
+        scanner.scan_archive(wheel, allowlist_path=_write_anchor_allowlist(tmp_path / "allowlist.json"))
+
+
+def test_wheel_rejects_the_wrong_anchor_at_an_allowlisted_source_path(tmp_path: Path) -> None:
+    scanner = _scanner()
+    source = (
+        _joined("credential = 'NVI'", " + 'DIA'", " + '_INFERENCE_KEY'")
+        + "  # oss-boundary-anchor: wrong-credential\n"
+    )
+    wheel = tmp_path / "package.whl"
+    with zipfile.ZipFile(wheel, "w") as archive:
+        archive.writestr("tests/test_negative.py", source)
+
+    with pytest.raises(ValueError, match="unregistered OSS boundary anchor 'wrong-credential'"):
+        scanner.scan_archive(wheel, allowlist_path=_write_anchor_allowlist(tmp_path / "allowlist.json"))
+
+
+def test_wheel_rejects_an_unregistered_anchor_on_an_unconfigured_path(tmp_path: Path) -> None:
+    scanner = _scanner()
+    wheel = tmp_path / "package.whl"
+    with zipfile.ZipFile(wheel, "w") as archive:
+        archive.writestr("package/module.py", "public_value = True  # oss-boundary-anchor: rogue-marker\n")
+
+    with pytest.raises(ValueError, match="unregistered OSS boundary anchor"):
+        scanner.scan_archive(wheel, allowlist_path=_write_anchor_allowlist(tmp_path / "allowlist.json"))
+
+
+def test_archive_scan_fails_closed_when_anchor_tokenization_fails(tmp_path: Path) -> None:
+    scanner = _scanner()
+    wheel = tmp_path / "package.whl"
+    with zipfile.ZipFile(wheel, "w") as archive:
+        archive.writestr(
+            "tests/test_negative.py",
+            "public_value = True  # oss-boundary-anchor: fixture-credential\nunterminated = '''\n",
+        )
+
+    with pytest.raises(ValueError, match="could not tokenize Python source"):
+        scanner.scan_archive(wheel, allowlist_path=_write_anchor_allowlist(tmp_path / "allowlist.json"))
+
+
 def _negative_test_allowlist(path: Path) -> Path:
     allowlist = path / "allowlist.json"
     allowlist.write_text(
         json.dumps(
             {
-                "version": 1,
+                "version": 2,
                 "allowlist": [
                     {
-                        "path": "tests/negative.py",
+                        "path": "tests/test_negative.py",
                         "rule": "internal-nvidia-credential",
-                        "line": 1,
+                        "anchor": "fixture-credential",
                         "reason": "negative archive fixture",
                         "expires": "2099-12-31",
                         "review_owner": "oss-release-reviewers",
@@ -740,24 +1186,92 @@ def _negative_test_allowlist(path: Path) -> Path:
 
 def test_wheel_allowlist_does_not_strip_an_arbitrary_member_prefix(tmp_path: Path) -> None:
     scanner = _scanner()
-    source = _joined("credential = 'NVI'", " + 'DIA'", " + '_INFERENCE_KEY'\n")
+    source = (
+        _joined("credential = 'NVI'", " + 'DIA'", " + '_INFERENCE_KEY'")
+        + "  # oss-boundary-anchor: fixture-credential\n"
+    )
     wheel = tmp_path / "package.whl"
     with zipfile.ZipFile(wheel, "w") as archive:
-        archive.writestr("evil/tests/negative.py", source)
+        archive.writestr("evil/tests/test_negative.py", source)
 
-    findings = scanner.scan_archive(wheel, allowlist_path=_negative_test_allowlist(tmp_path))
+    with pytest.raises(ValueError, match=r"unregistered OSS boundary anchor.*evil/tests/test_negative.py"):
+        scanner.scan_archive(wheel, allowlist_path=_negative_test_allowlist(tmp_path))
 
-    assert [(finding.path, finding.rule, finding.line) for finding in findings] == [
-        (f"{wheel}!evil/tests/negative.py", "internal-nvidia-credential", 1)
-    ]
+
+def test_wheel_rejects_duplicate_members_before_associating_anchors(tmp_path: Path) -> None:
+    scanner = _scanner()
+    wheel = tmp_path / "package.whl"
+    denied = _joined("credential = 'NVI'", " + 'DIA'", " + '_INFERENCE_KEY'\n")
+    with zipfile.ZipFile(wheel, "w") as archive:
+        archive.writestr("tests/test_negative.py", denied)
+        with pytest.warns(UserWarning, match="Duplicate name"):
+            archive.writestr(
+                "tests/test_negative.py",
+                "public_value = True  # oss-boundary-anchor: fixture-credential\n",
+            )
+
+    with pytest.raises(ValueError, match="duplicate archive member path"):
+        scanner.scan_archive(wheel, allowlist_path=_negative_test_allowlist(tmp_path))
+
+
+def test_sdist_rejects_duplicate_members_before_associating_anchors(tmp_path: Path) -> None:
+    scanner = _scanner()
+    sdist = tmp_path / "package-1.0.tar.gz"
+    denied = _joined("credential = 'NVI'", " + 'DIA'", " + '_INFERENCE_KEY'\n").encode()
+    anchored_public = b"public_value = True  # oss-boundary-anchor: fixture-credential\n"
+    with tarfile.open(sdist, "w:gz") as archive:
+        for source in (denied, anchored_public):
+            info = tarfile.TarInfo("package-1.0/tests/test_negative.py")
+            info.size = len(source)
+            archive.addfile(info, BytesIO(source))
+
+    with pytest.raises(ValueError, match="duplicate archive member path"):
+        scanner.scan_archive(sdist, allowlist_path=_negative_test_allowlist(tmp_path))
+
+
+@pytest.mark.parametrize("member_type", (tarfile.SYMTYPE, tarfile.LNKTYPE))
+def test_sdist_rejects_links_before_allowlisting(tmp_path: Path, member_type: bytes) -> None:
+    scanner = _scanner()
+    sdist = tmp_path / "package-1.0.tar.gz"
+    allowed_source = (
+        _joined("credential = 'NVI'", " + 'DIA'", " + '_INFERENCE_KEY'")
+        + "  # oss-boundary-anchor: fixture-credential\n"
+    ).encode()
+    with tarfile.open(sdist, "w:gz") as archive:
+        allowed = tarfile.TarInfo("package-1.0/tests/test_negative.py")
+        allowed.size = len(allowed_source)
+        archive.addfile(allowed, BytesIO(allowed_source))
+        link = tarfile.TarInfo("package-1.0/src/runtime.py")
+        link.type = member_type
+        link.linkname = "../tests/test_negative.py"
+        archive.addfile(link)
+
+    with pytest.raises(ValueError, match="unsupported TAR member"):
+        scanner.scan_archive(sdist, allowlist_path=_negative_test_allowlist(tmp_path))
+
+
+def test_wheel_rejects_a_unix_symlink_entry(tmp_path: Path) -> None:
+    scanner = _scanner()
+    wheel = tmp_path / "package.whl"
+    symlink = zipfile.ZipInfo("src/runtime.py")
+    symlink.create_system = 3
+    symlink.external_attr = (stat.S_IFLNK | 0o777) << 16
+    with zipfile.ZipFile(wheel, "w") as archive:
+        archive.writestr(symlink, "../tests/test_negative.py")
+
+    with pytest.raises(ValueError, match="unsupported ZIP member"):
+        scanner.scan_archive(wheel)
 
 
 def test_wheel_scan_rejects_member_path_traversal_before_allowlisting(tmp_path: Path) -> None:
     scanner = _scanner()
-    source = _joined("credential = 'NVI'", " + 'DIA'", " + '_INFERENCE_KEY'\n")
+    source = (
+        _joined("credential = 'NVI'", " + 'DIA'", " + '_INFERENCE_KEY'")
+        + "  # oss-boundary-anchor: fixture-credential\n"
+    )
     wheel = tmp_path / "package.whl"
     with zipfile.ZipFile(wheel, "w") as archive:
-        archive.writestr("../tests/negative.py", source)
+        archive.writestr("../tests/test_negative.py", source)
 
     with pytest.raises(ValueError, match="unsafe archive member path"):
         scanner.scan_archive(wheel, allowlist_path=_negative_test_allowlist(tmp_path))
@@ -765,9 +1279,12 @@ def test_wheel_scan_rejects_member_path_traversal_before_allowlisting(tmp_path: 
 
 def test_sdist_allowlist_only_normalizes_the_expected_distribution_root(tmp_path: Path) -> None:
     scanner = _scanner()
-    source = _joined("credential = 'NVI'", " + 'DIA'", " + '_INFERENCE_KEY'\n").encode()
+    source = (
+        _joined("credential = 'NVI'", " + 'DIA'", " + '_INFERENCE_KEY'")
+        + "  # oss-boundary-anchor: fixture-credential\n"
+    ).encode()
     sdist = tmp_path / "package-1.0.tar.gz"
-    info = tarfile.TarInfo("evil/tests/negative.py")
+    info = tarfile.TarInfo("evil/tests/test_negative.py")
     info.size = len(source)
     with tarfile.open(sdist, "w:gz") as archive:
         archive.addfile(info, BytesIO(source))

--- a/tests/test_oss_packaging.py
+++ b/tests/test_oss_packaging.py
@@ -123,18 +123,18 @@ def test_public_extras_exclude_internal_runtime_dependencies() -> None:
     extras = project["project"]["optional-dependencies"]
     dependency_text = "\n".join(requirement.lower() for requirements in extras.values() for requirement in requirements)
 
-    assert "py" + "mil" + "vus" not in dependency_text
-    assert "sandbox" + "-k8s" not in dependency_text
-    assert "ipp" + "bot" not in dependency_text
+    assert "py" + "mil" + "vus" not in dependency_text  # oss-boundary-anchor: public-extra-vector-db
+    assert "sandbox" + "-k8s" not in dependency_text  # oss-boundary-anchor: public-extra-cluster-runtime
+    assert "ipp" + "bot" not in dependency_text  # oss-boundary-anchor: public-extra-retired-product
 
 
 def test_public_sources_exclude_retired_internal_runtime_paths() -> None:
     source_text = "\n".join(path.read_text(encoding="utf-8") for path in (REPO_ROOT / "src").rglob("*.py"))
     retired_terms = (
-        "NVI" + "DIA" + "_INFERENCE_KEY",
-        "as" + "tra_sandbox",
+        "NVI" + "DIA" + "_INFERENCE_KEY",  # oss-boundary-anchor: source-retired-credential
+        "as" + "tra_sandbox",  # oss-boundary-anchor: source-retired-executor
         "inter" + "_skill",
-        "py" + "mil" + "vus",
+        "py" + "mil" + "vus",  # oss-boundary-anchor: source-retired-vector-store
     )
 
     for term in retired_terms:
@@ -453,7 +453,7 @@ def test_ci_scans_source_and_built_distributions_for_oss_boundary_violations() -
 
 def test_retired_private_upload_artifact_is_not_part_of_public_gitignore() -> None:
     gitignore = (REPO_ROOT / ".gitignore").read_text(encoding="utf-8")
-    retired_artifact = "." + "harbor" + "-viewer-upload/"
+    retired_artifact = "." + "harbor" + "-viewer-upload/"  # oss-boundary-anchor: gitignore-retired-upload-artifact
 
     assert retired_artifact not in gitignore
 
@@ -494,7 +494,7 @@ def test_public_docs_show_tier_two_collection_and_catalog_workflows() -> None:
     assert "sends each discovered `SKILL.md` in full" in public_docs
     assert "Only candidate clusters found by the embedding stage are" in public_docs
     assert "sent to the configured chat LLM for classification" in public_docs
-    assert "NVI" + "DIA" + "_INFERENCE_KEY" not in public_docs
+    assert "NVI" + "DIA" + "_INFERENCE_KEY" not in public_docs  # oss-boundary-anchor: docs-retired-credential
 
 
 def test_public_docs_show_external_nvidia_build_harness_paths_only() -> None:

--- a/tests/test_provider_config.py
+++ b/tests/test_provider_config.py
@@ -76,7 +76,7 @@ def test_public_provider_matches_shared_contract_fixture() -> None:
 
 
 def test_nvidia_build_ignores_unrelated_credential_names() -> None:
-    legacy_name = "NVI" + "DIA" + "_INFERENCE_KEY"
+    legacy_name = "NVI" + "DIA" + "_INFERENCE_KEY"  # oss-boundary-anchor: provider-retired-credential
 
     with pytest.raises(ProviderConfigurationError, match="NVIDIA_API_KEY"):
         resolve_llm_provider(

--- a/tests/validators/test_security.py
+++ b/tests/validators/test_security.py
@@ -1406,7 +1406,7 @@ Call us at 555-123-4567 or +1-555-987-6543
     ) -> None:
         """The public key reaches SkillSpector without creating a second NVIDIA credential."""
         public_key = "unit-test-nvidia-build-key"
-        retired_name = "NVI" + "DIA" + "_INFERENCE_KEY"
+        retired_name = "NVI" + "DIA" + "_INFERENCE_KEY"  # oss-boundary-anchor: security-retired-credential
         monkeypatch.setenv("SKILL_EVAL_LLM_PROVIDER", "nv_build")
         monkeypatch.setenv("NVIDIA_API_KEY", public_key)
         monkeypatch.setenv("OPENAI_API_KEY", "unrelated-openai-key")


### PR DESCRIPTION
## Summary

- migrate `config/oss_boundary_allowlist.json` from line-number entries to stable, same-line Python comment anchors
- require strict v2 metadata, canonical negative-test paths, globally unique safe anchor IDs, and exactly one matching boundary finding per anchor
- validate repository, wheel, and sdist anchors without requiring source-only test allowances in artifacts that omit those paths
- reject malformed, orphaned, duplicate, self-authorizing, or syntactically invalid anchors and unsafe duplicate/link archive members

## Why

Line-number entries drift whenever unrelated edits move a negative fixture. Stable semantic anchors keep the security exception attached to the exact finding and fail closed when either the fixture or its rule changes.

This is a follow-up to the public-readiness review on #33 and is not coupled to that merged PR.

## Verification

- Python 3.12: `3093 passed, 7 skipped, 3 deselected`
- Python 3.13: `3093 passed, 7 skipped, 3 deselected`
- boundary scanner tests: `140 passed` on both Python 3.12 and 3.13
- `uv run ruff check .`
- checked-in repository boundary scan
- rebuilt wheel and source distribution with Python 3.13, then scanned both real artifacts
- independent security and archive reviews completed with no remaining findings

The commit is SSH-signed and includes the DCO `Signed-off-by` trailer.