### PR TITLE
fix(tier3): isolate per-task inputs and evaluator fixtures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,17 @@ jobs:
           tests/validators/test_similarity.py
           tests/reporting
           tests/test_cli.py
+          tests/test_harbor_output_provenance.py
+          tests/test_harbor_runtime_skill_isolation.py
+          tests/test_harbor_secure_copy.py::test_checked_windows_fallback_accepts_crt_descriptor_identity
+          tests/test_harbor_secure_copy.py::test_checked_windows_fallback_verifies_portable_chmod_semantics
+          tests/test_harbor_secure_copy.py::test_native_windows_fallback_copies_tree_and_file
+          tests/test_harbor_secure_copy.py::test_native_windows_tree_fingerprint_binds_writable_mode
+          tests/test_results_location.py
+          tests/test_results_location_legacy_compatibility.py
+          tests/test_tier3_compare.py
+          tests/test_tier3_progress.py
+          tests/utils/test_secure_fs_selected_reads.py
           tests/test_oss_packaging.py
 
   native-windows-local-mode:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,11 @@ All notable changes to SkillEvaluator are documented in this file.
 - Tier 3 generated tasks now stage only an entry's declared `files`, preventing
   undeclared fixtures from the shared `evals/files/` directory from appearing
   in that task's `/workspace/input/`, while preserving copy-all behavior for
-  legacy entries that omit the field.
+  legacy entries that omit the field. Agent-visible target, reference, and
+  workspace skill projections now omit evaluator-owned `evals/` directories
+  from every staged skill package, including sanitized `--copy-repo` contexts,
+  while graders, native tasks, custom
+  environments, and declared inputs continue to load from the source dataset.
 - Public benchmark cards now omit policy profiles, redact absolute host paths,
   and normalize imported internal or retired metadata before publication.
 - Previous-version validation now rejects catalog-wide scalar reuse and removal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,11 @@ All notable changes to SkillEvaluator are documented in this file.
   environments, and declared inputs continue to load from the source dataset.
   Authenticated historical result trees are also excluded after output rotation,
   invalid markers fail closed, and late Codex, Cline, Goose, and Qwen
-  skill-discovery roots are reset before agent execution.
+  skill-discovery roots are reset before agent execution. Pre-upgrade custom
+  result roots outside `evals/` have no authenticity marker and cannot be
+  distinguished safely from authored runtime content. Move or delete that old
+  content before `--copy-repo` or other full-context evaluation, then rerun with
+  this version if replacement evidence is needed.
 - Public benchmark cards now omit policy profiles, redact absolute host paths,
   and normalize imported internal or retired metadata before publication.
 - Previous-version validation now rejects catalog-wide scalar reuse and removal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,10 @@ All notable changes to SkillEvaluator are documented in this file.
 
 ### Fixed
 
+- Tier 3 generated tasks now stage only an entry's declared `files`, preventing
+  undeclared fixtures from the shared `evals/files/` directory from appearing
+  in that task's `/workspace/input/`, while preserving copy-all behavior for
+  legacy entries that omit the field.
 - Public benchmark cards now omit policy profiles, redact absolute host paths,
   and normalize imported internal or retired metadata before publication.
 - Previous-version validation now rejects catalog-wide scalar reuse and removal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,7 +88,21 @@ All notable changes to SkillEvaluator are documented in this file.
   result roots outside `evals/` have no authenticity marker and cannot be
   distinguished safely from authored runtime content. Move or delete that old
   content before `--copy-repo` or other full-context evaluation, then rerun with
-  this version if replacement evidence is needed.
+  this version if replacement evidence is needed. Explicit task inputs cannot
+  select evaluator-owned datasets, configuration, graders, tests, native tasks,
+  environments, or results. Every agent and baseline arm now reads from one
+  private, selective evaluator snapshot containing the active control files,
+  task-source data, consumed fixtures and grader, and the complete authored
+  custom environment. Legacy omitted-file entries retain the full shared files
+  corpus. Unrelated evaluator subtrees and generated results stay outside the
+  snapshot. MCP configuration and completed-run artifacts are
+  read through bounded descriptor-anchored roots; on Windows, selected file
+  handles deny concurrent writes and deletes while live. Historical unmarked
+  runs created before canonical run-level `result.json` remain discoverable only
+  when their stable configuration and summaries satisfy the complete historical
+  schema. Pre-status scored summaries remain consumable, coherent status-era
+  failures remain visible without contributing scores, and marked current
+  partial runs continue to fail closed.
 - Public benchmark cards now omit policy profiles, redact absolute host paths,
   and normalize imported internal or retired metadata before publication.
 - Previous-version validation now rejects catalog-wide scalar reuse and removal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,9 @@ All notable changes to SkillEvaluator are documented in this file.
   from every staged skill package, including sanitized `--copy-repo` contexts,
   while graders, native tasks, custom
   environments, and declared inputs continue to load from the source dataset.
+  Authenticated historical result trees are also excluded after output rotation,
+  invalid markers fail closed, and late Codex, Cline, Goose, and Qwen
+  skill-discovery roots are reset before agent execution.
 - Public benchmark cards now omit policy profiles, redact absolute host paths,
   and normalize imported internal or retired metadata before publication.
 - Previous-version validation now rejects catalog-wide scalar reuse and removal

--- a/docs/eval-datasets.mdx
+++ b/docs/eval-datasets.mdx
@@ -266,8 +266,10 @@ grading:
 Two optional directories shape the world the agent works in.
 
 **`evals/files/`** holds input fixtures — test data, configs, sample
-documents. The entire directory is copied into `/workspace/input/` inside the
-container, so prompts can reference those paths directly.
+documents. An eval entry's `files` string or list selects only those paths
+(relative to `evals/`) for its `/workspace/input/`. An explicit empty list or
+`null` stages no fixture. For backward compatibility, an entry that omits
+`files` receives the entire shared `evals/files/` directory.
 
 **`evals/environment/`** customizes the container itself:
 

--- a/docs/reports.mdx
+++ b/docs/reports.mdx
@@ -147,8 +147,17 @@ Each run creates a directory named by its run ID (`YYYYMMDD_HHMMSS`), and a
   Read commands (`view`, `compare`, `create-eval-dataset --refine`) honor the
   same precedence, then fall back to the legacy `<skill>/evals/results/`
   location — so old runs stay visible after you configure
-  `SKILLEVALUATOR_RESULTS_DIR`. The results tree is generated output: don't
-  commit it.
+  `SKILLEVALUATOR_RESULTS_DIR`. Current timestamped runs are selected only when
+  stable regular `run_config.json` and matching atomic `result.json` artifacts
+  are present. Unmarked runs created before run-level `result.json` remain
+  readable only when `run_config.json` has a recognized historical task source
+  and complete agent metadata, and every configured agent has one stable,
+  identity-matched summary satisfying the full historical score, dimension,
+  pass-at-k, and completion schema. Authenticated summaries from before status
+  fields are consumed as successful; coherent status-era failed summaries stay
+  visible without contributing scores. Any marker presence prevents an
+  incomplete current run from being interpreted as legacy output. The results
+  tree is generated output: don't commit it.
 </Note>
 
 ## Reading a live-eval report

--- a/docs/reports.mdx
+++ b/docs/reports.mdx
@@ -104,14 +104,16 @@ With an external root (the first two options), each skill gets its own
 subdirectory — runs land under `<dir>/<skill-name>/`, not directly under
 `<dir>`.
 
-Each run creates a directory named by its run ID (`YYYYMMDD_HHMMSS`), and a
-`latest` symlink points at the newest run:
+Each run creates a collision-safe directory named by its run ID
+(`YYYYMMDD_HHMMSS_<pid>_<12-hex-nonce>`). Where symlinks are supported, a
+`latest` symlink points at the newest run; otherwise readers select the newest
+completed run directly:
 
 <FileTree>
 - evals/
   - results/
     - latest/
-    - 20260709_141530/
+    - 20260709_141530_12345_a1b2c3d4e5f6/
       - result.json
       - run_config.json
       - attempt_policy.json
@@ -260,7 +262,7 @@ Retained jobs live under `_harbor-jobs/` inside the run directory.
 
 ```bash title="Browse retained trajectories"
 skillevaluator tier3 evaluate ./my-skill --agents codex --env-mode docker --harbor-keep-jobs
-skillevaluator harbor-view ./my-skill/evals/results/20260709_141530/_harbor-jobs
+skillevaluator harbor-view ./my-skill/evals/results/20260709_141530_12345_a1b2c3d4e5f6/_harbor-jobs
 ```
 
 (`skillevaluator tier3 harbor-view` is the same command under its expert

--- a/docs/tier3-live-evaluation.mdx
+++ b/docs/tier3-live-evaluation.mdx
@@ -101,7 +101,11 @@ nested, reference, or workspace skill into agent-visible copies. `--copy-repo`
 uses the same filtering and excludes generated result roots. Authenticated
 historical result roots remain excluded after the configured output location is
 changed; a present marker that is copied, stale, or cannot be authenticated
-fails staging closed instead of copying that tree. Runtime assets that
+fails staging closed instead of copying that tree. Custom result roots created
+outside `evals/` by a pre-marker version cannot be identified safely after the
+configured location changes. Move or delete that old content before
+`--copy-repo` or another full-context evaluation, then rerun with the current
+version if replacement evidence is needed. Runtime assets that
 the agent needs should live outside skill-owned `evals/`, or be declared as task
 inputs with `files`.
 

--- a/docs/tier3-live-evaluation.mdx
+++ b/docs/tier3-live-evaluation.mdx
@@ -94,6 +94,34 @@ declared paths are staged into that task's `/workspace/input/`. An explicit
 empty list or `null` stages no task input. For backward compatibility, omitting
 the `files` field stages the entire shared `evals/files/` directory.
 
+An `evals/` directory directly owned by a skill package is evaluator-only. Tier
+3 reads datasets, graders, native Harbor tasks, and custom environments from the
+source tree, but does not install those directories from the target or any
+nested, reference, or workspace skill into agent-visible copies. `--copy-repo`
+uses the same filtering and excludes generated result roots. Runtime assets that
+the agent needs should live outside skill-owned `evals/`, or be declared as task
+inputs with `files`.
+
+`evals/environment/input/` is reserved and is not copied into generated tasks.
+Directory-level custom Docker `COPY input/` remains buildable for an empty entry
+using an empty context directory. Missing, dynamic, linked, hardlinked, aliased,
+or escaping input sources fail closed. Native Harbor tasks and Compose input
+contexts use the same omitted-versus-explicit selection rules.
+
+The final evaluator layer replaces `/workspace/input`, `/workspace/repo`, and
+supported agent skill-discovery roots. Custom Docker `preserve` mode also
+requires a statically known final `USER` so the projection can be installed and
+the original user restored. Custom Dockerfiles and base images remain trusted
+executable environment inputs: these controls isolate evaluation fixtures and
+supported discovery roots; they are not a security boundary against an image
+that intentionally changes system binaries or startup behavior.
+
+Evaluator-owned in-skill output uses a path-bound authenticity marker backed by
+a local key. A copied, forged, or stale marker cannot authorize replacement at
+another path. A custom key path set through
+`SKILLEVALUATOR_OUTPUT_PROVENANCE_KEY_FILE` must remain outside every evaluated
+skill source.
+
 ### Run the comparison
 
 ```bash title="With-skill vs. without-skill in Docker"

--- a/docs/tier3-live-evaluation.mdx
+++ b/docs/tier3-live-evaluation.mdx
@@ -116,12 +116,13 @@ outside `evals/` by a pre-marker version cannot be identified safely after the
 configured location changes. Move or delete that old content before
 `--copy-repo` or another full-context evaluation, then rerun with the current
 version if replacement evidence is needed. Runtime assets that the agent needs
-should live outside skill-owned `evals/`, under `evals/files/`
-(preferred), or under another non-control subtree such as `evals/data/` and be
-declared as task inputs with `files`. A `files` declaration cannot select
-evaluator control material: dataset/configuration files, graders, developer
-eval guidance, benchmark conversion reports, native Harbor tasks, custom
-environments, evaluator tests, or generated results.
+as part of the installed skill should live outside skill-owned `evals/`. Task
+fixtures should live under `evals/files/` (preferred) or another non-control
+subtree such as `evals/data/`, and should be declared as task inputs with
+`files`. A `files` declaration cannot select evaluator control material:
+dataset/configuration files, graders, developer eval guidance, benchmark
+conversion reports, native Harbor tasks, custom environments, evaluator tests,
+or generated results.
 
 MCP declarations are read only from a bounded, stable, single-link regular
 `evals/environment/mcp_servers.toml` through a descriptor-anchored evaluator
@@ -173,7 +174,7 @@ directory:
 <FileTree>
 - evals/
   - results/
-    - 20260709_141530/
+    - 20260709_141530_12345_a1b2c3d4e5f6/
       - result.json
       - run_config.json
       - report.html

--- a/docs/tier3-live-evaluation.mdx
+++ b/docs/tier3-live-evaluation.mdx
@@ -98,7 +98,10 @@ An `evals/` directory directly owned by a skill package is evaluator-only. Tier
 3 reads datasets, graders, native Harbor tasks, and custom environments from the
 source tree, but does not install those directories from the target or any
 nested, reference, or workspace skill into agent-visible copies. `--copy-repo`
-uses the same filtering and excludes generated result roots. Runtime assets that
+uses the same filtering and excludes generated result roots. Authenticated
+historical result roots remain excluded after the configured output location is
+changed; a present marker that is copied, stale, or cannot be authenticated
+fails staging closed instead of copying that tree. Runtime assets that
 the agent needs should live outside skill-owned `evals/`, or be declared as task
 inputs with `files`.
 

--- a/docs/tier3-live-evaluation.mdx
+++ b/docs/tier3-live-evaluation.mdx
@@ -95,8 +95,18 @@ empty list or `null` stages no task input. For backward compatibility, omitting
 the `files` field stages the entire shared `evals/files/` directory.
 
 An `evals/` directory directly owned by a skill package is evaluator-only. Tier
-3 reads datasets, graders, native Harbor tasks, and custom environments from the
-source tree, but does not install those directories from the target or any
+3 resolves the selected task source once and copies only the evaluator inputs it
+can consume into one private temporary snapshot. That projection includes the
+active dataset and configuration, selected fixtures, the first consumed grader,
+the complete authored custom environment, and native tasks when selected.
+Legacy entries that omit `files` retain the complete shared `evals/files/`
+corpus. Unrelated evaluator subtrees and generated results are not copied. Every
+agent and baseline arm reads the same snapshot, preventing a concurrent source
+replacement from mixing dataset, fixture, grader, custom-environment, or
+native-task identities. The snapshot is removed when the run returns and
+requires temporary space only for the selected compatibility scope.
+
+Tier 3 does not install evaluator-owned directories from the target or any
 nested, reference, or workspace skill into agent-visible copies. `--copy-repo`
 uses the same filtering and excludes generated result roots. Authenticated
 historical result roots remain excluded after the configured output location is
@@ -105,9 +115,20 @@ fails staging closed instead of copying that tree. Custom result roots created
 outside `evals/` by a pre-marker version cannot be identified safely after the
 configured location changes. Move or delete that old content before
 `--copy-repo` or another full-context evaluation, then rerun with the current
-version if replacement evidence is needed. Runtime assets that
-the agent needs should live outside skill-owned `evals/`, or be declared as task
-inputs with `files`.
+version if replacement evidence is needed. Runtime assets that the agent needs
+should live outside skill-owned `evals/`, under `evals/files/`
+(preferred), or under another non-control subtree such as `evals/data/` and be
+declared as task inputs with `files`. A `files` declaration cannot select
+evaluator control material: dataset/configuration files, graders, developer
+eval guidance, benchmark conversion reports, native Harbor tasks, custom
+environments, evaluator tests, or generated results.
+
+MCP declarations are read only from a bounded, stable, single-link regular
+`evals/environment/mcp_servers.toml` through a descriptor-anchored evaluator
+root. Linked configuration files or parents, hardlinks, reparse points, and
+files replaced during the read fail task generation before output mutation. On
+Windows, the selected-file handle also denies concurrent writes and deletion
+for the read.
 
 `evals/environment/input/` is reserved and is not copied into generated tasks.
 Directory-level custom Docker `COPY input/` remains buildable for an empty entry

--- a/docs/tier3-live-evaluation.mdx
+++ b/docs/tier3-live-evaluation.mdx
@@ -88,6 +88,12 @@ receive, an `expected_output`, and optional `assertions` the grader checks.
 Edit freely — the generated cases are a starting point, and the run is only as
 good as its dataset.
 
+Each eval entry can declare task inputs with a `files` string or list. Paths are
+relative to `evals/` (for example, `"files/case-001/input.txt"`) and only those
+declared paths are staged into that task's `/workspace/input/`. An explicit
+empty list or `null` stages no task input. For backward compatibility, omitting
+the `files` field stages the entire shared `evals/files/` directory.
+
 ### Run the comparison
 
 ```bash title="With-skill vs. without-skill in Docker"

--- a/src/skillevaluator/evaluation/tier3_report.py
+++ b/src/skillevaluator/evaluation/tier3_report.py
@@ -307,7 +307,12 @@ def agent_eval_result_from_directory(
     )
 
     run_dir = run_dir.expanduser().resolve()
-    agents = load_agent_data(run_dir)
+    from skillevaluator.tier3.results_location import is_legacy_completed_run_dir
+
+    agents = load_agent_data(
+        run_dir,
+        allow_legacy_missing_status=is_legacy_completed_run_dir(run_dir),
+    )
     if not agents:
         return None
 

--- a/src/skillevaluator/tier3/case_ids.py
+++ b/src/skillevaluator/tier3/case_ids.py
@@ -39,8 +39,6 @@ def validate_case_id(value: object) -> str:
         raise ValueError("case id must not be an absolute path")
     if "/" in case_id or "\\" in case_id:
         raise ValueError("case id must be one path component and must not contain '/' or '\\'")
-    if ".." in case_id:
-        raise ValueError("case id must not contain '..'")
     if not _CASE_ID_PATTERN.fullmatch(case_id):
         raise ValueError(
             "case id must start with an ASCII letter or digit and contain only ASCII letters, digits, '.', '_', or '-'"
@@ -133,6 +131,11 @@ def _validate_directory_components(path: Path, *, case_id: str) -> None:
             )
         if not stat.S_ISDIR(metadata.st_mode):
             raise ValueError(f"refusing case id {case_id!r}: output directory component is not a directory")
+
+
+def validate_output_directory_path(path: Path) -> None:
+    """Reject link/reparse components before creating an evaluator output tree."""
+    _validate_directory_components(path, case_id="<output>")
 
 
 def safe_child(base: Path, component: object) -> Path:

--- a/src/skillevaluator/tier3/commands.py
+++ b/src/skillevaluator/tier3/commands.py
@@ -50,6 +50,7 @@ from skillevaluator.tier3.harbor.runner import (
 from skillevaluator.tier3.harbor.secure_copy import copytree_secure
 from skillevaluator.tier3.results_location import (
     iter_candidate_results_roots,
+    ordered_run_directories,
     resolve_latest_results,
     resolve_results_root,
 )
@@ -927,8 +928,7 @@ def harbor_view(jobs_dir: Path) -> int:
 def compare_results(skill_path: Path, *, results_dir: Path | None = None) -> int:
     """Compare latest Harbor result scores across agents."""
     candidate_roots = iter_candidate_results_roots(skill_path, results_dir)
-    resolved_results_dir = next((root for root in candidate_roots if root.exists()), candidate_roots[0])
-    if not resolved_results_dir.exists():
+    if not any(root.exists() for root in candidate_roots):
         searched = ", ".join(str(p) for p in candidate_roots)
         console.print(f"[red]Error: No results found. Searched: {searched}[/red]")
         return 1
@@ -937,40 +937,51 @@ def compare_results(skill_path: Path, *, results_dir: Path | None = None) -> int
     agent_without: dict[str, dict[str, float]] = {}
     agent_meta: dict[str, dict[str, Any]] = {}
 
-    for ts_dir in sorted(resolved_results_dir.iterdir(), reverse=True):
-        if not ts_dir.is_dir() or ts_dir.name.startswith("_") or ts_dir.name == "latest":
+    for candidate_root in candidate_roots:
+        if not candidate_root.exists():
             continue
-        for agent_dir in sorted(ts_dir.iterdir()):
-            if not agent_dir.is_dir() or agent_dir.name.startswith("_"):
-                continue
-            agent_name = agent_dir.name
-            if agent_name in agent_with:
-                continue
-            summary = agent_dir / "with-skill" / "summary.json"
-            if not summary.exists():
-                summary = agent_dir / "summary.json"
-            if not summary.exists():
-                continue
+        root_with: dict[str, dict[str, float]] = {}
+        root_without: dict[str, dict[str, float]] = {}
+        root_meta: dict[str, dict[str, Any]] = {}
+        for ts_dir in ordered_run_directories(candidate_root):
             try:
-                data = json.loads(summary.read_text(encoding="utf-8"))
-            except (ValueError, OSError):
+                agent_dirs = sorted(ts_dir.iterdir())
+            except OSError:
                 continue
-            scores = _summary_scores(data)
-            if scores:
-                agent_with[agent_name] = scores
-                agent_meta[agent_name] = {
-                    "timestamp": ts_dir.name,
-                    "path": str(agent_dir),
-                    "num_trials": data.get("num_trials", "?"),
-                }
-                wo_summary = agent_dir / "without-skill" / "summary.json"
-                if wo_summary.exists():
-                    try:
-                        wo_scores = _summary_scores(json.loads(wo_summary.read_text(encoding="utf-8")))
-                        if wo_scores:
-                            agent_without[agent_name] = wo_scores
-                    except (ValueError, OSError):
-                        pass
+            for agent_dir in agent_dirs:
+                if not agent_dir.is_dir() or agent_dir.name.startswith("_"):
+                    continue
+                agent_name = agent_dir.name
+                if agent_name in root_with:
+                    continue
+                summary = agent_dir / "with-skill" / "summary.json"
+                if not summary.exists():
+                    summary = agent_dir / "summary.json"
+                if not summary.exists():
+                    continue
+                try:
+                    data = json.loads(summary.read_text(encoding="utf-8"))
+                except (ValueError, OSError):
+                    continue
+                scores = _summary_scores(data)
+                if scores:
+                    root_with[agent_name] = scores
+                    root_meta[agent_name] = {
+                        "timestamp": ts_dir.name,
+                        "path": str(agent_dir),
+                        "num_trials": data.get("num_trials", "?"),
+                    }
+                    wo_summary = agent_dir / "without-skill" / "summary.json"
+                    if wo_summary.exists():
+                        try:
+                            wo_scores = _summary_scores(json.loads(wo_summary.read_text(encoding="utf-8")))
+                            if wo_scores:
+                                root_without[agent_name] = wo_scores
+                        except (ValueError, OSError):
+                            pass
+        if root_with:
+            agent_with, agent_without, agent_meta = root_with, root_without, root_meta
+            break
 
     if not agent_with:
         console.print("[red]No agent results found. Run skillevaluator evaluate first.[/red]")
@@ -1030,6 +1041,8 @@ def compare_results(skill_path: Path, *, results_dir: Path | None = None) -> int
 
 
 def _summary_scores(data: dict[str, Any]) -> dict[str, float]:
+    if not isinstance(data, dict):
+        return {}
     if data.get("execution_status") != "succeeded":
         return {}
     scores: dict[str, float] = {}

--- a/src/skillevaluator/tier3/commands.py
+++ b/src/skillevaluator/tier3/commands.py
@@ -49,6 +49,8 @@ from skillevaluator.tier3.harbor.runner import (
 )
 from skillevaluator.tier3.harbor.secure_copy import copytree_secure
 from skillevaluator.tier3.results_location import (
+    _run_timestamp,
+    is_legacy_completed_run_dir,
     iter_candidate_results_roots,
     ordered_run_directories,
     resolve_latest_results,
@@ -944,6 +946,7 @@ def compare_results(skill_path: Path, *, results_dir: Path | None = None) -> int
         root_without: dict[str, dict[str, float]] = {}
         root_meta: dict[str, dict[str, Any]] = {}
         for ts_dir in ordered_run_directories(candidate_root):
+            allow_missing_status = _run_timestamp(ts_dir.name) is None or is_legacy_completed_run_dir(ts_dir)
             try:
                 agent_dirs = sorted(ts_dir.iterdir())
             except OSError:
@@ -963,7 +966,7 @@ def compare_results(skill_path: Path, *, results_dir: Path | None = None) -> int
                     data = json.loads(summary.read_text(encoding="utf-8"))
                 except (ValueError, OSError):
                     continue
-                scores = _summary_scores(data)
+                scores = _summary_scores(data, allow_missing_status=allow_missing_status)
                 if scores:
                     root_with[agent_name] = scores
                     root_meta[agent_name] = {
@@ -974,7 +977,10 @@ def compare_results(skill_path: Path, *, results_dir: Path | None = None) -> int
                     wo_summary = agent_dir / "without-skill" / "summary.json"
                     if wo_summary.exists():
                         try:
-                            wo_scores = _summary_scores(json.loads(wo_summary.read_text(encoding="utf-8")))
+                            wo_scores = _summary_scores(
+                                json.loads(wo_summary.read_text(encoding="utf-8")),
+                                allow_missing_status=allow_missing_status,
+                            )
                             if wo_scores:
                                 root_without[agent_name] = wo_scores
                         except (ValueError, OSError):
@@ -1040,10 +1046,11 @@ def compare_results(skill_path: Path, *, results_dir: Path | None = None) -> int
     return 0
 
 
-def _summary_scores(data: dict[str, Any]) -> dict[str, float]:
+def _summary_scores(data: dict[str, Any], *, allow_missing_status: bool = False) -> dict[str, float]:
     if not isinstance(data, dict):
         return {}
-    if data.get("execution_status") != "succeeded":
+    status = data.get("execution_status")
+    if status != "succeeded" and not (allow_missing_status and status is None):
         return {}
     scores: dict[str, float] = {}
     raw_scores = data.get("scores", data)

--- a/src/skillevaluator/tier3/evals_spec.py
+++ b/src/skillevaluator/tier3/evals_spec.py
@@ -200,9 +200,12 @@ grading:
         kind="dir",
         requirement=Requirement.OPTIONAL,
         scope=Scope.HARBOR,
-        description="Input files staged into /workspace/input/ inside containers. "
-        "Test data, configs, sample documents the skill needs during evaluation.",
-        validation_notes=["Any file types. Entire directory is copied into the agent workspace."],
+        description="Shared pool of test data, configs, and sample documents that eval entries can stage "
+        "into /workspace/input/ inside containers.",
+        validation_notes=[
+            "Any file types. An entry with files stages only its declared paths; "
+            "omitting files copies this entire directory for backward compatibility."
+        ],
     ),
     # -- Custom environment --
     EntrySpec(

--- a/src/skillevaluator/tier3/harbor/adapter.py
+++ b/src/skillevaluator/tier3/harbor/adapter.py
@@ -398,10 +398,11 @@ def _path_is_link_or_reparse(path: Path, metadata: os.stat_result | None = None)
         except FileNotFoundError:
             return False
     reparse_flag = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+    file_attributes = getattr(metadata, "st_file_attributes", 0) or 0
     is_junction = getattr(path, "is_junction", None)
     return (
         stat.S_ISLNK(metadata.st_mode)
-        or bool(getattr(metadata, "st_file_attributes", 0) & reparse_flag)
+        or bool(file_attributes & reparse_flag)
         or (callable(is_junction) and is_junction())
     )
 

--- a/src/skillevaluator/tier3/harbor/adapter.py
+++ b/src/skillevaluator/tier3/harbor/adapter.py
@@ -323,13 +323,15 @@ def _find_target_manifest_payload(
     return None
 
 
+def _casefold_contained(candidate: Path, root: Path) -> bool:
+    """Return whether *candidate* is lexically below *root*, ignoring path casing."""
+    candidate_parts = tuple(part.casefold() for part in candidate.parts)
+    root_parts = tuple(part.casefold() for part in root.parts)
+    return len(candidate_parts) >= len(root_parts) and candidate_parts[: len(root_parts)] == root_parts
+
+
 def _path_is_excluded(path: Path, excluded_roots: Sequence[Path]) -> bool:
     """Check lexical and resolved containment using cross-platform path casing."""
-
-    def _casefold_contained(candidate: Path, root: Path) -> bool:
-        candidate_parts = tuple(part.casefold() for part in candidate.parts)
-        root_parts = tuple(part.casefold() for part in root.parts)
-        return len(candidate_parts) >= len(root_parts) and candidate_parts[: len(root_parts)] == root_parts
 
     for excluded_root in excluded_roots:
         if _casefold_contained(path.absolute(), excluded_root.absolute()):
@@ -378,18 +380,75 @@ def _path_is_canonically_contained(path: Path, root: Path) -> bool:
     return True
 
 
+def _authenticated_generated_output_ancestor(
+    path: Path,
+    root: Path,
+    authenticated_roots: set[Path] | None = None,
+) -> Path | None:
+    """Find an authenticated generated-output boundary or reject an unsafe marker."""
+    lexical_path = path.absolute()
+    for authenticated_root in authenticated_roots or ():
+        if _casefold_contained(lexical_path, authenticated_root.absolute()):
+            return authenticated_root
+
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        current = path.parent
+    except OSError as exc:
+        raise ValueError(f"Cannot inspect potential generated output path: {path}") from exc
+    else:
+        current = (
+            path if stat.S_ISDIR(metadata.st_mode) and not _path_is_link_or_reparse(path, metadata) else path.parent
+        )
+
+    lexical_root = root.absolute()
+    try:
+        resolved_root = root.resolve()
+    except (OSError, RuntimeError):
+        resolved_root = lexical_root
+
+    def _inside_root(candidate: Path) -> bool:
+        absolute_candidate = candidate.absolute()
+        if _casefold_contained(absolute_candidate, lexical_root) or _casefold_contained(
+            absolute_candidate, resolved_root
+        ):
+            return True
+        try:
+            return _casefold_contained(candidate.resolve(), resolved_root)
+        except (OSError, RuntimeError):
+            return False
+
+    while _inside_root(current):
+        marker = current / GENERATED_OUTPUT_MARKER
+        if os.path.lexists(marker):
+            if _path_is_link_or_reparse(current):
+                raise ValueError(f"Generated output marker is under an unsafe linked directory: {current}")
+            try:
+                authenticated = is_generated_output_root(current)
+            except (OSError, ValueError) as exc:
+                raise ValueError(f"Generated output marker is invalid or cannot be authenticated: {current}") from exc
+            if not authenticated:
+                raise ValueError(f"Generated output marker is invalid or cannot be authenticated: {current}")
+            if authenticated_roots is not None:
+                authenticated_roots.add(current)
+            return current
+        if _paths_equivalent(current, root):
+            break
+        parent = current.parent
+        if parent == current:
+            break
+        current = parent
+    return None
+
+
 def _inside_declared_generated_dataset(path: Path, declared_roots: Sequence[Path]) -> bool:
     """Return whether *path* is below a staged dataset marker in a declared output root."""
     for declared_root in declared_roots:
         if not _path_is_excluded(path, (declared_root,)):
             continue
-        current = path if path.is_dir() else path.parent
-        while _path_is_excluded(current, (declared_root,)):
-            if is_generated_output_root(current):
-                return True
-            if _paths_equivalent(current, declared_root):
-                break
-            current = current.parent
+        if _authenticated_generated_output_ancestor(path, declared_root) is not None:
+            return True
     return False
 
 
@@ -535,6 +594,16 @@ def _runtime_skill_copy_ignore(skill_root: Path, excluded_roots: Sequence[Path] 
     """Build a root-aware ignore callback for an agent-visible skill copy."""
     resolved_root = skill_root.resolve()
     excluded_roots = _skill_scoped_excluded_roots(skill_root, excluded_roots)
+    authenticated_output_roots: set[Path] = set()
+    if (
+        _authenticated_generated_output_ancestor(
+            skill_root,
+            skill_root,
+            authenticated_output_roots,
+        )
+        is not None
+    ):
+        raise ValueError(f"Runtime skill source must not be a generated output root: {skill_root}")
 
     def _ignore(directory: str, contents: list[str]) -> list[str]:
         current = Path(directory)
@@ -543,7 +612,16 @@ def _runtime_skill_copy_ignore(skill_root: Path, excluded_roots: Sequence[Path] 
             ignored.update(name for name in contents if name.casefold() == "evals")
         for name in contents:
             candidate = current / name
-            if _is_skill_evals_path(candidate, skill_root) or _path_is_excluded(candidate, excluded_roots):
+            if (
+                _is_skill_evals_path(candidate, skill_root)
+                or _path_is_excluded(candidate, excluded_roots)
+                or _authenticated_generated_output_ancestor(
+                    candidate,
+                    skill_root,
+                    authenticated_output_roots,
+                )
+                is not None
+            ):
                 ignored.add(name)
         return sorted(ignored)
 
@@ -735,17 +813,27 @@ def _staged_relative_link_path(skill_name: str, raw_target: str) -> Path | None:
         "skills",
         ".agents",
         ".claude",
+        ".cline",
         ".codex",
         ".config",
         ".cursor",
         ".gemini",
         ".opencode",
+        ".qwen",
     }:
         return None
     return rel
 
 
-def _repo_context_ignore_file(path: Path, root: Path) -> bool:
+def _repo_context_ignore_file(
+    path: Path,
+    root: Path,
+    authenticated_output_roots: set[Path] | None = None,
+) -> bool:
+    if authenticated_output_roots is None:
+        authenticated_output_roots = set()
+    if _authenticated_generated_output_ancestor(path, root, authenticated_output_roots) is not None:
+        return True
     try:
         path.resolve().relative_to(root.resolve())
     except ValueError:
@@ -821,11 +909,19 @@ def _git_context_files(root: Path) -> list[Path]:
     return [root / line for line in result.stdout.splitlines() if line.strip()]
 
 
-def _iter_repo_context_files(root: Path) -> list[Path]:
+def _iter_repo_context_files(root: Path, authenticated_output_roots: set[Path]) -> list[Path]:
     git_files = _git_context_files(root)
     if git_files:
-        return sorted(path for path in git_files if path.is_file())
-    return sorted(path for path in root.rglob("*") if path.is_file() and not _repo_context_ignore_file(path, root))
+        return sorted(
+            path
+            for path in git_files
+            if path.is_file() and not _repo_context_ignore_file(path, root, authenticated_output_roots)
+        )
+    return sorted(
+        path
+        for path in root.rglob("*")
+        if path.is_file() and not _repo_context_ignore_file(path, root, authenticated_output_roots)
+    )
 
 
 def _stage_repo_context(
@@ -843,6 +939,16 @@ def _stage_repo_context(
     source_skill_path = source_skill_path.resolve()
     skill_md = _skill_manifest(source_skill_path)
     repo_root = _repo_context_root(source_skill_path)
+    authenticated_output_roots: set[Path] = set()
+    if (
+        _authenticated_generated_output_ancestor(
+            repo_root,
+            repo_root,
+            authenticated_output_roots,
+        )
+        is not None
+    ):
+        raise ValueError(f"Repo context root must not be a generated output root: {repo_root}")
 
     resolved_excluded_roots: list[Path] = []
     for excluded_root in excluded_roots:
@@ -863,10 +969,10 @@ def _stage_repo_context(
     staged: list[dict[str, str]] = []
 
     if mode == "full":
-        for src in _iter_repo_context_files(repo_root):
+        for src in _iter_repo_context_files(repo_root, authenticated_output_roots):
             if _is_excluded_output(src):
                 continue
-            if _repo_context_ignore_file(src, repo_root):
+            if _repo_context_ignore_file(src, repo_root, authenticated_output_roots):
                 continue
             if exclude_source_skill and _is_relative_to(src, source_skill_path):
                 continue
@@ -901,8 +1007,14 @@ def _stage_repo_context(
         if _is_excluded_output(target_path) or _path_is_excluded(lexical_target_path, resolved_excluded_roots):
             logger.warning("Skipping SKILL.md link into generated output: %s", raw_target)
             continue
-        if _repo_context_ignore_file(lexical_target_path, repo_root) or _repo_context_ignore_file(
-            target_path, repo_root
+        if _repo_context_ignore_file(
+            lexical_target_path,
+            repo_root,
+            authenticated_output_roots,
+        ) or _repo_context_ignore_file(
+            target_path,
+            repo_root,
+            authenticated_output_roots,
         ):
             logger.warning("Skipping ignored SKILL.md repo link: %s", raw_target)
             continue
@@ -2717,22 +2829,29 @@ _AGENT_SKILL_PATHS = [
 ]
 _RUNTIME_SKILL_DIRS = (
     "/etc/codex/skills",
+    "/tmp/codex-home/skills",
     "/workspace/skills",
     "/workspace/.agents/skills",
     "/workspace/.claude/commands",
     "/workspace/.claude/skills",
+    "/workspace/.cline/skills",
     "/workspace/.codex/skills",
+    "/workspace/.config/goose/skills",
     "/workspace/.config/opencode/skills",
     "/workspace/.cursor/skills",
     "/workspace/.gemini/skills",
     "/workspace/.gemini/extensions",
     "/workspace/.opencode/skills",
+    "/workspace/.qwen/skills",
     "/root/.claude/commands",
     "/root/.claude/skills",
+    "/root/.cline/skills",
     "/root/.agents/skills",
     "/root/.codex/skills",
+    "/root/.config/goose/skills",
     "/root/.config/opencode/skills",
     "/root/.gemini/extensions",
+    "/root/.qwen/skills",
     "/logs/agent/sessions/skills",
     "/tmp/agent-home/sessions/skills",
 )
@@ -2740,12 +2859,15 @@ _PROJECT_SKILL_RELATIVE_DIRS = (
     ".agents/skills",
     ".claude/commands",
     ".claude/skills",
+    ".cline/skills",
     ".codex/skills",
+    ".config/goose/skills",
     ".config/opencode/skills",
     ".cursor/skills",
     ".gemini/skills",
     ".gemini/extensions",
     ".opencode/skills",
+    ".qwen/skills",
 )
 _RUNTIME_DISCOVERY_ENV_NAMES = frozenset(
     {
@@ -2842,11 +2964,12 @@ _RUNTIME_PROJECTION_OVERLAP_PREFLIGHT = (
     "/workspace/input|/workspace/input/*|/workspace/repo|/workspace/repo/*|"
     "/workspace/skills|/workspace/skills/*|"
     "*/.agents/skills|*/.agents/skills/*|*/.claude/commands|*/.claude/commands/*|"
-    "*/.claude/skills|*/.claude/skills/*|"
-    "*/.codex/skills|*/.codex/skills/*|*/.config/opencode/skills|*/.config/opencode/skills/*|"
+    "*/.claude/skills|*/.claude/skills/*|*/.cline/skills|*/.cline/skills/*|"
+    "*/.codex/skills|*/.codex/skills/*|*/.config/goose/skills|*/.config/goose/skills/*|"
+    "*/.config/opencode/skills|*/.config/opencode/skills/*|"
     "*/.cursor/skills|*/.cursor/skills/*|*/.gemini/skills|*/.gemini/skills/*|"
     "*/.gemini/extensions|*/.gemini/extensions/*|"
-    "*/.opencode/skills|*/.opencode/skills/*) "
+    "*/.opencode/skills|*/.opencode/skills/*|*/.qwen/skills|*/.qwen/skills/*) "
     "echo 'SkillEvaluator agent workdir/home overlaps an evaluator-controlled runtime projection' >&2; "
     'exit 78;; esac; }; check_control_path() { value=$1; check_path "$value"; '
     'if [ -d "$value" ]; then canonical=$(CDPATH= cd -P -- "$value" 2>/dev/null && /bin/pwd -P) || exit 78; '
@@ -2899,11 +3022,14 @@ def _validated_agent_workdir(agent_workdir: str | None) -> str | None:
     discovery_parts = (
         (".agents", "skills"),
         (".claude", "skills"),
+        (".cline", "skills"),
         (".codex", "skills"),
+        (".config", "goose", "skills"),
         (".config", "opencode", "skills"),
         (".cursor", "skills"),
         (".gemini", "skills"),
         (".opencode", "skills"),
+        (".qwen", "skills"),
     )
     if any(
         parts[index : index + len(candidate)] == candidate

--- a/src/skillevaluator/tier3/harbor/adapter.py
+++ b/src/skillevaluator/tier3/harbor/adapter.py
@@ -27,7 +27,7 @@ import stat
 import subprocess
 import tempfile
 import tomllib
-from collections.abc import Sequence
+from collections.abc import Callable, Iterable, Sequence
 from pathlib import Path
 from typing import Any
 from urllib.parse import unquote
@@ -81,6 +81,8 @@ _REPO_CONTEXT_IGNORE_NAMES = {
 }
 _REPO_CONTEXT_IGNORE_PARTS = {("evals", "results")}
 _REPO_CONTEXT_IGNORE_SUFFIXES = (".pem", ".key", ".p12", ".pfx")
+_NATIVE_SOURCE_IGNORE_NAMES = ("results", "__pycache__", ".git", GENERATED_OUTPUT_MARKER)
+_NATIVE_SOURCE_IGNORE = shutil.ignore_patterns(*_NATIVE_SOURCE_IGNORE_NAMES)
 _REPO_CONTEXT_PUBLIC_ENV_SUFFIXES = (".dist", ".example", ".sample", ".template")
 _REPO_CONTEXT_SENSITIVE_NAMES = {
     ".git-credentials",
@@ -291,6 +293,7 @@ def _find_target_manifest_payload(
     runtime_projection: bool = False,
     excluded_roots: Sequence[Path] = (),
     ignored_parts: frozenset[str] = frozenset(),
+    ignored_path_predicate: Callable[[Path], bool] | None = None,
 ) -> Path | None:
     """Find a renamed file containing the exact evaluated-skill instructions."""
     target_manifest = _skill_manifest(target_skill)
@@ -299,6 +302,8 @@ def _find_target_manifest_payload(
     target_payload = target_manifest.read_bytes()
     runtime_ignore = _runtime_skill_copy_ignore(root, excluded_roots) if runtime_projection else None
     for candidate in root.rglob("*"):
+        if ignored_path_predicate is not None and ignored_path_predicate(candidate):
+            continue
         relative_parts = candidate.relative_to(root).parts
         if ignored_parts.intersection(relative_parts):
             continue
@@ -3500,9 +3505,10 @@ def _write_dockerfile(
     custom_env_dir = skill_path / "evals" / "environment" if skill_path else None
 
     if custom_env_dir and custom_env_dir.exists():
-        staged_custom_env = env_dir / ".skillevaluator-custom-environment"
-        copytree_secure(custom_env_dir, staged_custom_env, allowed_root=skill_path)
+        private_custom_env = tempfile.TemporaryDirectory(prefix="skillevaluator-custom-environment-")
+        staged_custom_env = Path(private_custom_env.name) / "environment"
         try:
+            copytree_secure(custom_env_dir, staged_custom_env, allowed_root=skill_path)
             if not has_skill and skill_path:
                 _check_custom_environment_does_not_stage_target(staged_custom_env, skill_path)
 
@@ -3571,7 +3577,7 @@ def _write_dockerfile(
                     )
                 return
         finally:
-            shutil.rmtree(staged_custom_env, ignore_errors=True)
+            private_custom_env.cleanup()
 
     if base_image:
         dockerfile_lines = [
@@ -3899,13 +3905,29 @@ def _prepare_native_environment(
     )
 
 
-def _native_task_dirs(dataset_dir: Path) -> list[Path]:
+def _native_task_dirs(
+    dataset_dir: Path,
+    *,
+    ignore: Callable[[str, list[str]], Iterable[str]] | None = None,
+) -> list[Path]:
     """Return native Harbor task directories from a copied dataset."""
+    children = sorted(dataset_dir.iterdir())
+    ignored = set(ignore(os.fspath(dataset_dir), [path.name for path in children])) if ignore is not None else set()
     return [
         p
-        for p in sorted(dataset_dir.iterdir())
-        if p.is_dir() and not p.name.startswith((".", "_")) and (p / "task.toml").exists()
+        for p in children
+        if p.name not in ignored and p.is_dir() and not p.name.startswith((".", "_")) and (p / "task.toml").exists()
     ]
+
+
+def _native_source_path_is_ignored(path: Path, native_dir: Path) -> bool:
+    """Apply the native copy ignore callback to every lexical path component."""
+    parent = native_dir
+    for part in path.relative_to(native_dir).parts:
+        if part in _NATIVE_SOURCE_IGNORE(os.fspath(parent), [part]):
+            return True
+        parent /= part
+    return False
 
 
 def _native_entry_id(task_dir: Path) -> str:
@@ -4163,10 +4185,8 @@ def _check_native_source_does_not_stage_target(
     *,
     with_skill: bool,
 ) -> None:
-    ignored_parts = frozenset({"results", "__pycache__", ".git"})
-
     def _is_ignored(path: Path) -> bool:
-        return bool(ignored_parts.intersection(path.relative_to(native_dir).parts))
+        return _native_source_path_is_ignored(path, native_dir)
 
     target_skill_name = target_skill.name
     for skill_md in _iter_skill_manifests(native_dir):
@@ -4191,7 +4211,7 @@ def _check_native_source_does_not_stage_target(
             payload = _find_target_manifest_payload(
                 environment_dir,
                 target_skill,
-                ignored_parts=ignored_parts,
+                ignored_path_predicate=_is_ignored,
             )
             if payload is not None:
                 raise ValueError(
@@ -4251,7 +4271,7 @@ def _stage_native_harbor_tasks_into(
     _validate_output_roots_outside_evaluator_sources(skill_path, repo_context_exclude_paths)
     _check_native_source_does_not_stage_target(native_dir, skill_path, with_skill=with_skill)
     entries_by_id = _load_entries_by_id(skill_path)
-    source_task_dirs = _native_task_dirs(native_dir)
+    source_task_dirs = _native_task_dirs(native_dir, ignore=_NATIVE_SOURCE_IGNORE)
     if not source_task_dirs:
         raise ValueError(f"No Harbor task directories with task.toml found in {native_dir}")
     validate_case_ids(path.name for path in source_task_dirs)
@@ -4265,7 +4285,7 @@ def _stage_native_harbor_tasks_into(
     copytree_secure(
         native_dir,
         output_dir,
-        ignore=shutil.ignore_patterns("results", "__pycache__", ".git", GENERATED_OUTPUT_MARKER),
+        ignore=_NATIVE_SOURCE_IGNORE,
     )
     output_dir.mkdir(parents=True, exist_ok=True)
     task_dirs = _native_task_dirs(output_dir)

--- a/src/skillevaluator/tier3/harbor/adapter.py
+++ b/src/skillevaluator/tier3/harbor/adapter.py
@@ -476,6 +476,44 @@ def _authenticated_generated_output_ancestor(
     return None
 
 
+def _authenticated_generated_output_latest_alias(
+    path: Path,
+    root: Path,
+    authenticated_roots: set[Path] | None = None,
+) -> bool:
+    """Recognize only ``latest`` links to an authenticated immediate run child."""
+    if path.name != "latest":
+        return False
+    try:
+        metadata = path.lstat()
+    except OSError:
+        return False
+    if not stat.S_ISLNK(metadata.st_mode):
+        return False
+    try:
+        relative_target = path.readlink()
+    except OSError:
+        return False
+    target_text = os.fspath(relative_target)
+    if (
+        relative_target.is_absolute()
+        or len(relative_target.parts) != 1
+        or target_text in {"", ".", ".."}
+        or "/" in target_text
+        or "\\" in target_text
+    ):
+        return False
+    target = path.parent / relative_target
+    try:
+        target_metadata = target.lstat()
+    except OSError:
+        return False
+    if _path_is_link_or_reparse(target, target_metadata) or not stat.S_ISDIR(target_metadata.st_mode):
+        return False
+    authenticated = _authenticated_generated_output_ancestor(target, root, authenticated_roots)
+    return authenticated is not None and _paths_equivalent(authenticated, target)
+
+
 def _inside_declared_generated_dataset(path: Path, declared_roots: Sequence[Path]) -> bool:
     """Return whether *path* is below a staged dataset marker in a declared output root."""
     for declared_root in declared_roots:
@@ -655,6 +693,11 @@ def _runtime_skill_copy_ignore(skill_root: Path, excluded_roots: Sequence[Path] 
                     authenticated_output_roots,
                 )
                 is not None
+                or _authenticated_generated_output_latest_alias(
+                    candidate,
+                    skill_root,
+                    authenticated_output_roots,
+                )
             ):
                 ignored.add(name)
         return sorted(ignored)
@@ -867,6 +910,8 @@ def _repo_context_ignore_file(
     if authenticated_output_roots is None:
         authenticated_output_roots = set()
     if _authenticated_generated_output_ancestor(path, root, authenticated_output_roots) is not None:
+        return True
+    if _authenticated_generated_output_latest_alias(path, root, authenticated_output_roots):
         return True
     try:
         path.resolve().relative_to(root.resolve())

--- a/src/skillevaluator/tier3/harbor/adapter.py
+++ b/src/skillevaluator/tier3/harbor/adapter.py
@@ -27,7 +27,9 @@ import stat
 import subprocess
 import tempfile
 import tomllib
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Iterable, Iterator, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 from urllib.parse import unquote
@@ -44,6 +46,7 @@ from skillevaluator.tier3.output_provenance import (
 )
 from skillevaluator.tier3.toml_utils import toml_quote
 from skillevaluator.utils.process_environment import child_process_env
+from skillevaluator.utils.secure_fs import SecurePathError, SecureRoot
 
 logger = logging.getLogger(__name__)
 
@@ -52,6 +55,32 @@ _EVAL_CORE_DIR = Path(__file__).resolve().parent.parent / "eval_core"
 _BASE_IMAGE_PREFIX = "skillevaluator-base"
 _MAX_REPO_CONTEXT_FILE_BYTES = 10 * 1024 * 1024
 _MAX_REPO_CONTEXT_TOTAL_BYTES = 200 * 1024 * 1024
+_MAX_EVALUATOR_FILE_BYTES = 64 * 1024 * 1024
+_MAX_EVALS_CONFIG_BYTES = 4 * 1024 * 1024
+_MAX_MCP_CONFIG_BYTES = 1024 * 1024
+_EVALUATOR_DATASET_FILENAMES = (
+    "evals.json",
+    "evals.jsonl",
+    "evals.yaml",
+    "evals.yml",
+    "dataset.json",
+    "dataset.jsonl",
+    "dataset.yaml",
+    "dataset.yml",
+)
+_EVALUATOR_ONLY_TASK_INPUT_FILES = frozenset(
+    {
+        *(name.casefold() for name in _EVALUATOR_DATASET_FILENAMES),
+        "benchmark_" + "conversion_report.md",
+        "config.yaml",
+        "config.yml",
+        "eval.md",
+        "grader.py",
+        "grader.sh",
+        GENERATED_OUTPUT_MARKER.casefold(),
+    }
+)
+_EVALUATOR_ONLY_TASK_INPUT_ROOTS = frozenset({"environment", "harbor", "results", "tests"})
 _REPO_CONTEXT_IGNORE_NAMES = {
     ".git",
     ".hg",
@@ -1157,6 +1186,7 @@ def build_eval_base_image(
     reference_skills_dir: Path | None = None,
     *,
     workspace_skill_paths: list[Path] | None = None,
+    evaluator_skill_path: Path | None = None,
     excluded_roots: Sequence[Path] = (),
     force_rebuild: bool = False,
     action_out: list[str] | None = None,
@@ -1174,10 +1204,11 @@ def build_eval_base_image(
     Returns the image tag (e.g. ``skillevaluator-base:a1b2c3d4e5f6``) or ``""``
     on failure (callers fall back to full per-task Dockerfiles).
     """
+    evaluator_source = evaluator_skill_path or skill_path
     has_custom_dockerfile = (
-        skill_path
-        and (skill_path / "evals" / "environment" / "Dockerfile").is_file()
-        and _validate_custom_dockerfile(skill_path / "evals" / "environment" / "Dockerfile") is None
+        evaluator_source
+        and (evaluator_source / "evals" / "environment" / "Dockerfile").is_file()
+        and _validate_custom_dockerfile(evaluator_source / "evals" / "environment" / "Dockerfile") is None
     )
 
     if has_custom_dockerfile:
@@ -1422,48 +1453,101 @@ def _load_evals(evals_path: Path) -> list[dict[str, Any]]:
     return normalize_dataset_entries(data)
 
 
-def _read_regular_evals_file(path: Path) -> bytes:
-    """Read one evaluator file without following links or accepting swaps."""
+def _evaluator_node_fingerprint(metadata: os.stat_result) -> tuple[int, int, int, int, int, int, int]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_mode,
+        metadata.st_nlink,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+    )
+
+
+def _snapshot_evaluator_parent_path(path: Path, allowed_root: Path, *, label: str) -> tuple[tuple[Path, tuple], ...]:
+    """Capture every real directory component anchoring an evaluator file."""
+    lexical_path = path.absolute()
+    lexical_root = allowed_root.absolute()
+    try:
+        lexical_path.relative_to(lexical_root)
+    except ValueError as exc:
+        raise ValueError(f"{label} resolves outside its evaluator root: {path}") from exc
+    snapshot: list[tuple[Path, tuple]] = []
+    current = lexical_path.parent
+    while True:
+        try:
+            component = current.lstat()
+        except OSError as exc:
+            raise ValueError(f"Cannot inspect {label.lower()} path: {current}") from exc
+        if _path_is_link_or_reparse(current, component):
+            raise ValueError(f"{label} path must not contain symlinks or reparse points: {current}")
+        if not stat.S_ISDIR(component.st_mode):
+            raise ValueError(f"{label} parent path must contain only directories: {current}")
+        snapshot.append((current, _evaluator_node_fingerprint(component)))
+        if current == lexical_root:
+            break
+        if lexical_root not in current.parents:
+            raise ValueError(f"{label} resolves outside its evaluator root: {path}")
+        current = current.parent
+    return tuple(snapshot)
+
+
+def _validate_evaluator_parent_snapshot(snapshot: tuple[tuple[Path, tuple], ...], *, label: str) -> None:
+    for component_path, expected in snapshot:
+        try:
+            component = component_path.lstat()
+        except OSError as exc:
+            raise ValueError(f"{label} path changed while it was read: {component_path}") from exc
+        if (
+            _path_is_link_or_reparse(component_path, component)
+            or not stat.S_ISDIR(component.st_mode)
+            or _evaluator_node_fingerprint(component) != expected
+        ):
+            raise ValueError(f"{label} path changed while it was read: {component_path}")
+
+
+def _read_regular_evals_file(
+    path: Path,
+    *,
+    label: str = "Eval dataset",
+    max_bytes: int = _MAX_EVALUATOR_FILE_BYTES,
+    allowed_root: Path | None = None,
+) -> bytes:
+    """Read one bounded evaluator file without following links or accepting swaps."""
+    parent_snapshot = (
+        _snapshot_evaluator_parent_path(path, allowed_root, label=label) if allowed_root is not None else ()
+    )
     try:
         before = path.lstat()
     except OSError as exc:
-        raise ValueError(f"Cannot inspect eval dataset file: {path}") from exc
+        raise ValueError(f"Cannot inspect {label.lower()} file: {path}") from exc
     if _path_is_link_or_reparse(path, before) or not stat.S_ISREG(before.st_mode) or before.st_nlink != 1:
-        raise ValueError(f"Eval dataset must be a regular non-linked file: {path}")
-    if before.st_size > 64 * 1024 * 1024:
-        raise ValueError(f"Eval dataset exceeds the 64 MiB safety limit: {path}")
-    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+        raise ValueError(f"{label} must be a regular non-linked file: {path}")
+    if before.st_size > max_bytes:
+        raise ValueError(f"{label} exceeds the {max_bytes}-byte safety limit: {path}")
+    secure_root_path = allowed_root.absolute() if allowed_root is not None else path.parent.absolute()
     try:
-        descriptor = os.open(path, flags)
+        relative_path = path.absolute().relative_to(secure_root_path)
+        root_metadata = secure_root_path.lstat()
+        with SecureRoot(secure_root_path, expected=root_metadata) as secure_root:
+            payload, opened = secure_root.read_bytes(relative_path, max_bytes, expected=before)
+    except (OSError, SecurePathError, ValueError) as exc:
+        raise ValueError(f"{label} changed while it was read: {path}") from exc
+
+    try:
+        named_after = path.lstat()
     except OSError as exc:
-        raise ValueError(f"Cannot safely open eval dataset file: {path}") from exc
-    try:
-        opened = os.fstat(descriptor)
-        before_fingerprint = (before.st_dev, before.st_ino, before.st_mode, before.st_nlink, before.st_size)
-        opened_fingerprint = (opened.st_dev, opened.st_ino, opened.st_mode, opened.st_nlink, opened.st_size)
-        if (
-            _path_is_link_or_reparse(path, opened)
-            or not stat.S_ISREG(opened.st_mode)
-            or opened.st_nlink != 1
-            or opened_fingerprint != before_fingerprint
-        ):
-            raise ValueError(f"Eval dataset changed while it was opened: {path}")
-        chunks: list[bytes] = []
-        remaining = opened.st_size + 1
-        while remaining:
-            chunk = os.read(descriptor, min(1024 * 1024, remaining))
-            if not chunk:
-                break
-            chunks.append(chunk)
-            remaining -= len(chunk)
-        payload = b"".join(chunks)
-        after = os.fstat(descriptor)
-        after_fingerprint = (after.st_dev, after.st_ino, after.st_mode, after.st_nlink, after.st_size)
-        if after_fingerprint != opened_fingerprint or len(payload) != opened.st_size:
-            raise ValueError(f"Eval dataset changed while it was read: {path}")
-        return payload
-    finally:
-        os.close(descriptor)
+        raise ValueError(f"{label} changed while it was read: {path}") from exc
+    if (
+        _path_is_link_or_reparse(path, named_after)
+        or _evaluator_node_fingerprint(named_after) != _evaluator_node_fingerprint(opened)
+        or len(payload) != opened.st_size
+    ):
+        raise ValueError(f"{label} changed while it was read: {path}")
+    if parent_snapshot:
+        _validate_evaluator_parent_snapshot(parent_snapshot, label=label)
+    return payload
 
 
 def _validate_evals_source_directory(skill_path: Path) -> None:
@@ -1519,15 +1603,30 @@ def _write_instruction(task_dir: Path, question: str) -> None:
 
 def _load_mcp_servers(skill_path: Path) -> list[dict[str, Any]]:
     """Load MCP server declarations from evals/environment/mcp_servers.toml."""
-    mcp_file = skill_path / "evals" / "environment" / "mcp_servers.toml"
-    if not mcp_file.exists():
+    evals_dir = skill_path / "evals"
+    environment_dir = evals_dir / "environment"
+    mcp_file = environment_dir / "mcp_servers.toml"
+    if not os.path.lexists(environment_dir):
+        return []
+    parent_snapshot = _snapshot_evaluator_parent_path(mcp_file, evals_dir, label="MCP server configuration")
+    if not os.path.lexists(mcp_file):
+        _validate_evaluator_parent_snapshot(parent_snapshot, label="MCP server configuration")
         return []
     try:
         import tomllib
     except ImportError:
         import tomli as tomllib  # type: ignore[no-redef]
+    payload = _read_regular_evals_file(
+        mcp_file,
+        label="MCP server configuration",
+        max_bytes=_MAX_MCP_CONFIG_BYTES,
+        allowed_root=evals_dir,
+    )
     try:
-        data = tomllib.loads(mcp_file.read_text(encoding="utf-8"))
+        data = tomllib.loads(payload.decode("utf-8"))
+        if not isinstance(data, dict):
+            logger.warning("mcp_servers.toml: expected a TOML table, got %s", type(data).__name__)
+            return []
         servers = data.get("mcp_servers", [])
         if not isinstance(servers, list):
             logger.warning("mcp_servers.toml: expected [[mcp_servers]] array, got %s", type(servers).__name__)
@@ -1547,7 +1646,7 @@ def _load_mcp_servers(skill_path: Path) -> list[dict[str, Any]]:
         if valid:
             logger.debug("Loaded %d MCP server(s) from %s", len(valid), mcp_file)
         return valid
-    except Exception as e:
+    except (UnicodeDecodeError, tomllib.TOMLDecodeError) as e:
         logger.warning("Failed to parse %s: %s", mcp_file, e)
         return []
 
@@ -1739,7 +1838,13 @@ def _has_symlink_component(path: Path, root: Path) -> bool:
     return False
 
 
-def _copy_custom_grader(task_dir: Path, skill_path: Path, grading_mode: str) -> bool:
+def _copy_custom_grader(
+    task_dir: Path,
+    skill_path: Path,
+    grading_mode: str,
+    *,
+    evals_dir: Path | None = None,
+) -> bool:
     """Copy user custom grader support into a generated task, if configured."""
     tests_dir = task_dir / "tests"
     tests_dir.mkdir(parents=True, exist_ok=True)
@@ -1748,27 +1853,27 @@ def _copy_custom_grader(task_dir: Path, skill_path: Path, grading_mode: str) -> 
     if runner_src.exists():
         shutil.copy2(runner_src, tests_dir / "custom_grader_runner.py")
 
+    evals_dir = evals_dir or skill_path / "evals"
     grader_candidates = [
-        (skill_path / "evals" / "grader.py", tests_dir / "grader.py"),
-        (skill_path / "evals" / "grader.sh", tests_dir / "grader.sh"),
-        (skill_path / "evals" / "tests" / "grader.py", tests_dir / "grader.py"),
-        (skill_path / "evals" / "tests" / "grader.sh", tests_dir / "grader.sh"),
+        (evals_dir / "grader.py", tests_dir / "grader.py"),
+        (evals_dir / "grader.sh", tests_dir / "grader.sh"),
+        (evals_dir / "tests" / "grader.py", tests_dir / "grader.py"),
+        (evals_dir / "tests" / "grader.sh", tests_dir / "grader.sh"),
     ]
     for grader, destination in grader_candidates:
-        if _has_symlink_component(grader, skill_path):
+        if _has_symlink_component(grader, evals_dir):
             raise ValueError(f"custom grader must be a non-symlinked regular file contained under evals/: {grader}")
         if not grader.exists():
             continue
         if not grader.is_file():
             raise ValueError(f"custom grader must be a non-symlinked regular file contained under evals/: {grader}")
 
-        resolved_skill = skill_path.resolve(strict=True)
-        resolved_evals = (skill_path / "evals").resolve(strict=True)
+        resolved_evals = evals_dir.resolve(strict=True)
         resolved_grader = grader.resolve(strict=True)
-        if not resolved_evals.is_relative_to(resolved_skill) or not resolved_grader.is_relative_to(resolved_evals):
+        if not resolved_grader.is_relative_to(resolved_evals):
             raise ValueError(f"custom grader must be a non-symlinked regular file contained under evals/: {grader}")
 
-        copy_file_secure(grader, destination, allowed_root=skill_path / "evals")
+        copy_file_secure(grader, destination, allowed_root=evals_dir)
         if destination.suffix == ".sh":
             destination.chmod(0o755)
         return True
@@ -3304,6 +3409,16 @@ def _entry_file_refs(entry: dict[str, Any]) -> list[str]:
     return refs
 
 
+def _is_evaluator_only_task_input(relative: Path) -> bool:
+    """Return whether an eval-relative path is evaluator control material."""
+    if not relative.parts:
+        return True
+    top_level = relative.parts[0].casefold()
+    return top_level in _EVALUATOR_ONLY_TASK_INPUT_ROOTS or (
+        len(relative.parts) == 1 and top_level in _EVALUATOR_ONLY_TASK_INPUT_FILES
+    )
+
+
 def _resolve_entry_file_ref(
     ref: str,
     *,
@@ -3323,9 +3438,9 @@ def _resolve_entry_file_ref(
         raise ValueError(f"evals.json files entry uses unsupported URI scheme: {ref}")
 
     if ref_path.parts and ref_path.parts[0] == "evals":
-        candidates = [skill_path / ref_path]
+        candidates = [evals_dir.joinpath(*ref_path.parts[1:])]
     else:
-        candidates = [evals_dir / ref_path, skill_path / ref_path]
+        candidates = [evals_dir / ref_path]
 
     source_path = next((candidate.absolute() for candidate in candidates if candidate.exists()), None)
     if source_path is None:
@@ -3335,6 +3450,9 @@ def _resolve_entry_file_ref(
     resolved_evals_dir = evals_dir.resolve()
     if source == resolved_evals_dir or not _is_relative_to(source, resolved_evals_dir):
         raise ValueError(f"evals.json files entry resolves outside evals/: {ref}")
+    source_relative = source.relative_to(resolved_evals_dir)
+    if _is_evaluator_only_task_input(source_relative):
+        raise ValueError(f"evals.json files entry selects evaluator-only material: {ref}")
     if _has_symlink_component(source_path, evals_dir.absolute()):
         raise ValueError(f"evals.json files entry must not contain symlinks: {ref}")
 
@@ -3342,7 +3460,7 @@ def _resolve_entry_file_ref(
     if resolved_input_files_dir and _is_relative_to(source, resolved_input_files_dir):
         rel = source.relative_to(resolved_input_files_dir)
     else:
-        rel = source.relative_to(resolved_evals_dir)
+        rel = source_relative
 
     return source_path, rel
 
@@ -3523,13 +3641,19 @@ def _write_dockerfile(
     include_repo = (env_dir / "repo").exists()
     include_repo_linked_root = (env_dir / "repo-linked-root").exists()
 
-    custom_env_dir = skill_path / "evals" / "environment" if skill_path else None
+    custom_env_dir = (
+        evals_dir / "environment"
+        if evals_dir is not None
+        else skill_path / "evals" / "environment"
+        if skill_path is not None
+        else None
+    )
 
     if custom_env_dir and custom_env_dir.exists():
         private_custom_env = tempfile.TemporaryDirectory(prefix="skillevaluator-custom-environment-")
         staged_custom_env = Path(private_custom_env.name) / "environment"
         try:
-            copytree_secure(custom_env_dir, staged_custom_env, allowed_root=skill_path)
+            copytree_secure(custom_env_dir, staged_custom_env, allowed_root=evals_dir)
             if not has_skill and skill_path:
                 _check_custom_environment_does_not_stage_target(staged_custom_env, skill_path)
 
@@ -4258,6 +4382,7 @@ def _stage_native_harbor_tasks_into(
     skill_path: Path,
     output_dir: Path,
     *,
+    evaluator_skill_path: Path,
     with_skill: bool = True,
     reference_skills_dir: Path | None = None,
     workspace_skill_paths: list[Path] | None = None,
@@ -4267,6 +4392,7 @@ def _stage_native_harbor_tasks_into(
     custom_dockerfile_mode: str = "rebase",
     copy_repo: bool = False,
     repo_context_exclude_paths: Sequence[Path] = (),
+    private_repo_context_exclude_paths: Sequence[Path] = (),
     runtime_env: dict[str, str] | None = None,
     verifier_env: dict[str, str] | None = None,
     pre_agent_setup: list[str] | None = None,
@@ -4280,7 +4406,8 @@ def _stage_native_harbor_tasks_into(
     """
     _validate_runtime_discovery_env(runtime_env)
     _validate_runtime_loader_env(runtime_env)
-    native_dir = skill_path / "evals" / "harbor"
+    evals_dir = evaluator_skill_path / "evals"
+    native_dir = evals_dir / "harbor"
     if not native_dir.exists():
         raise FileNotFoundError(f"No native Harbor task source found at {native_dir}")
     _validate_staging_output_location(
@@ -4291,7 +4418,7 @@ def _stage_native_harbor_tasks_into(
     )
     _validate_output_roots_outside_evaluator_sources(skill_path, repo_context_exclude_paths)
     _check_native_source_does_not_stage_target(native_dir, skill_path, with_skill=with_skill)
-    entries_by_id = _load_entries_by_id(skill_path)
+    entries_by_id = _load_entries_by_id(evaluator_skill_path)
     source_task_dirs = _native_task_dirs(native_dir, ignore=_NATIVE_SOURCE_IGNORE)
     if not source_task_dirs:
         raise ValueError(f"No Harbor task directories with task.toml found in {native_dir}")
@@ -4340,7 +4467,7 @@ def _stage_native_harbor_tasks_into(
         if (not custom_grader and grading_mode != "custom_only") or (
             not custom_grader and not (tests_dir / "test.sh").exists()
         ):
-            custom_grader = _copy_custom_grader(task_dir, skill_path, grading_mode)
+            custom_grader = _copy_custom_grader(task_dir, skill_path, grading_mode, evals_dir=evals_dir)
 
         if grading_mode in ("default", "default_plus_custom"):
             _ensure_skill_evaluator_verifier_env(
@@ -4373,13 +4500,13 @@ def _stage_native_harbor_tasks_into(
                 f"custom_only native Harbor task '{entry_id}' requires tests/grader.py or tests/test.sh"
             )
 
-        if entry is not None and _entry_declares_task_input(entry, skill_path / "evals" / "files"):
+        if entry is not None and _entry_declares_task_input(entry, evals_dir / "files"):
             _stage_task_inputs(
                 task_dir / "environment",
-                input_files_dir=skill_path / "evals" / "files",
+                input_files_dir=evals_dir / "files",
                 entry=entry,
                 source_skill_path=skill_path,
-                evals_dir=skill_path / "evals",
+                evals_dir=evals_dir,
             )
         _prepare_native_environment(
             task_dir,
@@ -4392,7 +4519,7 @@ def _stage_native_harbor_tasks_into(
             grading_mode=grading_mode,
             repo_context_mode="full" if copy_repo else "linked",
             compose_env_names=set(runtime_env or {}),
-            repo_context_exclude_paths=repo_context_exclude_paths,
+            repo_context_exclude_paths=(*repo_context_exclude_paths, *private_repo_context_exclude_paths),
             agent_workdir=native_agent_workdir,
         )
 
@@ -4400,6 +4527,32 @@ def _stage_native_harbor_tasks_into(
         _write_dataset_toml(output_dir, [p.name for p in task_dirs])
     _copy_metric_py(output_dir)
     return task_dirs
+
+
+def _private_task_staging_parent(
+    skill_path: Path,
+    *,
+    reference_skills_dir: Path | None,
+    workspace_skill_paths: Sequence[Path],
+) -> Path:
+    """Choose a temp parent outside every runtime skill source.
+
+    Preserve the normal system temporary location unless TMPDIR places task
+    staging inside a runtime skill source. In that case, use a sibling of the
+    target skill and ascend only when that location is itself inside a
+    configured reference or workspace source.
+    """
+    external_sources = [*workspace_skill_paths]
+    if reference_skills_dir is not None:
+        external_sources.append(reference_skills_dir)
+    candidate = Path(tempfile.gettempdir())
+    if not any(_path_is_excluded(candidate, (source,)) for source in (skill_path, *external_sources)):
+        return candidate
+
+    candidate = skill_path.parent
+    while candidate.parent != candidate and any(_path_is_excluded(candidate, (source,)) for source in external_sources):
+        candidate = candidate.parent
+    return candidate
 
 
 def stage_native_harbor_tasks(
@@ -4420,8 +4573,31 @@ def stage_native_harbor_tasks(
     pre_agent_setup: list[str] | None = None,
     task_resources: dict[str, int] | None = None,
     agent_workdir: str | None = None,
+    evaluator_skill_path: Path | None = None,
 ) -> list[Path]:
     """Stage native tasks privately, then publish one exact output snapshot."""
+
+    if evaluator_skill_path is None:
+        with private_evaluator_skill_snapshot(skill_path, task_source="native_harbor") as private_skill_path:
+            return stage_native_harbor_tasks(
+                skill_path,
+                output_dir,
+                with_skill=with_skill,
+                reference_skills_dir=reference_skills_dir,
+                workspace_skill_paths=workspace_skill_paths,
+                workspace_mode=workspace_mode,
+                grading_mode=grading_mode,
+                base_image=base_image,
+                custom_dockerfile_mode=custom_dockerfile_mode,
+                copy_repo=copy_repo,
+                repo_context_exclude_paths=repo_context_exclude_paths,
+                runtime_env=runtime_env,
+                verifier_env=verifier_env,
+                pre_agent_setup=pre_agent_setup,
+                task_resources=task_resources,
+                agent_workdir=agent_workdir,
+                evaluator_skill_path=private_skill_path,
+            )
 
     validate_output_provenance_key_location(
         skill_path,
@@ -4440,12 +4616,21 @@ def stage_native_harbor_tasks(
     if output_requires_provenance:
         validate_generated_output_replacement(output_dir)
 
-    with tempfile.TemporaryDirectory(prefix="skillevaluator-native-tasks-") as temporary:
+    private_staging_parent = _private_task_staging_parent(
+        skill_path,
+        reference_skills_dir=reference_skills_dir,
+        workspace_skill_paths=workspace_skill_paths or (),
+    )
+    with tempfile.TemporaryDirectory(
+        prefix="skillevaluator-native-tasks-",
+        dir=private_staging_parent,
+    ) as temporary:
         private_root = Path(temporary).resolve(strict=True)
         private_output = private_root / "dataset"
         private_tasks = _stage_native_harbor_tasks_into(
             skill_path,
             private_output,
+            evaluator_skill_path=evaluator_skill_path,
             with_skill=with_skill,
             reference_skills_dir=reference_skills_dir,
             workspace_skill_paths=workspace_skill_paths,
@@ -4454,7 +4639,12 @@ def stage_native_harbor_tasks(
             base_image=base_image,
             custom_dockerfile_mode=custom_dockerfile_mode,
             copy_repo=copy_repo,
-            repo_context_exclude_paths=(*repo_context_exclude_paths, output_dir, private_root),
+            repo_context_exclude_paths=(
+                *repo_context_exclude_paths,
+                output_dir,
+                private_root,
+            ),
+            private_repo_context_exclude_paths=(evaluator_skill_path.parent,),
             runtime_env=runtime_env,
             verifier_env=verifier_env,
             pre_agent_setup=pre_agent_setup,
@@ -4501,6 +4691,7 @@ def _generate_harbor_tasks_into(
     skill_path: Path,
     output_dir: Path,
     *,
+    evaluator_skill_path: Path,
     with_skill: bool = True,
     reference_skills_dir: Path | None = None,
     workspace_skill_paths: list[Path] | None = None,
@@ -4510,6 +4701,7 @@ def _generate_harbor_tasks_into(
     custom_dockerfile_mode: str = "rebase",
     copy_repo: bool = False,
     repo_context_exclude_paths: Sequence[Path] = (),
+    private_repo_context_exclude_paths: Sequence[Path] = (),
     runtime_env: dict[str, str] | None = None,
     verifier_env: dict[str, str] | None = None,
     pre_agent_setup: list[str] | None = None,
@@ -4550,8 +4742,8 @@ def _generate_harbor_tasks_into(
     _validate_runtime_discovery_env(runtime_env)
     _validate_runtime_loader_env(runtime_env)
     agent_workdir = _validated_agent_workdir(agent_workdir)
-    evals_dir = skill_path / "evals"
-    evals_file = find_evals_file(skill_path)
+    evals_dir = evaluator_skill_path / "evals"
+    evals_file = find_evals_file(evaluator_skill_path)
     _validate_staging_output_location(
         skill_path,
         output_dir,
@@ -4573,7 +4765,7 @@ def _generate_harbor_tasks_into(
     if not input_files_dir.exists():
         input_files_dir = None
 
-    mcp_servers = _load_mcp_servers(skill_path)
+    mcp_servers = _load_mcp_servers(evaluator_skill_path)
     prepared_entries = _preflight_generated_tasks(entries, output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
     task_dirs: list[str] = []
@@ -4604,7 +4796,7 @@ def _generate_harbor_tasks_into(
             agent_workdir=agent_workdir,
         )
         _copy_verifier(task_dir)
-        custom_grader = _copy_custom_grader(task_dir, skill_path, grading_mode)
+        custom_grader = _copy_custom_grader(task_dir, skill_path, grading_mode, evals_dir=evals_dir)
         _write_entry_json(
             task_dir,
             normalized_entry,
@@ -4631,7 +4823,7 @@ def _generate_harbor_tasks_into(
             repo_context_skill_path=skill_path,
             repo_context_mode="full" if copy_repo else "linked",
             compose_env_names=set(runtime_env or {}),
-            repo_context_exclude_paths=repo_context_exclude_paths,
+            repo_context_exclude_paths=(*repo_context_exclude_paths, *private_repo_context_exclude_paths),
             agent_workdir=agent_workdir,
         )
 
@@ -4649,6 +4841,361 @@ def _generate_harbor_tasks_into(
         with_skill,
     )
     return task_paths
+
+
+@dataclass(frozen=True)
+class _EvaluatorProjectionSelection:
+    """Evaluator paths selected before the single secure-copy transaction."""
+
+    exact_paths: frozenset[tuple[str, ...]]
+    whole_roots: frozenset[tuple[str, ...]]
+    signature: tuple[Any, ...]
+
+
+def _projection_path_exists(path: Path) -> bool:
+    """Check lexical presence without silently dropping a broken link."""
+    return os.path.lexists(path)
+
+
+def _selected_environment_projection(evals_dir: Path) -> tuple[set[tuple[str, ...]], set[tuple[str, ...]]]:
+    """Select the custom environment as one compatibility-preserving unit."""
+    exact: set[tuple[str, ...]] = set()
+    whole: set[tuple[str, ...]] = set()
+    environment = evals_dir / "environment"
+    if not _projection_path_exists(environment):
+        return exact, whole
+    # Custom Docker handling first creates a secure copy of this complete tree
+    # before it validates Dockerfile/Compose and selects sidecars. Keeping the
+    # directory whole preserves authored environment behavior while unrelated
+    # evals/ siblings remain outside the snapshot.
+    whole.add(("environment",))
+    return exact, whole
+
+
+def _selected_grader_paths(evals_dir: Path) -> tuple[tuple[str, ...], ...]:
+    candidates = (("grader.py",), ("grader.sh",), ("tests", "grader.py"), ("tests", "grader.sh"))
+    return tuple(relative for relative in candidates if _projection_path_exists(evals_dir.joinpath(*relative)))
+
+
+def _resolved_projection_task_source(
+    requested_task_source: str | None,
+    evals_config: dict[str, Any],
+    *,
+    dataset_path: Path | None,
+    native_dir: Path,
+) -> str:
+    configured = requested_task_source
+    if configured is None:
+        harbor_config = evals_config.get("harbor", {})
+        configured = harbor_config.get("task_source", "auto") if isinstance(harbor_config, dict) else "auto"
+    if configured not in {"auto", "evals_json", "native_harbor"}:
+        configured = "auto"
+    if configured == "auto":
+        if dataset_path is not None:
+            return "evals_json"
+        if native_dir.exists():
+            return "native_harbor"
+    return configured
+
+
+def _native_projection_entry_ids(native_dir: Path) -> tuple[str, ...]:
+    """Read native task IDs without following unsafe authored nodes.
+
+    The secure projection copy validates the complete selected ``harbor/`` tree
+    as one transaction. Selection only needs immediate task identities so it
+    can avoid fixtures referenced exclusively by generated entries.
+    """
+    try:
+        native_metadata = native_dir.lstat()
+        parent_metadata = native_dir.parent.lstat()
+    except OSError:
+        return ()
+    if (
+        _path_is_link_or_reparse(native_dir, native_metadata)
+        or not stat.S_ISDIR(native_metadata.st_mode)
+        or not stat.S_ISDIR(parent_metadata.st_mode)
+        or native_metadata.st_dev != parent_metadata.st_dev
+    ):
+        return ()
+    try:
+        children = sorted(native_dir.iterdir())
+    except OSError:
+        return ()
+    ignored = set(_NATIVE_SOURCE_IGNORE(os.fspath(native_dir), [path.name for path in children]))
+    entry_ids: list[str] = []
+    for task_dir in children:
+        if task_dir.name in ignored or task_dir.name.startswith((".", "_")):
+            continue
+        try:
+            task_metadata = task_dir.lstat()
+        except OSError:
+            continue
+        if (
+            _path_is_link_or_reparse(task_dir, task_metadata)
+            or not stat.S_ISDIR(task_metadata.st_mode)
+            or task_metadata.st_dev != native_metadata.st_dev
+        ):
+            continue
+        task_toml = task_dir / "task.toml"
+        if not _projection_path_exists(task_toml):
+            continue
+        entry_id = task_dir.name
+        try:
+            payload = _read_regular_evals_file(
+                task_toml,
+                label="Native Harbor task configuration",
+                allowed_root=native_dir,
+            )
+            data = tomllib.loads(payload.decode("utf-8"))
+            metadata = data.get("metadata", {}) if isinstance(data, dict) else {}
+            if isinstance(metadata, dict) and metadata.get("entry_id"):
+                entry_id = str(metadata["entry_id"])
+        except (UnicodeError, ValueError):
+            # Staging owns the detailed invalid-task diagnostic after the secure
+            # snapshot exists. Directory-name fallback remains non-invasive.
+            pass
+        entry_ids.append(entry_id)
+    return tuple(sorted(entry_ids))
+
+
+def _decode_projection_config(payload: bytes) -> tuple[dict[str, Any], bool]:
+    """Decode only the source-selection hint from already-secured config bytes."""
+    import yaml
+
+    try:
+        raw = yaml.safe_load(payload.decode("utf-8"))
+    except (UnicodeError, yaml.YAMLError):
+        return {}, False
+    if not isinstance(raw, dict):
+        return {}, False
+    harbor = raw.get("harbor")
+    if harbor is not None and not isinstance(harbor, dict):
+        return {}, False
+    return raw, True
+
+
+def _evaluator_projection_selection(
+    skill_path: Path,
+    *,
+    task_source: str | None,
+    bind_full_evidence_sources: bool,
+) -> _EvaluatorProjectionSelection:
+    """Resolve the evaluator projection and a post-copy selection signature."""
+    import yaml
+
+    from skillevaluator.tier3.dataset_utils import normalize_dataset_entries
+    from skillevaluator.tier3.evals_config import CONFIG_FILENAMES
+
+    evals_dir = skill_path / "evals"
+    config_path = next(
+        (evals_dir / name for name in CONFIG_FILENAMES if _projection_path_exists(evals_dir / name)),
+        None,
+    )
+    evals_config: dict[str, Any] = {}
+    config_valid = True
+    config_digest: str | None = None
+    if config_path is not None:
+        config_payload = _read_regular_evals_file(
+            config_path,
+            label="Eval configuration",
+            max_bytes=_MAX_EVALS_CONFIG_BYTES,
+            allowed_root=evals_dir,
+        )
+        config_digest = hashlib.sha256(config_payload).hexdigest()
+        evals_config, config_valid = _decode_projection_config(config_payload)
+
+    dataset_path = find_evals_file(skill_path)
+    dataset_valid = True
+    entries: list[dict[str, Any]] = []
+    dataset_digest: str | None = None
+    if dataset_path is not None:
+        dataset_payload = _read_regular_evals_file(dataset_path, allowed_root=evals_dir)
+        dataset_digest = hashlib.sha256(dataset_payload).hexdigest()
+        try:
+            decoded = dataset_payload.decode("utf-8")
+            suffix = dataset_path.suffix.casefold()
+            if suffix == ".jsonl":
+                raw_entries: Any = [json.loads(line) for raw_line in decoded.splitlines() if (line := raw_line.strip())]
+            elif suffix in {".yaml", ".yml"}:
+                raw_entries = yaml.safe_load(decoded)
+            elif suffix == ".json":
+                raw_entries = json.loads(decoded)
+            else:
+                raise ValueError(f"Unsupported dataset format: {suffix}")
+            entries = normalize_dataset_entries(raw_entries)
+        except (UnicodeError, TypeError, ValueError, yaml.YAMLError):
+            # Invalid datasets do not have a meaningful fixture selection. Copy
+            # the dataset itself and let normal task staging report its error.
+            dataset_valid = False
+
+    resolved_task_source = _resolved_projection_task_source(
+        task_source,
+        evals_config,
+        dataset_path=dataset_path,
+        native_dir=evals_dir / "harbor",
+    )
+    native_entry_ids: tuple[str, ...] = ()
+    native_dir = evals_dir / "harbor"
+    if resolved_task_source == "native_harbor" and _projection_path_exists(native_dir):
+        native_entry_ids = _native_projection_entry_ids(native_dir)
+    exact_paths: set[tuple[str, ...]] = set()
+    whole_roots: set[tuple[str, ...]] = set()
+    if config_path is not None:
+        exact_paths.add((config_path.name,))
+    if dataset_path is not None:
+        exact_paths.add((dataset_path.name,))
+    if resolved_task_source == "native_harbor" and _projection_path_exists(evals_dir / "harbor"):
+        whole_roots.add(("harbor",))
+
+    environment_exact, environment_whole = _selected_environment_projection(evals_dir)
+    exact_paths.update(environment_exact)
+    whole_roots.update(environment_whole)
+
+    available_grader_paths = _selected_grader_paths(evals_dir)
+    grader_paths = (
+        available_grader_paths
+        if bind_full_evidence_sources and resolved_task_source == "evals_json"
+        else available_grader_paths[:1]
+    )
+    exact_paths.update(grader_paths)
+
+    fixture_signature: tuple[Any, ...] = ("invalid-or-absent-dataset",)
+    if dataset_path is not None and dataset_valid:
+        files_dir = evals_dir / "files"
+        native_entry_id_set = set(native_entry_ids)
+        fixture_entries = (
+            [entry for entry in entries if str(entry.get("id")) in native_entry_id_set]
+            if resolved_task_source == "native_harbor"
+            else entries
+        )
+        implicit_shared_files = (
+            (bind_full_evidence_sources and resolved_task_source == "evals_json")
+            or any("files" not in entry for entry in fixture_entries)
+        ) and _projection_path_exists(files_dir)
+        selected_refs: set[tuple[str, ...]] = set()
+        if implicit_shared_files:
+            whole_roots.add(("files",))
+        for entry in fixture_entries:
+            for ref in _entry_file_refs(entry):
+                source, _staged_relative = _resolve_entry_file_ref(
+                    ref,
+                    skill_path=skill_path,
+                    evals_dir=evals_dir,
+                    input_files_dir=files_dir if files_dir.exists() else None,
+                )
+                relative = source.absolute().relative_to(evals_dir.absolute()).parts
+                try:
+                    source_metadata = source.lstat()
+                except OSError:
+                    exact_paths.add(relative)
+                    selected_refs.add(relative)
+                    continue
+                if stat.S_ISDIR(source_metadata.st_mode) and not _path_is_link_or_reparse(source, source_metadata):
+                    whole_roots.add(relative)
+                else:
+                    exact_paths.add(relative)
+                selected_refs.add(relative)
+        fixture_signature = (
+            "all-files" if implicit_shared_files else "declared-only",
+            tuple(sorted(selected_refs)),
+        )
+
+    signature = (
+        config_path.name if config_path is not None else None,
+        config_valid,
+        config_digest,
+        resolved_task_source,
+        dataset_path.name if dataset_path is not None else None,
+        dataset_valid,
+        dataset_digest,
+        bind_full_evidence_sources,
+        native_entry_ids,
+        fixture_signature,
+        grader_paths,
+        tuple(sorted(environment_exact)),
+        tuple(sorted(environment_whole)),
+    )
+    return _EvaluatorProjectionSelection(
+        exact_paths=frozenset(exact_paths),
+        whole_roots=frozenset(whole_roots),
+        signature=signature,
+    )
+
+
+def _projection_includes(
+    relative: tuple[str, ...],
+    *,
+    exact_paths: frozenset[tuple[str, ...]],
+    whole_roots: frozenset[tuple[str, ...]],
+) -> bool:
+    if any(relative == exact[: len(relative)] for exact in exact_paths):
+        return True
+    return any(relative == whole[: len(relative)] or whole == relative[: len(whole)] for whole in whole_roots)
+
+
+@contextmanager
+def private_evaluator_skill_snapshot(
+    skill_path: Path,
+    *,
+    task_source: str | None = None,
+    bind_full_evidence_sources: bool = False,
+) -> Iterator[Path]:
+    """Yield one selective, immutable evaluator projection for a complete run."""
+    source_evals_dir = skill_path / "evals"
+    _validate_evals_source_directory(skill_path)
+    if not source_evals_dir.is_dir():
+        raise FileNotFoundError(f"No evaluator source directory found at {source_evals_dir}")
+
+    selection = _evaluator_projection_selection(
+        skill_path,
+        task_source=task_source,
+        bind_full_evidence_sources=bind_full_evidence_sources,
+    )
+    source_evals_canonical = source_evals_dir.resolve(strict=True)
+
+    with tempfile.TemporaryDirectory(prefix="skillevaluator-evals-snapshot-") as snapshot_root_text:
+        snapshot_root = Path(snapshot_root_text)
+        evaluator_skill_path = snapshot_root / skill_path.name
+        evaluator_skill_path.mkdir()
+        try:
+            snapshot_source_relative = snapshot_root.resolve(strict=True).relative_to(source_evals_canonical).parts
+        except (OSError, ValueError):
+            snapshot_source_relative = ()
+
+        def _ignore_unselected_evaluator_paths(current: str, names: list[str]) -> set[str]:
+            try:
+                current_relative = Path(current).resolve(strict=True).relative_to(source_evals_canonical).parts
+            except (OSError, ValueError):
+                return set(names)
+            ignored = {
+                name
+                for name in names
+                if not _projection_includes(
+                    (*current_relative, name),
+                    exact_paths=selection.exact_paths,
+                    whole_roots=selection.whole_roots,
+                )
+            }
+            if snapshot_source_relative:
+                ignored.update(name for name in names if (*current_relative, name) == snapshot_source_relative)
+            if current_relative and current_relative[0].casefold() == "harbor":
+                ignored.update(_NATIVE_SOURCE_IGNORE(current, names))
+            return ignored
+
+        copytree_secure(
+            source_evals_dir,
+            evaluator_skill_path / "evals",
+            ignore=_ignore_unselected_evaluator_paths,
+            allowed_root=source_evals_dir,
+        )
+        copied_selection = _evaluator_projection_selection(
+            evaluator_skill_path,
+            task_source=task_source,
+            bind_full_evidence_sources=bind_full_evidence_sources,
+        )
+        if copied_selection.signature != selection.signature:
+            raise ValueError("Evaluator source selection changed while its private snapshot was created")
+        yield evaluator_skill_path
 
 
 def generate_harbor_tasks(
@@ -4669,8 +5216,35 @@ def generate_harbor_tasks(
     pre_agent_setup: list[str] | None = None,
     task_resources: dict[str, int] | None = None,
     agent_workdir: str | None = None,
+    evaluator_skill_path: Path | None = None,
 ) -> list[Path]:
-    """Generate tasks privately, then publish one exact output snapshot."""
+    """Generate tasks from one private evals snapshot, then publish exactly."""
+
+    if evaluator_skill_path is None:
+        if find_evals_file(skill_path) is None:
+            raise FileNotFoundError(f"No evals dataset found in {skill_path / 'evals'}")
+        with private_evaluator_skill_snapshot(skill_path, task_source="evals_json") as private_skill_path:
+            return generate_harbor_tasks(
+                skill_path,
+                output_dir,
+                with_skill=with_skill,
+                reference_skills_dir=reference_skills_dir,
+                workspace_skill_paths=workspace_skill_paths,
+                workspace_mode=workspace_mode,
+                grading_mode=grading_mode,
+                base_image=base_image,
+                custom_dockerfile_mode=custom_dockerfile_mode,
+                copy_repo=copy_repo,
+                repo_context_exclude_paths=repo_context_exclude_paths,
+                runtime_env=runtime_env,
+                verifier_env=verifier_env,
+                pre_agent_setup=pre_agent_setup,
+                task_resources=task_resources,
+                agent_workdir=agent_workdir,
+                evaluator_skill_path=private_skill_path,
+            )
+    if find_evals_file(evaluator_skill_path) is None:
+        raise FileNotFoundError(f"No evals dataset found in {evaluator_skill_path / 'evals'}")
 
     validate_output_provenance_key_location(
         skill_path,
@@ -4689,12 +5263,21 @@ def generate_harbor_tasks(
     if output_requires_provenance:
         validate_generated_output_replacement(output_dir)
 
-    with tempfile.TemporaryDirectory(prefix="skillevaluator-generated-tasks-") as temporary:
+    private_staging_parent = _private_task_staging_parent(
+        skill_path,
+        reference_skills_dir=reference_skills_dir,
+        workspace_skill_paths=workspace_skill_paths or (),
+    )
+    with tempfile.TemporaryDirectory(
+        prefix="skillevaluator-generated-tasks-",
+        dir=private_staging_parent,
+    ) as temporary:
         private_root = Path(temporary).resolve(strict=True)
         private_output = private_root / "dataset"
         private_tasks = _generate_harbor_tasks_into(
             skill_path,
             private_output,
+            evaluator_skill_path=evaluator_skill_path,
             with_skill=with_skill,
             reference_skills_dir=reference_skills_dir,
             workspace_skill_paths=workspace_skill_paths,
@@ -4703,7 +5286,12 @@ def generate_harbor_tasks(
             base_image=base_image,
             custom_dockerfile_mode=custom_dockerfile_mode,
             copy_repo=copy_repo,
-            repo_context_exclude_paths=(*repo_context_exclude_paths, output_dir, private_root),
+            repo_context_exclude_paths=(
+                *repo_context_exclude_paths,
+                output_dir,
+                private_root,
+            ),
+            private_repo_context_exclude_paths=(evaluator_skill_path.parent,),
             runtime_env=runtime_env,
             verifier_env=verifier_env,
             pre_agent_setup=pre_agent_setup,

--- a/src/skillevaluator/tier3/harbor/adapter.py
+++ b/src/skillevaluator/tier3/harbor/adapter.py
@@ -35,7 +35,11 @@ from typing import Any
 from urllib.parse import unquote
 
 from skillevaluator.tier3.case_ids import safe_child, validate_case_ids, validate_output_directory_path
-from skillevaluator.tier3.harbor.secure_copy import copy_file_secure, copytree_secure
+from skillevaluator.tier3.harbor.secure_copy import (
+    copy_file_secure,
+    copytree_secure,
+    tree_content_fingerprint_secure,
+)
 from skillevaluator.tier3.output_provenance import (
     GENERATED_OUTPUT_MARKER,
     is_generated_output_root,
@@ -112,6 +116,7 @@ _REPO_CONTEXT_IGNORE_PARTS = {("evals", "results")}
 _REPO_CONTEXT_IGNORE_SUFFIXES = (".pem", ".key", ".p12", ".pfx")
 _NATIVE_SOURCE_IGNORE_NAMES = ("results", "__pycache__", ".git", GENERATED_OUTPUT_MARKER)
 _NATIVE_SOURCE_IGNORE = shutil.ignore_patterns(*_NATIVE_SOURCE_IGNORE_NAMES)
+_PATH_DESCRIPTOR_IDENTITIES_COMPARABLE = os.name == "posix"
 _REPO_CONTEXT_PUBLIC_ENV_SUFFIXES = (".dist", ".example", ".sample", ".template")
 _REPO_CONTEXT_SENSITIVE_NAMES = {
     ".git-credentials",
@@ -796,6 +801,69 @@ def _check_baseline_skill_candidates_do_not_alias_target(
                 f"Baseline skill candidate '{candidate}' is an alias of target skill '{target_skill.name}'. "
                 "A baseline must not contain the evaluated skill under another directory name."
             )
+
+
+@dataclass(frozen=True, slots=True)
+class _BaselineAliasValidation:
+    """Run-scoped proof that one exact baseline source set was prevalidated."""
+
+    source_key: tuple[Any, ...]
+
+
+def _baseline_alias_source_key(
+    target_skill: Path,
+    reference_skills_dir: Path | None,
+    workspace_skill_paths: Sequence[Path] | None,
+    excluded_roots: Sequence[Path],
+) -> tuple[Any, ...]:
+    def _path_key(path: Path) -> str:
+        return os.path.normcase(os.fspath(path.expanduser().resolve(strict=False)))
+
+    return (
+        _path_key(target_skill),
+        _path_key(reference_skills_dir) if reference_skills_dir is not None else None,
+        tuple(sorted(_path_key(path) for path in workspace_skill_paths or ())),
+        tuple(sorted(_path_key(path) for path in excluded_roots)),
+    )
+
+
+def _prevalidate_baseline_skill_candidates(
+    target_skill: Path,
+    reference_skills_dir: Path | None,
+    workspace_skill_paths: list[Path] | None,
+    *,
+    excluded_roots: Sequence[Path] = (),
+) -> _BaselineAliasValidation:
+    """Validate configured baseline sources once before a multi-agent run."""
+    _check_baseline_skill_candidates_do_not_alias_target(
+        target_skill,
+        reference_skills_dir,
+        workspace_skill_paths,
+        excluded_roots=excluded_roots,
+    )
+    return _BaselineAliasValidation(
+        _baseline_alias_source_key(
+            target_skill,
+            reference_skills_dir,
+            workspace_skill_paths,
+            excluded_roots,
+        )
+    )
+
+
+def _baseline_alias_validation_matches(
+    validation: _BaselineAliasValidation,
+    target_skill: Path,
+    reference_skills_dir: Path | None,
+    workspace_skill_paths: list[Path] | None,
+    excluded_roots: Sequence[Path],
+) -> bool:
+    return validation.source_key == _baseline_alias_source_key(
+        target_skill,
+        reference_skills_dir,
+        workspace_skill_paths,
+        excluded_roots,
+    )
 
 
 def _check_staged_baseline_does_not_contain_target(env_dir: Path, target_skill: Path) -> None:
@@ -1586,8 +1654,18 @@ def _read_regular_evals_file(
         raise ValueError(f"{label} changed while it was read: {path}") from exc
     if (
         _path_is_link_or_reparse(path, named_after)
-        or _evaluator_node_fingerprint(named_after) != _evaluator_node_fingerprint(opened)
         or len(payload) != opened.st_size
+        or (
+            _PATH_DESCRIPTOR_IDENTITIES_COMPARABLE
+            and _evaluator_node_fingerprint(named_after) != _evaluator_node_fingerprint(opened)
+        )
+        or (
+            not _PATH_DESCRIPTOR_IDENTITIES_COMPARABLE
+            and (
+                _evaluator_node_fingerprint(named_after) != _evaluator_node_fingerprint(before)
+                or len(payload) != named_after.st_size
+            )
+        )
     ):
         raise ValueError(f"{label} changed while it was read: {path}")
     if parent_snapshot:
@@ -3596,6 +3674,7 @@ def _write_dockerfile(
     compose_env_names: set[str] | None = None,
     repo_context_exclude_paths: Sequence[Path] = (),
     agent_workdir: str | None = None,
+    baseline_aliases_prevalidated: bool = False,
 ) -> None:
     """Generate a Dockerfile that installs skills into the container.
 
@@ -3608,7 +3687,7 @@ def _write_dockerfile(
     env_dir = task_dir / "environment"
     env_dir.mkdir(parents=True, exist_ok=True)
 
-    if not has_skill and skill_path is not None:
+    if not has_skill and skill_path is not None and not baseline_aliases_prevalidated:
         _check_baseline_skill_candidates_do_not_alias_target(
             skill_path,
             reference_skills_dir,
@@ -3982,11 +4061,12 @@ def _prepare_native_environment(
     compose_env_names: set[str] | None = None,
     repo_context_exclude_paths: Sequence[Path] = (),
     agent_workdir: str | None = None,
+    baseline_aliases_prevalidated: bool = False,
 ) -> None:
     """Stage SkillEvaluator runtime additions into a copied native Harbor task."""
     env_dir = task_dir / "environment"
     env_dir.mkdir(parents=True, exist_ok=True)
-    if not has_skill:
+    if not has_skill and not baseline_aliases_prevalidated:
         _check_baseline_skill_candidates_do_not_alias_target(
             skill_path,
             reference_skills_dir,
@@ -4443,6 +4523,7 @@ def _stage_native_harbor_tasks_into(
     pre_agent_setup: list[str] | None = None,
     task_resources: dict[str, int] | None = None,
     agent_workdir: str | None = None,
+    baseline_aliases_prevalidated: bool = False,
 ) -> list[Path]:
     """Build native Harbor tasks inside a private, caller-owned directory.
 
@@ -4489,6 +4570,15 @@ def _stage_native_harbor_tasks_into(
         )
 
     workspace_skill_names = sorted({p.name for p in workspace_skill_paths or []})
+    effective_excluded_roots = (*repo_context_exclude_paths, *private_repo_context_exclude_paths)
+    if not with_skill and not baseline_aliases_prevalidated:
+        _check_baseline_skill_candidates_do_not_alias_target(
+            skill_path,
+            reference_skills_dir,
+            workspace_skill_paths,
+            excluded_roots=effective_excluded_roots,
+        )
+        baseline_aliases_prevalidated = True
     for task_dir in task_dirs:
         entry_id = _native_entry_id(task_dir)
         native_agent_workdir = _native_task_workdir(task_dir)
@@ -4564,8 +4654,9 @@ def _stage_native_harbor_tasks_into(
             grading_mode=grading_mode,
             repo_context_mode="full" if copy_repo else "linked",
             compose_env_names=set(runtime_env or {}),
-            repo_context_exclude_paths=(*repo_context_exclude_paths, *private_repo_context_exclude_paths),
+            repo_context_exclude_paths=effective_excluded_roots,
             agent_workdir=native_agent_workdir,
+            baseline_aliases_prevalidated=baseline_aliases_prevalidated,
         )
 
     if not (output_dir / "dataset.toml").exists():
@@ -4619,6 +4710,7 @@ def stage_native_harbor_tasks(
     task_resources: dict[str, int] | None = None,
     agent_workdir: str | None = None,
     evaluator_skill_path: Path | None = None,
+    _baseline_alias_validation: _BaselineAliasValidation | None = None,
 ) -> list[Path]:
     """Stage native tasks privately, then publish one exact output snapshot."""
 
@@ -4642,7 +4734,20 @@ def stage_native_harbor_tasks(
                 task_resources=task_resources,
                 agent_workdir=agent_workdir,
                 evaluator_skill_path=private_skill_path,
+                _baseline_alias_validation=_baseline_alias_validation,
             )
+
+    baseline_aliases_prevalidated = False
+    if not with_skill and _baseline_alias_validation is not None:
+        if not _baseline_alias_validation_matches(
+            _baseline_alias_validation,
+            skill_path,
+            reference_skills_dir,
+            workspace_skill_paths,
+            repo_context_exclude_paths,
+        ):
+            raise ValueError("Run-scoped baseline alias validation does not match the requested source set")
+        baseline_aliases_prevalidated = True
 
     validate_output_provenance_key_location(
         skill_path,
@@ -4695,6 +4800,7 @@ def stage_native_harbor_tasks(
             pre_agent_setup=pre_agent_setup,
             task_resources=task_resources,
             agent_workdir=agent_workdir,
+            baseline_aliases_prevalidated=baseline_aliases_prevalidated,
         )
         relative_tasks = [task.relative_to(private_output) for task in private_tasks]
         if output_requires_provenance:
@@ -4752,6 +4858,7 @@ def _generate_harbor_tasks_into(
     pre_agent_setup: list[str] | None = None,
     task_resources: dict[str, int] | None = None,
     agent_workdir: str | None = None,
+    baseline_aliases_prevalidated: bool = False,
 ) -> list[Path]:
     """Generate Harbor task directories inside a private output directory.
 
@@ -4815,6 +4922,15 @@ def _generate_harbor_tasks_into(
     output_dir.mkdir(parents=True, exist_ok=True)
     task_dirs: list[str] = []
     task_paths: list[Path] = []
+    effective_excluded_roots = (*repo_context_exclude_paths, *private_repo_context_exclude_paths)
+    if not with_skill and not baseline_aliases_prevalidated:
+        _check_baseline_skill_candidates_do_not_alias_target(
+            skill_path,
+            reference_skills_dir,
+            workspace_skill_paths,
+            excluded_roots=effective_excluded_roots,
+        )
+        baseline_aliases_prevalidated = True
 
     for normalized_entry, case_id in prepared_entries:
         task_dir = safe_child(output_dir, case_id)
@@ -4868,8 +4984,9 @@ def _generate_harbor_tasks_into(
             repo_context_skill_path=skill_path,
             repo_context_mode="full" if copy_repo else "linked",
             compose_env_names=set(runtime_env or {}),
-            repo_context_exclude_paths=(*repo_context_exclude_paths, *private_repo_context_exclude_paths),
+            repo_context_exclude_paths=effective_excluded_roots,
             agent_workdir=agent_workdir,
+            baseline_aliases_prevalidated=baseline_aliases_prevalidated,
         )
 
         task_dirs.append(case_id)
@@ -5227,6 +5344,12 @@ def private_evaluator_skill_snapshot(
                 ignored.update(_NATIVE_SOURCE_IGNORE(current, names))
             return ignored
 
+        source_content_fingerprint = tree_content_fingerprint_secure(
+            source_evals_dir,
+            ignore=_ignore_unselected_evaluator_paths,
+            allowed_root=source_evals_dir,
+        )
+
         copytree_secure(
             source_evals_dir,
             evaluator_skill_path / "evals",
@@ -5239,6 +5362,9 @@ def private_evaluator_skill_snapshot(
             bind_full_evidence_sources=bind_full_evidence_sources,
         )
         if copied_selection.signature != selection.signature:
+            raise ValueError("Evaluator source selection changed while its private snapshot was created")
+        copied_content_fingerprint = tree_content_fingerprint_secure(evaluator_skill_path / "evals")
+        if copied_content_fingerprint != source_content_fingerprint:
             raise ValueError("Evaluator source selection changed while its private snapshot was created")
         yield evaluator_skill_path
 
@@ -5262,6 +5388,7 @@ def generate_harbor_tasks(
     task_resources: dict[str, int] | None = None,
     agent_workdir: str | None = None,
     evaluator_skill_path: Path | None = None,
+    _baseline_alias_validation: _BaselineAliasValidation | None = None,
 ) -> list[Path]:
     """Generate tasks from one private evals snapshot, then publish exactly."""
 
@@ -5287,9 +5414,22 @@ def generate_harbor_tasks(
                 task_resources=task_resources,
                 agent_workdir=agent_workdir,
                 evaluator_skill_path=private_skill_path,
+                _baseline_alias_validation=_baseline_alias_validation,
             )
     if find_evals_file(evaluator_skill_path) is None:
         raise FileNotFoundError(f"No evals dataset found in {evaluator_skill_path / 'evals'}")
+
+    baseline_aliases_prevalidated = False
+    if not with_skill and _baseline_alias_validation is not None:
+        if not _baseline_alias_validation_matches(
+            _baseline_alias_validation,
+            skill_path,
+            reference_skills_dir,
+            workspace_skill_paths,
+            repo_context_exclude_paths,
+        ):
+            raise ValueError("Run-scoped baseline alias validation does not match the requested source set")
+        baseline_aliases_prevalidated = True
 
     validate_output_provenance_key_location(
         skill_path,
@@ -5342,6 +5482,7 @@ def generate_harbor_tasks(
             pre_agent_setup=pre_agent_setup,
             task_resources=task_resources,
             agent_workdir=agent_workdir,
+            baseline_aliases_prevalidated=baseline_aliases_prevalidated,
         )
         relative_tasks = [task.relative_to(private_output) for task in private_tasks]
         if output_requires_provenance:

--- a/src/skillevaluator/tier3/harbor/adapter.py
+++ b/src/skillevaluator/tier3/harbor/adapter.py
@@ -1469,9 +1469,12 @@ def _stage_task_inputs(
     evals_dir: Path,
 ) -> bool:
     input_dir = env_dir / "input"
-    if input_files_dir and input_files_dir.exists():
-        if input_dir.exists():
-            shutil.rmtree(input_dir)
+    if os.path.lexists(input_dir) and (input_dir.is_symlink() or not input_dir.is_dir()):
+        input_dir.unlink()
+    elif input_dir.exists():
+        shutil.rmtree(input_dir)
+
+    if "files" not in entry and input_files_dir and input_files_dir.exists():
         copytree_secure(input_files_dir, input_dir, dirs_exist_ok=True)
 
     for ref in _entry_file_refs(entry):
@@ -1704,7 +1707,7 @@ def _write_dockerfile(
     )
     dockerfile_lines.extend(agent_config_lines)
 
-    if input_files_dir and input_files_dir.exists():
+    if include_input:
         dockerfile_lines.append("COPY input/ /workspace/input/")
     if include_repo:
         dockerfile_lines.append("COPY repo/ /workspace/repo/")

--- a/src/skillevaluator/tier3/harbor/adapter.py
+++ b/src/skillevaluator/tier3/harbor/adapter.py
@@ -23,15 +23,25 @@ import posixpath
 import re
 import shlex
 import shutil
+import stat
 import subprocess
 import tempfile
 import tomllib
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 from urllib.parse import unquote
 
-from skillevaluator.tier3.case_ids import safe_child, validate_case_ids
-from skillevaluator.tier3.harbor.secure_copy import copytree_secure
+from skillevaluator.tier3.case_ids import safe_child, validate_case_ids, validate_output_directory_path
+from skillevaluator.tier3.harbor.secure_copy import copy_file_secure, copytree_secure
+from skillevaluator.tier3.output_provenance import (
+    GENERATED_OUTPUT_MARKER,
+    is_generated_output_root,
+    output_provenance_key_path,
+    validate_generated_output_replacement,
+    validate_provenance_key_outside,
+    write_generated_output_marker,
+)
 from skillevaluator.tier3.toml_utils import toml_quote
 from skillevaluator.utils.process_environment import child_process_env
 
@@ -220,12 +230,432 @@ def _find_repo_root(path: Path) -> Path | None:
     return None
 
 
+def _repo_context_root(path: Path) -> Path:
+    """Return the exact source root used by repo-context staging."""
+    try:
+        repo_root = _find_repo_root(path)
+        resolved = path.resolve()
+        return repo_root or resolved.parent
+    except (OSError, RuntimeError) as exc:
+        raise ValueError(f"Cannot resolve repository context root for: {path}") from exc
+
+
+def validate_output_provenance_key_location(
+    skill_path: Path,
+    output_dir: Path,
+    *,
+    reference_skills_dir: Path | None,
+    workspace_skill_paths: Sequence[Path],
+) -> None:
+    """Keep the private marker key out of every tree that may reach an agent."""
+    protected_roots = [skill_path, output_dir, *workspace_skill_paths]
+    if reference_skills_dir is not None:
+        protected_roots.append(reference_skills_dir)
+    repo_root = _find_repo_root(skill_path)
+    if repo_root is not None:
+        protected_roots.append(repo_root)
+    for protected_root in protected_roots:
+        validate_provenance_key_outside(protected_root)
+
+
 def _is_relative_to(path: Path, parent: Path) -> bool:
     try:
         path.resolve().relative_to(parent.resolve())
         return True
     except ValueError:
         return False
+
+
+_SKILL_MANIFEST_NAMES = ("SKILL.md", "skill.md")
+
+
+def _skill_manifest(path: Path) -> Path | None:
+    for name in _SKILL_MANIFEST_NAMES:
+        candidate = path / name
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _iter_skill_manifests(root: Path) -> list[Path]:
+    manifests: set[Path] = set()
+    for name in _SKILL_MANIFEST_NAMES:
+        manifests.update(root.rglob(name))
+    return sorted(manifests)
+
+
+def _find_target_manifest_payload(
+    root: Path,
+    target_skill: Path,
+    *,
+    runtime_projection: bool = False,
+    excluded_roots: Sequence[Path] = (),
+    ignored_parts: frozenset[str] = frozenset(),
+) -> Path | None:
+    """Find a renamed file containing the exact evaluated-skill instructions."""
+    target_manifest = _skill_manifest(target_skill)
+    if target_manifest is None:
+        return None
+    target_payload = target_manifest.read_bytes()
+    runtime_ignore = _runtime_skill_copy_ignore(root, excluded_roots) if runtime_projection else None
+    for candidate in root.rglob("*"):
+        relative_parts = candidate.relative_to(root).parts
+        if ignored_parts.intersection(relative_parts):
+            continue
+        if runtime_ignore is not None and _runtime_projection_path_is_ignored(candidate, root, runtime_ignore):
+            continue
+        try:
+            metadata = candidate.lstat()
+        except OSError:
+            continue
+        if stat.S_ISREG(metadata.st_mode) and metadata.st_nlink == 1 and metadata.st_size >= len(target_payload):
+            overlap = max(0, len(target_payload) - 1)
+            previous = b""
+            try:
+                with candidate.open("rb") as stream:
+                    while chunk := stream.read(64 * 1024):
+                        combined = previous + chunk
+                        if target_payload in combined:
+                            return candidate
+                        previous = combined[-overlap:] if overlap else b""
+            except OSError:
+                continue
+    return None
+
+
+def _path_is_excluded(path: Path, excluded_roots: Sequence[Path]) -> bool:
+    """Check lexical and resolved containment using cross-platform path casing."""
+
+    def _casefold_contained(candidate: Path, root: Path) -> bool:
+        candidate_parts = tuple(part.casefold() for part in candidate.parts)
+        root_parts = tuple(part.casefold() for part in root.parts)
+        return len(candidate_parts) >= len(root_parts) and candidate_parts[: len(root_parts)] == root_parts
+
+    for excluded_root in excluded_roots:
+        if _casefold_contained(path.absolute(), excluded_root.absolute()):
+            return True
+        try:
+            resolved_path = path.resolve()
+            resolved_root = excluded_root.resolve()
+        except (OSError, RuntimeError):
+            continue
+        if _casefold_contained(resolved_path, resolved_root):
+            return True
+    return False
+
+
+def _paths_equivalent(first: Path, second: Path) -> bool:
+    """Return whether two paths identify the same cross-platform path."""
+    return _path_is_excluded(first, (second,)) and _path_is_excluded(second, (first,))
+
+
+def _path_is_link_or_reparse(path: Path, metadata: os.stat_result | None = None) -> bool:
+    """Return whether a path is a symlink, junction, or Windows reparse point."""
+    if metadata is None:
+        try:
+            metadata = path.lstat()
+        except FileNotFoundError:
+            return False
+    reparse_flag = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+    is_junction = getattr(path, "is_junction", None)
+    return (
+        stat.S_ISLNK(metadata.st_mode)
+        or bool(getattr(metadata, "st_file_attributes", 0) & reparse_flag)
+        or (callable(is_junction) and is_junction())
+    )
+
+
+def _path_is_canonically_contained(path: Path, root: Path) -> bool:
+    """Require exact-case lexical and resolved containment for safety exceptions."""
+    for candidate, canonical_root in (
+        (path.absolute(), root.absolute()),
+        (path.resolve(), root.resolve()),
+    ):
+        try:
+            candidate.relative_to(canonical_root)
+        except ValueError:
+            return False
+    return True
+
+
+def _inside_declared_generated_dataset(path: Path, declared_roots: Sequence[Path]) -> bool:
+    """Return whether *path* is below a staged dataset marker in a declared output root."""
+    for declared_root in declared_roots:
+        if not _path_is_excluded(path, (declared_root,)):
+            continue
+        current = path if path.is_dir() else path.parent
+        while _path_is_excluded(current, (declared_root,)):
+            if is_generated_output_root(current):
+                return True
+            if _paths_equivalent(current, declared_root):
+                break
+            current = current.parent
+    return False
+
+
+def _target_runtime_source_roots(
+    skill_path: Path,
+    declared_output_roots: Sequence[Path] = (),
+) -> tuple[Path, ...]:
+    """Return standard and nested-package runtime subtrees that output cannot replace."""
+    roots = {skill_path / name for name in ("assets", "references", "scripts", "templates")}
+    default_results_root = skill_path / "evals" / "results"
+    for manifest in _iter_skill_manifests(skill_path):
+        if _path_is_canonically_contained(manifest, default_results_root):
+            continue
+        owner = manifest.parent
+        if not _paths_equivalent(owner, skill_path) and not _inside_declared_generated_dataset(
+            manifest, declared_output_roots
+        ):
+            roots.add(owner)
+    return tuple(sorted(roots))
+
+
+def _validate_output_roots_outside_evaluator_sources(
+    skill_path: Path,
+    output_roots: Sequence[Path],
+) -> None:
+    """Reject output roots that would be copied back as evaluator source data."""
+    evals_dir = skill_path / "evals"
+    results_dir = evals_dir / "results"
+    for output_root in output_roots:
+        if not _path_is_excluded(output_root, (skill_path,)):
+            continue
+        if _path_is_excluded(output_root, (evals_dir,)) and not _path_is_canonically_contained(
+            output_root, results_dir
+        ):
+            raise ValueError(
+                f"Generated output root must not be inside evaluator source directory '{evals_dir}': {output_root}"
+            )
+        if _paths_equivalent(output_root, skill_path):
+            raise ValueError(f"Generated output root must not equal the runtime skill root: {skill_path}")
+        for source_root in _target_runtime_source_roots(skill_path, output_roots):
+            if _path_is_excluded(output_root, (source_root,)) or _path_is_excluded(source_root, (output_root,)):
+                raise ValueError(
+                    f"Generated output root must not overlap runtime skill source '{source_root}': {output_root}"
+                )
+
+
+def _validate_staging_output_location(
+    skill_path: Path,
+    output_dir: Path,
+    *,
+    reference_skills_dir: Path | None = None,
+    workspace_skill_paths: Sequence[Path] = (),
+    declared_output_roots: Sequence[Path] = (),
+) -> None:
+    """Reject a staging destination that could delete evaluator source data."""
+    validate_output_directory_path(output_dir)
+    evals_dir = skill_path / "evals"
+    results_dir = evals_dir / "results"
+    output_is_results = _path_is_canonically_contained(output_dir, results_dir)
+    if not output_is_results and (
+        _path_is_excluded(output_dir, (evals_dir,)) or _path_is_excluded(evals_dir, (output_dir,))
+    ):
+        raise ValueError(f"Staging output directory overlaps evaluator source directory '{evals_dir}': {output_dir}")
+    for source_root in _target_runtime_source_roots(skill_path, declared_output_roots):
+        if _path_is_excluded(output_dir, (source_root,)) or _path_is_excluded(source_root, (output_dir,)):
+            raise ValueError(f"Staging output directory overlaps runtime skill source '{source_root}': {output_dir}")
+    output_inside_skill = _path_is_excluded(output_dir, (skill_path,))
+    output_contains_skill = _path_is_excluded(skill_path, (output_dir,))
+    declared_in_skill = any(
+        _path_is_excluded(output_dir, (declared_root,))
+        and _path_is_excluded(declared_root, (skill_path,))
+        and not _paths_equivalent(declared_root, skill_path)
+        for declared_root in declared_output_roots
+    )
+    if output_contains_skill or (output_inside_skill and not output_is_results and not declared_in_skill):
+        raise ValueError(f"Staging output directory overlaps runtime skill source '{skill_path}': {output_dir}")
+
+    runtime_sources = [*(workspace_skill_paths or [])]
+    if reference_skills_dir is not None:
+        runtime_sources.append(reference_skills_dir)
+    for source_root in runtime_sources:
+        if _path_is_excluded(skill_path, (source_root,)) and _path_is_excluded(output_dir, (skill_path,)):
+            continue
+        if _path_is_excluded(output_dir, (source_root,)) or _path_is_excluded(source_root, (output_dir,)):
+            raise ValueError(f"Staging output directory overlaps runtime skill source '{source_root}': {output_dir}")
+
+
+def validate_results_root_location(
+    skill_path: Path,
+    results_root: Path,
+    *,
+    reference_skills_dir: Path | None = None,
+    workspace_skill_paths: Sequence[Path] = (),
+) -> None:
+    """Validate that a result root cannot become evaluator input or build context."""
+    validate_output_directory_path(results_root)
+    if _path_is_excluded(skill_path, (results_root,)):
+        raise ValueError(f"Generated output root must not contain the runtime skill source: {results_root}")
+    _validate_output_roots_outside_evaluator_sources(skill_path, (results_root,))
+    runtime_sources = [*(workspace_skill_paths or [])]
+    if reference_skills_dir is not None:
+        runtime_sources.append(reference_skills_dir)
+    for source_root in runtime_sources:
+        if _path_is_excluded(skill_path, (source_root,)) and _path_is_excluded(results_root, (skill_path,)):
+            continue
+        if _path_is_excluded(results_root, (source_root,)):
+            raise ValueError(
+                f"Generated output root must not be inside runtime skill source '{source_root}': {results_root}"
+            )
+
+
+def _skill_scoped_excluded_roots(skill_root: Path, excluded_roots: Sequence[Path]) -> tuple[Path, ...]:
+    """Keep only generated-output roots located inside this skill tree."""
+    scoped: list[Path] = []
+    for excluded_root in excluded_roots:
+        if _paths_equivalent(excluded_root, skill_root):
+            raise ValueError(f"Generated output root must not equal the runtime skill root: {skill_root}")
+        if _path_is_excluded(excluded_root, (skill_root,)):
+            scoped.append(excluded_root)
+    return tuple(scoped)
+
+
+def _is_skill_evals_path(path: Path, skill_root: Path) -> bool:
+    """Return whether *path* is under ``evals/`` owned by any nested skill package."""
+    for candidate, root in (
+        (path.absolute(), skill_root.absolute()),
+        (path.resolve(), skill_root.resolve()),
+    ):
+        try:
+            rel = candidate.relative_to(root)
+        except ValueError:
+            continue
+        for index, part in enumerate(rel.parts):
+            if part.casefold() != "evals":
+                continue
+            owner = root.joinpath(*rel.parts[:index])
+            if _skill_manifest(owner) is not None and (owner / part).is_dir():
+                return True
+    return False
+
+
+def _runtime_skill_copy_ignore(skill_root: Path, excluded_roots: Sequence[Path] = ()):
+    """Build a root-aware ignore callback for an agent-visible skill copy."""
+    resolved_root = skill_root.resolve()
+    excluded_roots = _skill_scoped_excluded_roots(skill_root, excluded_roots)
+
+    def _ignore(directory: str, contents: list[str]) -> list[str]:
+        current = Path(directory)
+        ignored = {name for name in contents if name in {"results", "__pycache__", ".git"}}
+        if current.resolve() == resolved_root:
+            ignored.update(name for name in contents if name.casefold() == "evals")
+        for name in contents:
+            candidate = current / name
+            if _is_skill_evals_path(candidate, skill_root) or _path_is_excluded(candidate, excluded_roots):
+                ignored.add(name)
+        return sorted(ignored)
+
+    return _ignore
+
+
+def _runtime_projection_path_is_ignored(path: Path, root: Path, ignore) -> bool:
+    """Apply a copytree ignore callback to every component of one source path."""
+    current = root
+    for part in path.relative_to(root).parts:
+        if part in ignore(str(current), [part]):
+            return True
+        current /= part
+    return False
+
+
+def _runtime_skill_fingerprint(skill_root: Path, excluded_roots: Sequence[Path] = ()) -> str | None:
+    """Hash the agent-visible runtime tree independent of its directory name."""
+    if _skill_manifest(skill_root) is None:
+        return None
+    ignore = _runtime_skill_copy_ignore(skill_root, excluded_roots)
+    digest = hashlib.sha256()
+    pending = [skill_root]
+    while pending:
+        directory = pending.pop()
+        entries = sorted(os.scandir(directory), key=lambda entry: entry.name)
+        ignored = set(ignore(str(directory), [entry.name for entry in entries]))
+        for entry in entries:
+            if entry.name in ignored:
+                continue
+            path = Path(entry.path)
+            metadata = entry.stat(follow_symlinks=False)
+            if _path_is_link_or_reparse(path, metadata):
+                return None
+            relative = path.relative_to(skill_root).as_posix().encode("utf-8")
+            if stat.S_ISDIR(metadata.st_mode):
+                digest.update(b"D\\0" + relative + b"\\0")
+                pending.append(path)
+            elif stat.S_ISREG(metadata.st_mode):
+                if metadata.st_nlink != 1:
+                    return None
+                digest.update(b"F\\0" + relative + b"\\0")
+                with path.open("rb") as handle:
+                    for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                        digest.update(chunk)
+            else:
+                return None
+    return digest.hexdigest()
+
+
+def _check_baseline_skill_candidates_do_not_alias_target(
+    target_skill: Path,
+    reference_skills_dir: Path | None,
+    workspace_skill_paths: list[Path] | None,
+    *,
+    excluded_roots: Sequence[Path] = (),
+) -> None:
+    target_fingerprint = _runtime_skill_fingerprint(target_skill, excluded_roots)
+    target_manifest = _skill_manifest(target_skill)
+    if target_fingerprint is None or target_manifest is None:
+        return
+    target_manifest_digest = hashlib.sha256(target_manifest.read_bytes()).digest()
+    candidates: list[Path] = []
+    if reference_skills_dir and reference_skills_dir.exists():
+        candidates.extend(
+            candidate
+            for candidate in reference_skills_dir.iterdir()
+            if candidate.is_dir() and not candidate.name.startswith(".")
+        )
+    candidates.extend(workspace_skill_paths or [])
+    seen: set[Path] = set()
+    for candidate in candidates:
+        if _paths_equivalent(candidate, target_skill):
+            continue
+        resolved = candidate.resolve()
+        if resolved in seen or not candidate.is_dir():
+            continue
+        seen.add(resolved)
+        candidate_manifest = _skill_manifest(candidate)
+        manifest_matches = candidate_manifest is not None and (
+            hashlib.sha256(candidate_manifest.read_bytes()).digest() == target_manifest_digest
+        )
+        payload_alias = _find_target_manifest_payload(
+            candidate,
+            target_skill,
+            runtime_projection=True,
+            excluded_roots=excluded_roots,
+        )
+        if (
+            manifest_matches
+            or payload_alias is not None
+            or _runtime_skill_fingerprint(candidate, excluded_roots) == target_fingerprint
+        ):
+            raise ValueError(
+                f"Baseline skill candidate '{candidate}' is an alias of target skill '{target_skill.name}'. "
+                "A baseline must not contain the evaluated skill under another directory name."
+            )
+
+
+def _check_staged_baseline_does_not_contain_target(env_dir: Path, target_skill: Path) -> None:
+    """Fail closed if any agent-visible staged file is the evaluated instructions."""
+    payload = _find_target_manifest_payload(env_dir, target_skill)
+    if payload is not None:
+        raise ValueError(
+            f"Baseline environment contains the target skill instructions in {payload}. "
+            "Remove copied or renamed target content from reference skills, task input, and repo context."
+        )
+
+
+def _repo_path_is_skill_evals(path: Path, root: Path) -> bool:
+    """Identify evaluator-only roots without dropping unrelated nested ``evals``."""
+    return _is_skill_evals_path(path, root)
 
 
 def _strip_link_target(raw_target: str) -> str:
@@ -296,8 +726,21 @@ def _staged_relative_link_path(skill_name: str, raw_target: str) -> Path | None:
     if normalized in {"", "."} or normalized.startswith("../"):
         return None
     rel = Path(normalized)
-    # Do not let linked repo docs stage sibling skills as discoverable skills.
-    if rel.parts[:1] == ("skills",) and (len(rel.parts) < 2 or rel.parts[1] != skill_name):
+    if rel.parts and rel.parts[0].casefold() in {"input", "output", "repo"}:
+        raise ValueError(f"SKILL.md link resolves into reserved runtime path '/workspace/{rel.parts[0]}': {raw_target}")
+    # Runtime skills and agent configuration are projected separately after
+    # recursive evaluator-only filtering. Linked repository content must never
+    # create an alternate project-level discovery/configuration namespace.
+    if rel.parts and rel.parts[0].casefold() in {
+        "skills",
+        ".agents",
+        ".claude",
+        ".codex",
+        ".config",
+        ".cursor",
+        ".gemini",
+        ".opencode",
+    }:
         return None
     return rel
 
@@ -306,6 +749,10 @@ def _repo_context_ignore_file(path: Path, root: Path) -> bool:
     try:
         path.resolve().relative_to(root.resolve())
     except ValueError:
+        return True
+    if _paths_equivalent(path, output_provenance_key_path()):
+        return True
+    if _repo_path_is_skill_evals(path, root):
         return True
     try:
         rel = path.absolute().relative_to(root.absolute())
@@ -331,7 +778,14 @@ def _repo_context_ignore_file(path: Path, root: Path) -> bool:
     return False
 
 
-def _copy_repo_context_file(src: Path, dest_root: Path, rel: Path, *, total_bytes: list[int]) -> bool:
+def _copy_repo_context_file(
+    src: Path,
+    dest_root: Path,
+    rel: Path,
+    *,
+    total_bytes: list[int],
+    source_root: Path,
+) -> bool:
     if not src.is_file():
         return False
     try:
@@ -346,7 +800,7 @@ def _copy_repo_context_file(src: Path, dest_root: Path, rel: Path, *, total_byte
         return False
     dest = dest_root / rel
     dest.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(src, dest)
+    copy_file_secure(src, dest, allowed_root=source_root)
     total_bytes[0] += size
     return True
 
@@ -380,16 +834,28 @@ def _stage_repo_context(
     source_skill_path: Path | None,
     mode: str,
     exclude_source_skill: bool = False,
+    excluded_roots: Sequence[Path] = (),
 ) -> dict[str, Any]:
     """Stage repo files referenced by SKILL.md, or the full repo when requested."""
     if not source_skill_path:
         return {"mode": "none", "files": []}
 
     source_skill_path = source_skill_path.resolve()
-    skill_md = source_skill_path / "SKILL.md"
-    repo_root = _find_repo_root(source_skill_path)
-    if repo_root is None:
-        repo_root = source_skill_path.parent.resolve()
+    skill_md = _skill_manifest(source_skill_path)
+    repo_root = _repo_context_root(source_skill_path)
+
+    resolved_excluded_roots: list[Path] = []
+    for excluded_root in excluded_roots:
+        candidate = excluded_root.resolve()
+        if mode == "full" and _paths_equivalent(candidate, repo_root):
+            raise ValueError(f"Repo context output root must not contain the repository root: {candidate}")
+        if _path_is_excluded(repo_root, (candidate,)):
+            continue
+        if _path_is_excluded(candidate, (repo_root,)):
+            resolved_excluded_roots.append(candidate)
+
+    def _is_excluded_output(path: Path) -> bool:
+        return _path_is_excluded(path, resolved_excluded_roots)
 
     repo_dest = env_dir / "repo"
     linked_root_dest = env_dir / "repo-linked-root"
@@ -398,6 +864,8 @@ def _stage_repo_context(
 
     if mode == "full":
         for src in _iter_repo_context_files(repo_root):
+            if _is_excluded_output(src):
+                continue
             if _repo_context_ignore_file(src, repo_root):
                 continue
             if exclude_source_skill and _is_relative_to(src, source_skill_path):
@@ -405,25 +873,37 @@ def _stage_repo_context(
             rel = _safe_repo_context_rel(src, repo_root)
             if rel is None:
                 continue
-            if _copy_repo_context_file(src, repo_dest, rel, total_bytes=total_bytes):
+            if _copy_repo_context_file(
+                src,
+                repo_dest,
+                rel,
+                total_bytes=total_bytes,
+                source_root=repo_root,
+            ):
                 staged.append({"source": str(src), "container": f"/workspace/repo/{rel.as_posix()}"})
         metadata = {"mode": "full", "repo_root": str(repo_root), "files": staged}
         if staged:
             (env_dir / "repo-context.json").write_text(json.dumps(metadata, indent=2), encoding="utf-8")
         return metadata
 
-    if mode != "linked" or not skill_md.exists():
+    if mode != "linked" or skill_md is None:
         return {"mode": mode, "repo_root": str(repo_root), "files": []}
 
     for raw_target in _discover_skill_link_targets(skill_md):
         target = _strip_link_target(raw_target)
-        target_path = (source_skill_path / target).resolve() if not Path(target).is_absolute() else Path(target)
+        lexical_target_path = source_skill_path / target if not Path(target).is_absolute() else Path(target)
+        target_path = lexical_target_path.resolve()
         if not target_path.is_file():
             continue
         if not _is_relative_to(target_path, repo_root):
             logger.warning("Skipping SKILL.md link outside repo root: %s", raw_target)
             continue
-        if _repo_context_ignore_file(target_path, repo_root):
+        if _is_excluded_output(target_path) or _path_is_excluded(lexical_target_path, resolved_excluded_roots):
+            logger.warning("Skipping SKILL.md link into generated output: %s", raw_target)
+            continue
+        if _repo_context_ignore_file(lexical_target_path, repo_root) or _repo_context_ignore_file(
+            target_path, repo_root
+        ):
             logger.warning("Skipping ignored SKILL.md repo link: %s", raw_target)
             continue
         if _is_relative_to(target_path, source_skill_path):
@@ -431,10 +911,22 @@ def _stage_repo_context(
         rel = _safe_repo_context_rel(target_path, repo_root)
         if rel is None:
             continue
-        copied = _copy_repo_context_file(target_path, repo_dest, rel, total_bytes=total_bytes)
+        copied = _copy_repo_context_file(
+            target_path,
+            repo_dest,
+            rel,
+            total_bytes=total_bytes,
+            source_root=repo_root,
+        )
         compat_rel = _staged_relative_link_path(source_skill_path.name, raw_target)
         if compat_rel is not None:
-            _copy_repo_context_file(target_path, linked_root_dest, compat_rel, total_bytes=total_bytes)
+            _copy_repo_context_file(
+                target_path,
+                linked_root_dest,
+                compat_rel,
+                total_bytes=total_bytes,
+                source_root=repo_root,
+            )
         if copied:
             staged.append(
                 {
@@ -454,6 +946,8 @@ def _collect_all_skill_deps(
     skill_path: Path | None,
     reference_skills_dir: Path | None,
     workspace_skill_paths: list[Path] | None = None,
+    *,
+    excluded_roots: Sequence[Path] = (),
 ) -> tuple[list[str], list[str]]:
     """Collect pip and apt deps from target skill + staged workspace skills."""
     all_pip: set[str] = set()
@@ -471,12 +965,31 @@ def _collect_all_skill_deps(
             skill_dirs.append(workspace_skill)
 
     for sd in skill_dirs:
+        runtime_ignore = _runtime_skill_copy_ignore(sd, excluded_roots)
         for req_file in sd.rglob("requirements.txt"):
+            if _runtime_projection_path_is_ignored(req_file, sd, runtime_ignore):
+                continue
+            metadata = req_file.lstat()
+            if (
+                _path_is_link_or_reparse(req_file, metadata)
+                or not stat.S_ISREG(metadata.st_mode)
+                or metadata.st_nlink != 1
+            ):
+                raise ValueError(f"Runtime dependency manifest must be a regular non-linked file: {req_file}")
             for line in req_file.read_text(encoding="utf-8").splitlines():
                 line = line.strip()
                 if line and not line.startswith("#"):
                     all_pip.add(line)
         for apt_file in sd.rglob("apt-packages.txt"):
+            if _runtime_projection_path_is_ignored(apt_file, sd, runtime_ignore):
+                continue
+            metadata = apt_file.lstat()
+            if (
+                _path_is_link_or_reparse(apt_file, metadata)
+                or not stat.S_ISREG(metadata.st_mode)
+                or metadata.st_nlink != 1
+            ):
+                raise ValueError(f"Runtime dependency manifest must be a regular non-linked file: {apt_file}")
             for line in apt_file.read_text(encoding="utf-8").splitlines():
                 line = line.strip()
                 if line and not line.startswith("#"):
@@ -490,6 +1003,7 @@ def build_eval_base_image(
     reference_skills_dir: Path | None = None,
     *,
     workspace_skill_paths: list[Path] | None = None,
+    excluded_roots: Sequence[Path] = (),
     force_rebuild: bool = False,
     action_out: list[str] | None = None,
 ) -> str:
@@ -513,9 +1027,19 @@ def build_eval_base_image(
     )
 
     if has_custom_dockerfile:
-        extra_pip, extra_apt = _collect_all_skill_deps(None, reference_skills_dir, workspace_skill_paths)
+        extra_pip, extra_apt = _collect_all_skill_deps(
+            None,
+            reference_skills_dir,
+            workspace_skill_paths,
+            excluded_roots=excluded_roots,
+        )
     else:
-        extra_pip, extra_apt = _collect_all_skill_deps(skill_path, reference_skills_dir, workspace_skill_paths)
+        extra_pip, extra_apt = _collect_all_skill_deps(
+            skill_path,
+            reference_skills_dir,
+            workspace_skill_paths,
+            excluded_roots=excluded_roots,
+        )
 
     lines = [
         "FROM python:3.12-slim",
@@ -529,20 +1053,7 @@ def build_eval_base_image(
         lines.append("    " + " ".join(extra_apt) + " \\")
     lines.append("    && rm -rf /var/lib/apt/lists/*")
 
-    lines.extend(
-        [
-            "",
-            "RUN pip install --no-cache-dir \\",
-            "    ragas~=0.4.0 \\",
-            "    openai>=1.0 \\",
-            "    anthropic>=0.40 \\",
-            "    boto3>=1.34",
-        ]
-    )
-
-    if extra_pip:
-        escaped = " ".join(f'"{r}"' for r in extra_pip)
-        lines.append(f"RUN pip install --no-cache-dir {escaped}")
+    lines.extend(["", *_verifier_install_lines(extra_pip)])
 
     lines.extend(
         [
@@ -628,12 +1139,32 @@ def _set_task_docker_image(task_dir: Path, image_tag: str) -> None:
     toml_path.write_text(replaced, encoding="utf-8")
 
 
+def _task_environment_context_hash(environment_dir: Path) -> str:
+    """Hash the Docker context shape, modes, paths, and file contents."""
+    digest = hashlib.sha256()
+    for path in sorted(
+        environment_dir.rglob("*"), key=lambda candidate: candidate.relative_to(environment_dir).as_posix()
+    ):
+        relative = path.relative_to(environment_dir).as_posix()
+        metadata = path.lstat()
+        mode = stat.S_IMODE(metadata.st_mode)
+        if stat.S_ISDIR(metadata.st_mode):
+            digest.update(f"D\0{relative}\0{mode:o}\0".encode())
+        elif stat.S_ISREG(metadata.st_mode):
+            digest.update(f"F\0{relative}\0{mode:o}\0".encode())
+            digest.update(path.read_bytes())
+            digest.update(b"\0")
+        else:
+            raise ValueError(f"Task Docker context contains an unsupported path: {path}")
+    return digest.hexdigest()
+
+
 def prebuild_task_environments(dataset_dirs: list[Path]) -> int:
     """Pre-build Docker images for generated task environments.
 
     After ``generate_harbor_tasks`` has written all task directories, this
-    function builds each unique environment once, tags it, and sets
-    ``docker_image`` in every task's ``task.toml`` so Harbor uses the prebuilt
+    function builds each task's exact environment, tags it independently, and
+    sets ``docker_image`` only in that task's ``task.toml`` so Harbor uses the prebuilt
     image directly (skipping ``docker compose build`` entirely).
 
     Returns the number of tasks configured to use prebuilt images.
@@ -662,71 +1193,161 @@ def prebuild_task_environments(dataset_dirs: list[Path]) -> int:
         if not task_dirs:
             continue
 
-        first_env = task_dirs[0] / "environment"
-
-        ctx_hash = hashlib.sha256()
-        for f in sorted(first_env.rglob("*")):
-            if f.is_file():
-                ctx_hash.update(str(f.relative_to(first_env)).encode())
-                ctx_hash.update(f.read_bytes())
-        tag = f"skillevaluator-env:{ctx_hash.hexdigest()[:12]}"
-
-        try:
-            check = subprocess.run(
-                ["docker", "image", "inspect", tag],
-                capture_output=True,
-                timeout=10,
-                env=child_process_env(),
-            )
-            if check.returncode == 0:
-                logger.debug("Pre-built env %s exists, reusing for %d tasks", tag, len(task_dirs))
-                for td in task_dirs:
-                    _set_task_docker_image(td, tag)
-                rewritten += len(task_dirs)
+        for task_dir in task_dirs:
+            environment_dir = task_dir / "environment"
+            if any((environment_dir / name).exists() for name in ("docker-compose.yaml", "docker-compose.yml")):
+                logger.warning(
+                    "Skipping task environment pre-build for %s because Compose build overrides require native Compose semantics",
+                    task_dir,
+                )
                 continue
-        except (subprocess.TimeoutExpired, OSError):
-            pass
+            try:
+                context_hash = _task_environment_context_hash(environment_dir)
+            except (OSError, ValueError) as error:
+                logger.warning("Skipping unsafe task environment pre-build for %s: %s", task_dir, error)
+                continue
+            task_identity = hashlib.sha256(f"{dataset_dir.resolve()}::{task_dir.name}".encode()).hexdigest()[:8]
+            tag = f"skillevaluator-env:{context_hash[:12]}-{task_identity}"
 
-        logger.debug("Pre-building task environment as %s ...", tag)
-        try:
-            result = subprocess.run(
-                ["docker", "build", "-t", tag, str(first_env)],
-                capture_output=True,
-                text=True,
-                timeout=600,
-                env=child_process_env(),
-            )
-        except subprocess.TimeoutExpired:
-            logger.warning("Environment pre-build timed out for %s", tag)
-            continue
+            try:
+                check = subprocess.run(
+                    ["docker", "image", "inspect", tag],
+                    capture_output=True,
+                    timeout=10,
+                    env=child_process_env(),
+                )
+                if check.returncode == 0:
+                    logger.debug("Pre-built env %s exists, reusing for task %s", tag, task_dir.name)
+                    _set_task_docker_image(task_dir, tag)
+                    rewritten += 1
+                    continue
+            except (subprocess.TimeoutExpired, OSError):
+                pass
 
-        if result.returncode != 0:
-            stderr_tail = (result.stderr or "")[-500:]
-            logger.warning("Environment pre-build failed for %s: %s", tag, stderr_tail)
-            continue
+            logger.debug("Pre-building task environment as %s ...", tag)
+            try:
+                result = subprocess.run(
+                    ["docker", "build", "-t", tag, str(environment_dir)],
+                    capture_output=True,
+                    text=True,
+                    timeout=600,
+                    env=child_process_env(),
+                )
+            except subprocess.TimeoutExpired:
+                logger.warning("Environment pre-build timed out for %s", tag)
+                continue
 
-        for td in task_dirs:
-            _set_task_docker_image(td, tag)
-        rewritten += len(task_dirs)
-        logger.debug("Pre-built env %s, configured %d tasks", tag, len(task_dirs))
+            if result.returncode != 0:
+                stderr_tail = (result.stderr or "")[-500:]
+                logger.warning("Environment pre-build failed for %s: %s", tag, stderr_tail)
+                continue
+
+            _set_task_docker_image(task_dir, tag)
+            rewritten += 1
+            logger.debug("Pre-built env %s for task %s", tag, task_dir.name)
 
     return rewritten
 
 
 def _load_evals(evals_path: Path) -> list[dict[str, Any]]:
     """Load normalized dataset entries from evals.json/jsonl/yaml."""
-    from skillevaluator.tier3.dataset_utils import load_dataset_entries
+    from skillevaluator.tier3.dataset_utils import normalize_dataset_entries
 
-    return load_dataset_entries(evals_path)
+    payload = _read_regular_evals_file(evals_path).decode("utf-8")
+    suffix = evals_path.suffix.casefold()
+    if suffix == ".jsonl":
+        data: Any = [json.loads(line) for raw_line in payload.splitlines() if (line := raw_line.strip())]
+    elif suffix in {".yaml", ".yml"}:
+        import yaml
+
+        data = yaml.safe_load(payload)
+    elif suffix == ".json":
+        data = json.loads(payload)
+    else:
+        raise ValueError(f"Unsupported dataset format: {suffix}")
+    return normalize_dataset_entries(data)
+
+
+def _read_regular_evals_file(path: Path) -> bytes:
+    """Read one evaluator file without following links or accepting swaps."""
+    try:
+        before = path.lstat()
+    except OSError as exc:
+        raise ValueError(f"Cannot inspect eval dataset file: {path}") from exc
+    if _path_is_link_or_reparse(path, before) or not stat.S_ISREG(before.st_mode) or before.st_nlink != 1:
+        raise ValueError(f"Eval dataset must be a regular non-linked file: {path}")
+    if before.st_size > 64 * 1024 * 1024:
+        raise ValueError(f"Eval dataset exceeds the 64 MiB safety limit: {path}")
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        raise ValueError(f"Cannot safely open eval dataset file: {path}") from exc
+    try:
+        opened = os.fstat(descriptor)
+        before_fingerprint = (before.st_dev, before.st_ino, before.st_mode, before.st_nlink, before.st_size)
+        opened_fingerprint = (opened.st_dev, opened.st_ino, opened.st_mode, opened.st_nlink, opened.st_size)
+        if (
+            _path_is_link_or_reparse(path, opened)
+            or not stat.S_ISREG(opened.st_mode)
+            or opened.st_nlink != 1
+            or opened_fingerprint != before_fingerprint
+        ):
+            raise ValueError(f"Eval dataset changed while it was opened: {path}")
+        chunks: list[bytes] = []
+        remaining = opened.st_size + 1
+        while remaining:
+            chunk = os.read(descriptor, min(1024 * 1024, remaining))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        payload = b"".join(chunks)
+        after = os.fstat(descriptor)
+        after_fingerprint = (after.st_dev, after.st_ino, after.st_mode, after.st_nlink, after.st_size)
+        if after_fingerprint != opened_fingerprint or len(payload) != opened.st_size:
+            raise ValueError(f"Eval dataset changed while it was read: {path}")
+        return payload
+    finally:
+        os.close(descriptor)
+
+
+def _validate_evals_source_directory(skill_path: Path) -> None:
+    """Reject a link/reparse-point evaluator root before loading any assets."""
+    evals_dir = skill_path / "evals"
+    try:
+        metadata = evals_dir.lstat()
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        raise ValueError(f"Cannot inspect evaluator source directory: {evals_dir}") from exc
+    if _path_is_link_or_reparse(evals_dir, metadata):
+        raise ValueError(
+            f"evals directory must be a real directory, not a symlink, reparse point, or junction: {evals_dir}"
+        )
+    if not stat.S_ISDIR(metadata.st_mode):
+        raise ValueError(f"Evaluator source path must be a directory: {evals_dir}")
 
 
 def find_evals_file(skill_path: Path) -> Path | None:
     """Return the first supported SkillEvaluator eval dataset for a skill, if present."""
     evals_dir = skill_path / "evals"
+    _validate_evals_source_directory(skill_path)
     for name in ("evals.json", "evals.jsonl", "evals.yaml", "evals.yml", "dataset.json", "dataset.jsonl"):
         candidate = evals_dir / name
-        if candidate.exists():
-            return candidate
+        try:
+            metadata = candidate.lstat()
+        except FileNotFoundError:
+            continue
+        except OSError as exc:
+            raise ValueError(f"Cannot inspect eval dataset file: {candidate}") from exc
+        if (
+            _path_is_link_or_reparse(candidate, metadata)
+            or not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_nlink != 1
+        ):
+            raise ValueError(f"Eval dataset must be a regular non-linked file: {candidate}")
+        return candidate
     return None
 
 
@@ -869,8 +1490,7 @@ def _toml_value(value: Any) -> str:
 
 
 def _runtime_env_toml_block(runtime_env: dict[str, str] | None) -> str:
-    if not runtime_env:
-        return ""
+    runtime_env = {**(runtime_env or {}), **_EVALUATOR_MANAGED_RUNTIME_ENV}
     lines = ["", "[environment.env]"]
     for key in sorted(runtime_env):
         lines.append(f"{_toml_quote(key)} = {_toml_quote(runtime_env[key])}")
@@ -960,7 +1580,7 @@ def _has_symlink_component(path: Path, root: Path) -> bool:
     current = root
     for part in path.relative_to(root).parts:
         current /= part
-        if current.is_symlink():
+        if _path_is_link_or_reparse(current):
             return True
     return False
 
@@ -1029,14 +1649,780 @@ def _validate_custom_dockerfile(path: Path) -> str | None:
     return None
 
 
+_DOCKER_HEREDOC_RE = re.compile(
+    r"<<(?P<strip>-?)(?:(?P<quote>['\"])(?P<quoted>[^'\"\s]+)(?P=quote)|(?P<bare>[^\s'\"<>]+))(?=\s|$)"
+)
+
+
+def _dockerfile_heredocs(line: str) -> list[tuple[str, bool]]:
+    """Return heredoc delimiters introduced by one Dockerfile instruction."""
+    heredocs: list[tuple[str, bool]] = []
+    quote: str | None = None
+    index = 0
+    while index < len(line):
+        character = line[index]
+        if quote is not None:
+            if character == quote:
+                quote = None
+            elif character == "\\" and quote == '"':
+                index += 1
+            index += 1
+            continue
+        if character in {"'", '"'}:
+            quote = character
+            index += 1
+            continue
+        if character == "\\":
+            index += 2
+            continue
+        if character == "<" and (index == 0 or line[index - 1].isspace()):
+            match = _DOCKER_HEREDOC_RE.match(line, index)
+            if match is not None:
+                delimiter = match.group("quoted") or match.group("bare")
+                heredocs.append((delimiter, match.group("strip") == "-"))
+                index = match.end()
+                continue
+        index += 1
+    return heredocs
+
+
+def _dockerfile_logical_lines_from_content(content: str, *, source: str = "Dockerfile") -> list[str]:
+    """Return Dockerfile instructions after applying its escape directive."""
+    raw_lines = content.splitlines()
+    escape_char = "\\"
+    for raw_line in raw_lines:
+        directive = re.match(r"^\s*#\s*escape\s*=\s*([`\\])\s*$", raw_line, flags=re.IGNORECASE)
+        if directive:
+            escape_char = directive.group(1)
+            break
+        if raw_line.strip() and not raw_line.lstrip().startswith("#"):
+            break
+
+    logical_lines: list[str] = []
+    pending = ""
+    active_heredocs: list[tuple[str, bool]] = []
+    for raw_line in raw_lines:
+        if active_heredocs:
+            delimiter, strip_tabs = active_heredocs[0]
+            candidate = raw_line.lstrip("\t") if strip_tabs else raw_line
+            if candidate == delimiter:
+                active_heredocs.pop(0)
+            continue
+        line = raw_line.strip()
+        if not line or (line.startswith("#") and not pending):
+            continue
+        pending = f"{pending} {line}".strip()
+        trailing_escapes = len(pending) - len(pending.rstrip(escape_char))
+        if trailing_escapes % 2 == 1:
+            pending = pending[:-1].rstrip()
+            continue
+        logical_lines.append(pending)
+        active_heredocs.extend(_dockerfile_heredocs(pending))
+        pending = ""
+    if pending:
+        logical_lines.append(pending)
+        active_heredocs.extend(_dockerfile_heredocs(pending))
+    if active_heredocs:
+        raise ValueError(f"Cannot safely parse unterminated Dockerfile heredoc in {source}")
+    return logical_lines
+
+
+def _dockerfile_logical_lines(path: Path) -> list[str]:
+    return _dockerfile_logical_lines_from_content(path.read_text(encoding="utf-8"), source=str(path))
+
+
+def _dockerfile_final_explicit_user(content: str) -> str | None:
+    """Return the statically known USER inherited by the final stage."""
+    user: str | None = None
+    stage_users: dict[str, str | None] = {}
+    current_stage_name: str | None = None
+    current_stage_index = -1
+
+    def _save_current_stage() -> None:
+        if current_stage_index < 0:
+            return
+        stage_users[str(current_stage_index)] = user
+        if current_stage_name is not None:
+            stage_users[current_stage_name.casefold()] = user
+
+    for line in _dockerfile_logical_lines_from_content(content):
+        parts = line.split(None, 1)
+        if not parts:
+            continue
+        instruction = parts[0].upper()
+        if instruction == "FROM" and len(parts) == 2:
+            _save_current_stage()
+            try:
+                from_parts = shlex.split(parts[1])
+            except ValueError:
+                from_parts = parts[1].split()
+            non_options = [part for part in from_parts if not part.startswith("--")]
+            base = non_options[0] if non_options else ""
+            alias = next(
+                (non_options[index + 1] for index, value in enumerate(non_options[:-1]) if value.upper() == "AS"),
+                None,
+            )
+            user = stage_users.get(base.casefold())
+            current_stage_index += 1
+            current_stage_name = alias
+        elif instruction == "USER" and len(parts) == 2:
+            user = parts[1].strip()
+    return user
+
+
+def _replace_single_from_image(content: str, base_image: str) -> tuple[str, str]:
+    """Replace one Dockerfile stage image while preserving options and its alias."""
+    from_lines = [
+        line for line in _dockerfile_logical_lines_from_content(content) if line.split(None, 1)[0].upper() == "FROM"
+    ]
+    if len(from_lines) != 1:
+        raise ValueError(
+            "Custom Dockerfile rebase mode requires exactly one FROM instruction; "
+            "use preserve mode for multi-stage Dockerfiles"
+        )
+    match = re.search(r"^(?P<prefix>[ \t]*FROM[ \t]+)(?P<body>[^\r\n]+)", content, flags=re.IGNORECASE | re.MULTILINE)
+    if match is None:
+        raise ValueError("Custom Dockerfile rebase mode could not locate its FROM instruction safely")
+    body = match.group("body")
+    if body.rstrip().endswith(("\\", "`")):
+        raise ValueError(
+            "Custom Dockerfile rebase mode does not support a continued FROM instruction; use preserve mode"
+        )
+    tokens = list(re.finditer(r'"[^"\r\n]*"|\'[^\'\r\n]*\'|\S+', body))
+    image_token = next((token for token in tokens if not token.group(0).startswith("--")), None)
+    if image_token is None:
+        raise ValueError("Custom Dockerfile FROM instruction does not contain an image")
+    body_start = match.start("body")
+    image_start = body_start + image_token.start()
+    image_end = body_start + image_token.end()
+    return content[:image_start] + base_image + content[image_end:], from_lines[0]
+
+
+def _dockerfile_instruction_sources(line: str) -> list[str]:
+    """Return build-context sources for one COPY/ADD instruction."""
+    parts = line.split(None, 1)
+    if len(parts) != 2 or parts[0].upper() not in {"COPY", "ADD"}:
+        return []
+    payload = parts[1].strip()
+    from_stage = False
+    while payload.startswith("--"):
+        option_parts = payload.split(None, 1)
+        option = option_parts[0]
+        if len(option_parts) == 1:
+            raise ValueError(f"Cannot safely parse custom Dockerfile COPY/ADD options: {line}")
+        payload = option_parts[1].lstrip()
+        if option == "--from":
+            stage_parts = payload.split(None, 1)
+            from_stage = True
+            if len(stage_parts) == 1:
+                raise ValueError(f"Cannot safely parse custom Dockerfile COPY/ADD --from option: {line}")
+            payload = stage_parts[1].lstrip()
+        elif option.startswith("--from="):
+            from_stage = True
+    if from_stage or not payload:
+        return []
+    if _docker_expression_has_literal_dollar(payload):
+        raise ValueError(f"Cannot safely parse quoted or escaped Dockerfile COPY/ADD variable: {line}")
+    if re.match(r'^\[\s*"', payload):
+        try:
+            values = json.loads(payload)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Cannot parse custom Dockerfile COPY/ADD JSON form: {line}") from exc
+        if isinstance(values, list) and len(values) >= 2 and all(isinstance(value, str) for value in values):
+            return values[:-1]
+        raise ValueError(f"Cannot safely parse custom Dockerfile COPY/ADD JSON form: {line}")
+    try:
+        values = shlex.split(payload)
+    except ValueError as exc:
+        raise ValueError(f"Cannot safely parse custom Dockerfile COPY/ADD form: {line}") from exc
+    if len(values) < 2:
+        raise ValueError(f"Cannot safely parse custom Dockerfile COPY/ADD form: {line}")
+    sources = values[:-1]
+    heredoc_sources = [source for source in sources if source.startswith("<<")]
+    malformed_heredocs = [source for source in heredoc_sources if _DOCKER_HEREDOC_RE.fullmatch(source) is None]
+    if malformed_heredocs:
+        raise ValueError(f"Cannot safely parse custom Dockerfile COPY/ADD heredoc: {line}")
+    return [source for source in sources if source not in heredoc_sources]
+
+
+def _dockerfile_named_context_sources(line: str) -> list[tuple[str, str]]:
+    """Return ``(--from context, source)`` pairs for one COPY/ADD."""
+    parts = line.split(None, 1)
+    if len(parts) != 2 or parts[0].upper() not in {"COPY", "ADD"}:
+        return []
+    payload = parts[1].strip()
+    from_context: str | None = None
+    while payload.startswith("--"):
+        option_parts = payload.split(None, 1)
+        option = option_parts[0]
+        if len(option_parts) == 1:
+            raise ValueError(f"Cannot safely parse custom Dockerfile COPY/ADD options: {line}")
+        payload = option_parts[1].lstrip()
+        if option == "--from":
+            context_parts = payload.split(None, 1)
+            if len(context_parts) == 1:
+                raise ValueError(f"Cannot safely parse custom Dockerfile COPY/ADD --from option: {line}")
+            from_context = context_parts[0]
+            payload = context_parts[1].lstrip()
+        elif option.startswith("--from="):
+            from_context = option.partition("=")[2]
+    if from_context is None or not payload:
+        return []
+    if "$" in from_context or _docker_expression_has_literal_dollar(payload):
+        raise ValueError(f"Cannot safely parse dynamic Dockerfile named-context source: {line}")
+    if re.match(r'^\[\s*"', payload):
+        try:
+            values = json.loads(payload)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Cannot parse custom Dockerfile COPY/ADD JSON form: {line}") from exc
+        if not (isinstance(values, list) and len(values) >= 2 and all(isinstance(value, str) for value in values)):
+            raise ValueError(f"Cannot safely parse custom Dockerfile COPY/ADD JSON form: {line}")
+        sources = values[:-1]
+    else:
+        try:
+            values = shlex.split(payload)
+        except ValueError as exc:
+            raise ValueError(f"Cannot safely parse custom Dockerfile COPY/ADD form: {line}") from exc
+        if len(values) < 2:
+            raise ValueError(f"Cannot safely parse custom Dockerfile COPY/ADD form: {line}")
+        sources = values[:-1]
+    heredoc_sources = [source for source in sources if source.startswith("<<")]
+    malformed_heredocs = [source for source in heredoc_sources if _DOCKER_HEREDOC_RE.fullmatch(source) is None]
+    if malformed_heredocs:
+        raise ValueError(f"Cannot safely parse custom Dockerfile COPY/ADD heredoc: {line}")
+    return [(from_context, source) for source in sources if source not in heredoc_sources]
+
+
+def _dockerfile_named_build_context_sources(path: Path) -> list[tuple[str, str]]:
+    """Return statically named build-context sources from a Dockerfile."""
+    sources: list[tuple[str, str]] = []
+    for line in _dockerfile_logical_lines(path):
+        parts = line.split(None, 1)
+        effective_line = parts[1].strip() if len(parts) == 2 and parts[0].upper() == "ONBUILD" else line
+        sources.extend(_dockerfile_named_context_sources(effective_line))
+    return sources
+
+
+def _dockerfile_build_context_sources(path: Path) -> list[str]:
+    """Return COPY/ADD build-context sources from a Dockerfile."""
+    sources: list[str] = []
+    for line in _dockerfile_logical_lines(path):
+        parts = line.split(None, 1)
+        effective_line = parts[1].strip() if len(parts) == 2 and parts[0].upper() == "ONBUILD" else line
+        sources.extend(_dockerfile_instruction_sources(effective_line))
+    return sources
+
+
+def _normalize_docker_context_source(source: str) -> str:
+    """Normalize a COPY/ADD source using Docker build-context traversal rules."""
+    normalized = posixpath.normpath(source.replace("\\", "/")).lstrip("/")
+    while normalized.startswith("../"):
+        normalized = normalized[3:]
+    if normalized == "..":
+        return "."
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    return normalized
+
+
+_DOCKER_VARIABLE_RE = re.compile(r"\$(?:\{(?P<braced>[A-Za-z_][A-Za-z0-9_]*)\}|(?P<plain>[A-Za-z_][A-Za-z0-9_]*))")
+
+
+def _docker_expression_has_literal_dollar(value: str) -> bool:
+    """Return whether Docker keeps a dollar literal that shlex would erase."""
+    return "$$" in value or re.search(r"\\+\$", value) is not None or re.search(r"'[^']*\$[^']*'", value) is not None
+
+
+def _resolve_docker_source_variables(source: str, defaults: dict[str, str | None]) -> tuple[str, bool]:
+    """Resolve known static Docker variables and report any unresolved reference."""
+    resolved = source
+    for _ in range(len(defaults) + 1):
+        changed = False
+
+        def _replace(match: re.Match[str]) -> str:
+            nonlocal changed
+            name = match.group("braced") or match.group("plain")
+            if name not in defaults or defaults[name] is None:
+                return match.group(0)
+            changed = True
+            return defaults[name]
+
+        updated = _DOCKER_VARIABLE_RE.sub(_replace, resolved)
+        resolved = updated
+        if not changed:
+            break
+    return resolved, "$" in resolved
+
+
+def _dockerfile_resolved_build_context_sources(
+    path: Path,
+    *,
+    build_arg_overrides: dict[str, str | None] | None = None,
+) -> list[tuple[str, str, bool]]:
+    """Resolve COPY/ADD sources using ARG/ENV values visible at each instruction."""
+    global_args: dict[str, str | None] = {}
+    stage_args: dict[str, str | None] = {}
+    stage_env: dict[str, str | None] = {}
+    stage_onbuild: list[str] = []
+    saved_stages: dict[str, tuple[dict[str, str | None], dict[str, str | None], list[str]]] = {}
+    current_stage_name: str | None = None
+    current_stage_index = -1
+    in_stage = False
+    resolved_sources: list[tuple[str, str, bool]] = []
+    build_arg_overrides = build_arg_overrides or {}
+
+    def _apply_arg(payload: str, *, stage_scope: bool) -> None:
+        name, separator, value = payload.partition("=")
+        name = name.strip()
+        if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name) is None:
+            raise ValueError(f"Cannot safely parse custom Dockerfile ARG: {payload}")
+        target = stage_args if stage_scope else global_args
+        visible = {**stage_args, **stage_env} if stage_scope else dict(global_args)
+        if name in build_arg_overrides:
+            target[name] = build_arg_overrides[name]
+        elif separator:
+            raw_value = value.strip()
+            if _docker_expression_has_literal_dollar(raw_value):
+                raise ValueError(f"Cannot safely parse quoted or escaped Dockerfile ARG variable: {payload}")
+            resolved, unresolved = _resolve_docker_source_variables(raw_value.strip("\"'"), visible)
+            target[name] = None if unresolved else resolved
+        elif stage_scope and name in target:
+            return
+        elif stage_scope and name in global_args:
+            target[name] = global_args[name]
+        else:
+            target[name] = None
+
+    def _apply_env(payload: str) -> None:
+        if _docker_expression_has_literal_dollar(payload):
+            raise ValueError(f"Cannot safely parse quoted or escaped Dockerfile ENV variable: {payload}")
+        try:
+            assignments = shlex.split(payload)
+        except ValueError as exc:
+            raise ValueError(f"Cannot safely parse custom Dockerfile ENV: {payload}") from exc
+        pairs: list[tuple[str, str]] = []
+        if assignments and all("=" in assignment for assignment in assignments):
+            pairs = [tuple(assignment.split("=", 1)) for assignment in assignments]
+        elif len(assignments) >= 2:
+            pairs = [(assignments[0], " ".join(assignments[1:]))]
+        if not pairs:
+            raise ValueError(f"Cannot safely parse custom Dockerfile ENV: {payload}")
+        visible = {**stage_args, **stage_env}
+        updates: dict[str, str | None] = {}
+        for name, value in pairs:
+            if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name) is None:
+                raise ValueError(f"Cannot safely parse custom Dockerfile ENV: {payload}")
+            resolved, unresolved = _resolve_docker_source_variables(value, visible)
+            updates[name] = None if unresolved else resolved
+        stage_env.update(updates)
+
+    def _append_context_sources(line: str) -> None:
+        visible = {**stage_args, **stage_env}
+        for source in _dockerfile_instruction_sources(line):
+            resolved, unresolved = _resolve_docker_source_variables(source, visible)
+            resolved_sources.append((source, resolved, unresolved))
+
+    def _run_onbuild_trigger(trigger: str) -> None:
+        trigger_parts = trigger.split(None, 1)
+        if len(trigger_parts) != 2:
+            raise ValueError(f"Cannot safely parse custom Dockerfile ONBUILD trigger: {trigger}")
+        trigger_instruction, trigger_payload = trigger_parts[0].upper(), trigger_parts[1].strip()
+        if trigger_instruction == "ARG":
+            _apply_arg(trigger_payload, stage_scope=True)
+        elif trigger_instruction == "ENV":
+            _apply_env(trigger_payload)
+        elif trigger_instruction in {"COPY", "ADD"}:
+            _append_context_sources(trigger)
+        elif trigger_instruction in {"FROM", "MAINTAINER", "ONBUILD"}:
+            raise ValueError(f"Cannot safely parse unsupported Dockerfile ONBUILD trigger: {trigger}")
+
+    for line in _dockerfile_logical_lines(path):
+        parts = line.split(None, 1)
+        if len(parts) != 2:
+            continue
+        instruction, payload = parts[0].upper(), parts[1].strip()
+
+        if instruction == "FROM":
+            if in_stage:
+                saved_stage = (dict(stage_args), dict(stage_env), list(stage_onbuild))
+                saved_stages[str(current_stage_index)] = saved_stage
+                if current_stage_name is not None:
+                    saved_stages[current_stage_name.casefold()] = saved_stage
+            try:
+                from_parts = shlex.split(payload)
+            except ValueError:
+                from_parts = payload.split()
+            non_options = [part for part in from_parts if not part.startswith("--")]
+            raw_base = non_options[0] if non_options else ""
+            base, base_unresolved = _resolve_docker_source_variables(raw_base, global_args)
+            alias = next(
+                (non_options[index + 1] for index, value in enumerate(non_options[:-1]) if value.upper() == "AS"),
+                None,
+            )
+            inherited_args, inherited_env, inherited_onbuild = (
+                saved_stages.get(base.casefold(), ({}, {}, [])) if not base_unresolved else ({}, {}, [])
+            )
+            stage_args = dict(inherited_args)
+            stage_env = dict(inherited_env)
+            stage_onbuild = []
+            current_stage_name = alias
+            current_stage_index += 1
+            in_stage = True
+            for trigger in inherited_onbuild:
+                _run_onbuild_trigger(trigger)
+            continue
+
+        if instruction == "ARG":
+            _apply_arg(payload, stage_scope=in_stage)
+            continue
+
+        if instruction == "ENV" and in_stage:
+            _apply_env(payload)
+            continue
+
+        if instruction == "ONBUILD" and in_stage:
+            stage_onbuild.append(payload)
+            continue
+
+        if instruction not in {"COPY", "ADD"}:
+            continue
+        _append_context_sources(line)
+
+    return resolved_sources
+
+
+def _compose_build_arg_overrides(env_dir: Path, dockerfile: Path) -> dict[str, str | None]:
+    """Return literal build-arg overrides for Compose services that build *dockerfile*."""
+    import yaml
+
+    compose_files = [env_dir / name for name in ("docker-compose.yaml", "docker-compose.yml")]
+    compose_files = [compose for compose in compose_files if compose.is_file()]
+    if not compose_files:
+        return {}
+
+    overrides: dict[str, str | None] = {}
+    for compose in compose_files:
+        try:
+            content = yaml.safe_load(compose.read_text(encoding="utf-8"))
+        except (OSError, yaml.YAMLError) as exc:
+            raise ValueError(f"Cannot safely resolve custom Docker Compose build args: {exc}") from exc
+        services = content.get("services", {}) if isinstance(content, dict) else {}
+        if not isinstance(services, dict):
+            continue
+        for service_name, service in services.items():
+            if service_name != "main" or not isinstance(service, dict):
+                continue
+            build = service.get("build")
+            if not isinstance(build, dict):
+                continue
+            context = build.get("context", ".")
+            dockerfile_name = build.get("dockerfile", "Dockerfile")
+            if not isinstance(context, str) or not isinstance(dockerfile_name, str):
+                continue
+            candidate = (compose.parent / context / dockerfile_name).resolve()
+            if candidate != dockerfile.resolve():
+                continue
+            args = build.get("args", {})
+            if isinstance(args, list):
+                items = [item.partition("=") if isinstance(item, str) else ("", "", "") for item in args]
+                parsed = {name: value if separator else None for name, separator, value in items if name}
+            elif isinstance(args, dict):
+                parsed = {str(name): None if value is None else str(value) for name, value in args.items()}
+            else:
+                raise ValueError("Cannot safely resolve custom Docker Compose build args")
+            for name, value in parsed.items():
+                if value is not None and "$" in value:
+                    value = None
+                if name in overrides and overrides[name] != value:
+                    overrides[name] = None
+                else:
+                    overrides[name] = value
+    return overrides
+
+
+def _ensure_empty_docker_input_compatibility(
+    context_dir: Path,
+    dockerfile: Path,
+    *,
+    has_input: bool,
+    context_is_reserved_input: bool = False,
+    build_arg_overrides: dict[str, str | None] | None = None,
+) -> None:
+    """Keep directory-level ``COPY input/`` valid for one Docker build context."""
+    resolved_sources: list[str] = []
+    unresolved_sources: list[str] = []
+    for source, resolved, unresolved in _dockerfile_resolved_build_context_sources(
+        dockerfile,
+        build_arg_overrides=build_arg_overrides or {},
+    ):
+        if unresolved:
+            unresolved_sources.append(source)
+        else:
+            resolved_sources.append(resolved)
+    for source in _dockerfile_main_mount_context_sources(dockerfile):
+        if "$" in source:
+            unresolved_sources.append(source)
+        else:
+            resolved_sources.append(source)
+    normalized_sources = [_normalize_docker_context_source(source) for source in resolved_sources]
+    for source in normalized_sources:
+        first_component = source.split("/", 1)[0]
+        if first_component.casefold() == "input" and first_component != "input":
+            raise ValueError("Custom Dockerfile input sources must use the canonical lowercase path 'input/'")
+    if has_input:
+        return
+    if unresolved_sources:
+        raise ValueError(
+            "Custom Dockerfile uses an ambiguous input source for an eval entry with no staged input files; "
+            "use a literal path or a static ARG/ENV default"
+        )
+    if any(source.casefold().startswith("input/") for source in normalized_sources):
+        raise ValueError("Custom Dockerfile copies a specific input path, but this eval entry stages no input files")
+    if context_is_reserved_input:
+        if any(source not in {"", "."} for source in normalized_sources):
+            raise ValueError(
+                "Custom Dockerfile copies a specific path from the input build context, "
+                "but this eval entry stages no input files"
+            )
+        return
+    # External base images can carry ONBUILD COPY input/ triggers that are not
+    # visible in the authored Dockerfile. An empty reserved directory keeps
+    # those builds valid without exposing any fixture bytes.
+    (context_dir / "input").mkdir(parents=True, exist_ok=True)
+
+
+def _ensure_empty_custom_docker_input_compatibility(env_dir: Path, dockerfile: Path, *, has_input: bool) -> None:
+    """Keep directory-level ``COPY input/`` valid for the managed main build."""
+    _ensure_empty_docker_input_compatibility(
+        env_dir,
+        dockerfile,
+        has_input=has_input,
+        build_arg_overrides=_compose_build_arg_overrides(env_dir, dockerfile),
+    )
+
+
+def _literal_compose_build_args(build: dict[str, Any]) -> dict[str, str | None]:
+    raw_args = build.get("args", {})
+    if isinstance(raw_args, list):
+        items = [item.partition("=") if isinstance(item, str) else ("", "", "") for item in raw_args]
+        parsed = {name: value if separator else None for name, separator, value in items if name}
+    elif isinstance(raw_args, dict):
+        parsed = {str(name): None if value is None else str(value) for name, value in raw_args.items()}
+    else:
+        raise ValueError("Cannot safely resolve custom Docker Compose build args")
+    return {name: None if value is not None and "$" in value else value for name, value in parsed.items()}
+
+
+def _compose_build_context_values(build: str | dict[str, Any]) -> list[str]:
+    """Return validated primary and named build-context paths."""
+    if isinstance(build, str):
+        return [build]
+    values = [str(build.get("context", "."))]
+    additional = build.get("additional_contexts", {})
+    if isinstance(additional, list):
+        values.extend(item.split("=", 1)[1] for item in additional if isinstance(item, str) and "=" in item)
+    elif isinstance(additional, dict):
+        values.extend(str(value) for value in additional.values())
+    return values
+
+
+def _compose_additional_build_contexts(build: str | dict[str, Any]) -> dict[str, str]:
+    """Return named Compose build contexts after structural validation."""
+    if not isinstance(build, dict):
+        return {}
+    additional = build.get("additional_contexts", {})
+    if isinstance(additional, list):
+        return {
+            name: value
+            for item in additional
+            if isinstance(item, str) and "=" in item
+            for name, _separator, value in [item.partition("=")]
+            if name
+        }
+    if isinstance(additional, dict):
+        return {str(name): str(value) for name, value in additional.items()}
+    return {}
+
+
+def _dockerfile_mount_context_sources(path: Path) -> list[tuple[str | None, str]]:
+    """Return BuildKit RUN-mount contexts and their source paths."""
+    sources: list[tuple[str | None, str]] = []
+    for line in _dockerfile_logical_lines(path):
+        parts = line.split(None, 1)
+        effective_line = parts[1].strip() if len(parts) == 2 and parts[0].upper() == "ONBUILD" else line
+        effective_parts = effective_line.split(None, 1)
+        if len(effective_parts) != 2 or effective_parts[0].upper() != "RUN":
+            continue
+        try:
+            tokens = shlex.split(effective_parts[1])
+        except ValueError as exc:
+            raise ValueError(f"Cannot safely parse custom Dockerfile RUN options: {effective_line}") from exc
+        for token in tokens:
+            if not token.startswith("--"):
+                break
+            if not token.startswith("--mount="):
+                continue
+            mount = token.partition("=")[2]
+            options = dict(item.partition("=")[::2] for item in mount.split(",") if "=" in item)
+            source = options.get("source", options.get("src", "."))
+            sources.append((options.get("from"), source))
+    return sources
+
+
+def _dockerfile_main_mount_context_sources(path: Path) -> list[str]:
+    """Return source paths for BuildKit mounts from the primary context."""
+    return [source for context, source in _dockerfile_mount_context_sources(path) if context is None]
+
+
+def _dockerfile_named_mount_context_sources(path: Path) -> list[tuple[str, str]]:
+    """Return source paths for BuildKit mounts from named contexts."""
+    return [(context, source) for context, source in _dockerfile_mount_context_sources(path) if context is not None]
+
+
+def _validate_empty_named_input_context_sources(
+    dockerfile: Path,
+    reserved_named_contexts: set[str],
+    has_input: bool,
+) -> None:
+    """Reject specific reads from an explicitly empty named input context."""
+    if has_input or not reserved_named_contexts:
+        return
+    named_sources = [
+        *_dockerfile_named_build_context_sources(dockerfile),
+        *_dockerfile_named_mount_context_sources(dockerfile),
+    ]
+    for context, source in named_sources:
+        if context not in reserved_named_contexts:
+            continue
+        if "$" in source or _normalize_docker_context_source(source) not in {"", "."}:
+            raise ValueError(
+                "Custom Dockerfile reads a specific path from an input context, "
+                "but this eval entry stages no input files"
+            )
+
+
+def _ensure_empty_compose_input_compatibility(env_dir: Path, *, has_input: bool) -> None:
+    """Apply explicit-empty input compatibility to every validated Compose build."""
+    compose_path = _custom_compose_path(env_dir)
+    if compose_path is None:
+        return
+    import yaml
+
+    content = yaml.safe_load(compose_path.read_text(encoding="utf-8"))
+    services = content.get("services", {}) if isinstance(content, dict) else {}
+    recipes: list[tuple[Path, Path | None, str | None, dict[str, str | None], bool, set[str]]] = []
+    for service in services.values():
+        if not isinstance(service, dict) or "build" not in service:
+            continue
+        build = service["build"]
+        if not has_input:
+            for value in _compose_build_context_values(build):
+                normalized = _normalize_docker_context_source(value)
+                first_component = normalized.split("/", 1)[0]
+                if first_component.casefold() == "input" and first_component != "input":
+                    raise ValueError(
+                        "Custom Docker Compose input contexts must use the canonical lowercase path 'input'"
+                    )
+                if normalized.casefold() == "input":
+                    (env_dir / "input").mkdir(parents=True, exist_ok=True)
+                elif normalized.casefold().startswith("input/"):
+                    raise ValueError(
+                        "Custom Docker Compose references a specific input context, but this eval entry stages no input files"
+                    )
+        if isinstance(build, str):
+            context_dir = (env_dir / build).resolve()
+            context_is_reserved_input = _normalize_docker_context_source(build).casefold() == "input"
+            recipes.append((context_dir, context_dir / "Dockerfile", None, {}, context_is_reserved_input, set()))
+            continue
+        if not isinstance(build, dict):
+            continue
+        context_dir = (env_dir / str(build.get("context", "."))).resolve()
+        inline = build.get("dockerfile_inline")
+        dockerfile = None if inline is not None else context_dir / str(build.get("dockerfile", "Dockerfile"))
+        context_is_reserved_input = (
+            _normalize_docker_context_source(str(build.get("context", "."))).casefold() == "input"
+        )
+        reserved_named_contexts = {
+            name
+            for name, value in _compose_additional_build_contexts(build).items()
+            if _normalize_docker_context_source(value).casefold() == "input"
+        }
+        recipes.append(
+            (
+                context_dir,
+                dockerfile,
+                inline,
+                _literal_compose_build_args(build),
+                context_is_reserved_input,
+                reserved_named_contexts,
+            )
+        )
+
+    initial_input = {
+        context_dir: (
+            has_input
+            if _paths_equivalent(context_dir, env_dir) or context_is_reserved_input
+            else (context_dir / "input").is_dir()
+        )
+        for context_dir, _dockerfile, _inline, _args, context_is_reserved_input, _named in recipes
+    }
+    for context_dir, dockerfile, inline, build_args, context_is_reserved_input, reserved_named_contexts in recipes:
+        if (
+            dockerfile is not None
+            and _paths_equivalent(context_dir, env_dir)
+            and _paths_equivalent(dockerfile, env_dir / "Dockerfile")
+        ):
+            continue
+        if inline is not None:
+            with tempfile.TemporaryDirectory(prefix="skillevaluator-compose-inline-") as temporary:
+                parsed_dockerfile = Path(temporary) / "Dockerfile"
+                parsed_dockerfile.write_text(str(inline).replace("$$", "$"), encoding="utf-8")
+                _ensure_empty_docker_input_compatibility(
+                    context_dir,
+                    parsed_dockerfile,
+                    has_input=initial_input[context_dir],
+                    context_is_reserved_input=context_is_reserved_input,
+                    build_arg_overrides=build_args,
+                )
+                _validate_empty_named_input_context_sources(parsed_dockerfile, reserved_named_contexts, has_input)
+            continue
+        if dockerfile is None or not dockerfile.is_file():
+            raise ValueError(f"Custom Docker Compose build Dockerfile does not exist: {dockerfile}")
+        _ensure_empty_docker_input_compatibility(
+            context_dir,
+            dockerfile,
+            has_input=initial_input[context_dir],
+            context_is_reserved_input=context_is_reserved_input,
+            build_arg_overrides=build_args,
+        )
+        _validate_empty_named_input_context_sources(dockerfile, reserved_named_contexts, has_input)
+
+
 def _compose_strings(value: Any) -> list[str]:
-    if isinstance(value, str):
-        return [value]
-    if isinstance(value, dict):
-        return [item for child in value.values() for item in _compose_strings(child)]
-    if isinstance(value, list):
-        return [item for child in value for item in _compose_strings(child)]
-    return []
+    strings: list[str] = []
+    seen_containers: set[int] = set()
+    nodes = 0
+
+    def _visit(node: Any, depth: int) -> None:
+        nonlocal nodes
+        nodes += 1
+        if depth > 64 or nodes > 10_000:
+            raise ValueError("Custom Docker Compose structure exceeds safe traversal limits")
+        if isinstance(node, str):
+            strings.append(node)
+            return
+        if not isinstance(node, (dict, list)):
+            return
+        identity = id(node)
+        if identity in seen_containers:
+            raise ValueError("Custom Docker Compose aliases or cycles are not supported")
+        seen_containers.add(identity)
+        children = node.values() if isinstance(node, dict) else node
+        for child in children:
+            _visit(child, depth + 1)
+
+    _visit(value, 0)
+    return strings
 
 
 def _validate_compose_interpolation(content: dict[str, Any], allowed_env: set[str]) -> None:
@@ -1090,6 +2476,11 @@ def _validate_compose_host_passthrough(value: object, *, allowed_env: set[str], 
         )
 
 
+def _require_string_mapping_keys(value: dict[object, object], *, field: str) -> None:
+    if any(not isinstance(key, str) for key in value):
+        raise ValueError(f"Custom Docker Compose {field} keys must be strings")
+
+
 def _validate_compose_build(
     service_name: str,
     build: object,
@@ -1103,6 +2494,7 @@ def _validate_compose_build(
         return
     if not isinstance(build, dict):
         raise ValueError(f"Custom Docker Compose service '{service_name}' build must be a path or mapping")
+    _require_string_mapping_keys(build, field=f"service '{service_name}' build")
 
     unsupported_keys = sorted(set(build) - _COMPOSE_ALLOWED_BUILD_KEYS)
     if unsupported_keys:
@@ -1116,8 +2508,15 @@ def _validate_compose_build(
     context_dir = environment_dir / str(context)
 
     dockerfile = build.get("dockerfile")
+    inline = build.get("dockerfile_inline")
+    if dockerfile is not None and inline is not None:
+        raise ValueError(f"Custom Docker Compose service '{service_name}' cannot set both dockerfile forms")
     if dockerfile is not None and not _is_relative_compose_path(dockerfile, context_dir):
         raise ValueError(f"Custom Docker Compose service '{service_name}' has an unsafe build dockerfile")
+    if inline is not None and (not isinstance(inline, str) or not inline.strip() or len(inline) > 20_000):
+        raise ValueError(f"Custom Docker Compose service '{service_name}' has an invalid inline Dockerfile")
+    if service_name == "main" and "target" in build:
+        raise ValueError("Custom Docker Compose service 'main' cannot select an authored build target")
 
     additional_contexts = build.get("additional_contexts", {})
     if isinstance(additional_contexts, list):
@@ -1125,6 +2524,7 @@ def _validate_compose_build(
             item.split("=", 1)[1] if isinstance(item, str) and "=" in item else None for item in additional_contexts
         ]
     elif isinstance(additional_contexts, dict):
+        _require_string_mapping_keys(additional_contexts, field=f"service '{service_name}' build additional_contexts")
         values = list(additional_contexts.values())
     else:
         raise ValueError(
@@ -1185,6 +2585,7 @@ def _validate_and_sanitize_custom_compose(
         raise ValueError(f"Custom Docker Compose file cannot be read safely: {exc}") from exc
     if not isinstance(content, dict):
         raise ValueError("Custom Docker Compose file must contain a top-level mapping")
+    _require_string_mapping_keys(content, field="top-level")
 
     unsupported_top_level = sorted(set(content) - _COMPOSE_ALLOWED_TOP_LEVEL_KEYS)
     if unsupported_top_level:
@@ -1198,6 +2599,9 @@ def _validate_and_sanitize_custom_compose(
     for svc_name, service in services.items():
         if not isinstance(svc_name, str) or not isinstance(service, dict):
             raise ValueError("Custom Docker Compose services must map names to service mappings")
+        _require_string_mapping_keys(service, field=f"service '{svc_name}'")
+        if "build" in service and "image" in service:
+            raise ValueError(f"Custom Docker Compose service '{svc_name}' cannot set image together with build")
 
         volumes = service.get("volumes", [])
         if not isinstance(volumes, list):
@@ -1236,10 +2640,13 @@ def _validate_and_sanitize_custom_compose(
     if not isinstance(volumes, dict):
         raise ValueError("Custom Docker Compose top-level volumes must be a mapping")
     for volume_name, volume in volumes.items():
+        if not isinstance(volume_name, str):
+            raise ValueError("Custom Docker Compose volume names must be strings")
         if volume is None:
             continue
         if not isinstance(volume, dict):
             raise ValueError(f"Custom Docker Compose volume '{volume_name}' must be a mapping")
+        _require_string_mapping_keys(volume, field=f"volume '{volume_name}'")
         unsupported_keys = sorted(set(volume) - _COMPOSE_ALLOWED_VOLUME_KEYS)
         if unsupported_keys:
             raise ValueError(f"Custom Docker Compose volume '{volume_name}' cannot set: {', '.join(unsupported_keys)}")
@@ -1248,10 +2655,13 @@ def _validate_and_sanitize_custom_compose(
     if not isinstance(networks, dict):
         raise ValueError("Custom Docker Compose top-level networks must be a mapping")
     for network_name, network in networks.items():
+        if not isinstance(network_name, str):
+            raise ValueError("Custom Docker Compose network names must be strings")
         if network is None:
             continue
         if not isinstance(network, dict):
             raise ValueError(f"Custom Docker Compose network '{network_name}' must be a mapping")
+        _require_string_mapping_keys(network, field=f"network '{network_name}'")
         unsupported_keys = sorted(set(network) - _COMPOSE_ALLOWED_NETWORK_KEYS)
         if unsupported_keys:
             raise ValueError(
@@ -1264,7 +2674,40 @@ def _validate_and_sanitize_custom_compose(
         compose_path.write_text(yaml.dump(content, default_flow_style=False), encoding="utf-8")
 
 
-_VERIFIER_DEPS = "ragas~=0.4.0 openai>=1.0 anthropic>=0.40 boto3>=1.34"
+def _custom_compose_path(environment_dir: Path) -> Path | None:
+    candidates = [
+        environment_dir / name
+        for name in ("docker-compose.yaml", "docker-compose.yml")
+        if (environment_dir / name).exists()
+    ]
+    if len(candidates) > 1:
+        raise ValueError("Custom environment must not contain both docker-compose.yaml and docker-compose.yml")
+    return candidates[0] if candidates else None
+
+
+_VERIFIER_DEPS = "ragas~=0.4.0 langchain-community<0.4.2 openai>=1.0 anthropic>=0.40 boto3>=1.34"
+_VERIFIER_IMPORT_SMOKE = (
+    "from ragas import SingleTurnSample; "
+    "from ragas.llms.base import llm_factory; "
+    "from ragas.messages import AIMessage, HumanMessage; "
+    "from ragas.metrics.collections import AgentGoalAccuracyWithReference"
+)
+_MANAGED_PATH_SHELL = 'PATH="${PATH:+$PATH:}/usr/local/bin:/usr/bin:/bin"; export PATH; exec "$@"'
+
+
+def _managed_run(command: str, *args: str) -> str:
+    """Build an exec-form RUN that remains usable after an authored PATH override."""
+    return "RUN " + json.dumps(["/bin/sh", "-c", _MANAGED_PATH_SHELL, "skillevaluator", command, *args])
+
+
+def _verifier_install_lines(extra_requirements: Sequence[str] = ()) -> list[str]:
+    """Install verifier and skill requirements in one resolver transaction."""
+    requirements = [*_VERIFIER_DEPS.split(), *extra_requirements]
+    return [
+        _managed_run("python", "-m", "pip", "install", "--no-cache-dir", *requirements),
+        _managed_run("python", "-c", _VERIFIER_IMPORT_SMOKE),
+    ]
+
 
 _WORKSPACE_SKILL_PATH = "COPY skills/ /workspace/skills/"
 _AGENT_SKILL_PATHS = [
@@ -1272,6 +2715,242 @@ _AGENT_SKILL_PATHS = [
     "COPY skills/ /root/.agents/skills/",
     "COPY skills/ /root/.config/opencode/skills/",
 ]
+_RUNTIME_SKILL_DIRS = (
+    "/etc/codex/skills",
+    "/workspace/skills",
+    "/workspace/.agents/skills",
+    "/workspace/.claude/commands",
+    "/workspace/.claude/skills",
+    "/workspace/.codex/skills",
+    "/workspace/.config/opencode/skills",
+    "/workspace/.cursor/skills",
+    "/workspace/.gemini/skills",
+    "/workspace/.gemini/extensions",
+    "/workspace/.opencode/skills",
+    "/root/.claude/commands",
+    "/root/.claude/skills",
+    "/root/.agents/skills",
+    "/root/.codex/skills",
+    "/root/.config/opencode/skills",
+    "/root/.gemini/extensions",
+    "/logs/agent/sessions/skills",
+    "/tmp/agent-home/sessions/skills",
+)
+_PROJECT_SKILL_RELATIVE_DIRS = (
+    ".agents/skills",
+    ".claude/commands",
+    ".claude/skills",
+    ".codex/skills",
+    ".config/opencode/skills",
+    ".cursor/skills",
+    ".gemini/skills",
+    ".gemini/extensions",
+    ".opencode/skills",
+)
+_RUNTIME_DISCOVERY_ENV_NAMES = frozenset(
+    {
+        "CLAUDE_CODE_DISABLE_POLICY_SKILLS",
+        "CLAUDE_CONFIG_DIR",
+        "CODEX_HOME",
+        "GEMINI_CLI_HOME",
+        "HOME",
+        "OPENCODE_CONFIG_DIR",
+        "USERPROFILE",
+        "XDG_CONFIG_HOME",
+    }
+)
+_RUNTIME_LOADER_ENV_NAMES = frozenset(
+    {
+        "BASH_ENV",
+        "CLASSPATH",
+        "DYLD_INSERT_LIBRARIES",
+        "ENV",
+        "GCONV_PATH",
+        "JAVA_TOOL_OPTIONS",
+        "LD_AUDIT",
+        "LD_LIBRARY_PATH",
+        "LD_PRELOAD",
+        "LOCPATH",
+        "LUA_CPATH",
+        "LUA_INIT",
+        "LUA_PATH",
+        "NLSPATH",
+        "NODE_OPTIONS",
+        "PERL5LIB",
+        "PERL5OPT",
+        "PYTHONHOME",
+        "PYTHONINSPECT",
+        "PYTHONPATH",
+        "PYTHONSTARTUP",
+        "RUBYLIB",
+        "RUBYOPT",
+        "ZDOTDIR",
+        "_JAVA_OPTIONS",
+    }
+)
+_RUNTIME_LOADER_ENV_PREFIXES = ("BASH_FUNC_",)
+_RUNTIME_LOADER_ENV_RESET = "ENV " + " ".join(f'{name}=""' for name in sorted(_RUNTIME_LOADER_ENV_NAMES))
+_RUNTIME_POLICY_ENV_RESET = 'ENV CLAUDE_CODE_DISABLE_POLICY_SKILLS="1"'
+_EVALUATOR_MANAGED_RUNTIME_ENV = {
+    **dict.fromkeys(_RUNTIME_LOADER_ENV_NAMES, ""),
+    "CLAUDE_CODE_DISABLE_POLICY_SKILLS": "1",
+}
+_CLEAR_SKILL_ROOT_FUNCTION = (
+    "clear_skill_root() { target=$1; "
+    'if [ -d "$target" ] && [ ! -L "$target" ]; then '
+    'for child in "$target"/* "$target"/.[!.]* "$target"/..?*; do '
+    '[ -e "$child" ] || [ -L "$child" ] || continue; /bin/rm -rf -- "$child"; done; '
+    'else /bin/rm -rf -- "$target"; fi; }; '
+)
+_PROJECT_SKILL_ANCESTOR_RESET = (
+    "set -eu; current=$(/bin/pwd -P); while :; do "
+    "for rel in "
+    + " ".join(_PROJECT_SKILL_RELATIVE_DIRS)
+    + '; do /bin/rm -rf -- "$current/$rel"; /bin/mkdir -p -- "$current/$rel"; done; '
+    '[ "$current" = / ] && break; current=${current%/*}; [ -n "$current" ] || current=/; done'
+)
+_HOME_SKILL_RESET = (
+    "set -eu; " + _CLEAR_SKILL_ROOT_FUNCTION + 'home=${HOME:-/root}; case "$home" in /*) ;; *) '
+    "echo 'SkillEvaluator requires an absolute HOME for runtime skill isolation' >&2; exit 78;; esac; "
+    "for rel in " + " ".join(_PROJECT_SKILL_RELATIVE_DIRS) + '; do clear_skill_root "$home/$rel"; done'
+)
+_PASSWD_HOME_SKILL_RESET = (
+    "set -eu; " + _CLEAR_SKILL_ROOT_FUNCTION + "[ -r /etc/passwd ] || exit 0; "
+    'while IFS=: read -r _ _ _ _ _ home _; do case "$home" in /*) ;; *) continue;; esac; '
+    '[ -d "$home" ] || continue; '
+    "for rel in "
+    + " ".join(_PROJECT_SKILL_RELATIVE_DIRS)
+    + '; do clear_skill_root "$home/$rel"; done; done < /etc/passwd'
+)
+_DISCOVERY_ENV_SKILL_RESET = (
+    "set -eu; "
+    + _CLEAR_SKILL_ROOT_FUNCTION
+    + 'if [ -n "${CLAUDE_CONFIG_DIR:-}" ]; then case "$CLAUDE_CONFIG_DIR" in /*) ;; *) exit 78;; esac; '
+    'clear_skill_root "$CLAUDE_CONFIG_DIR/skills"; clear_skill_root "$CLAUDE_CONFIG_DIR/commands"; fi; '
+    'if [ -n "${CODEX_HOME:-}" ]; then case "$CODEX_HOME" in /*) ;; *) exit 78;; esac; '
+    'clear_skill_root "$CODEX_HOME/skills"; fi; '
+    'if [ -n "${GEMINI_CLI_HOME:-}" ]; then case "$GEMINI_CLI_HOME" in /*) ;; *) exit 78;; esac; '
+    'clear_skill_root "$GEMINI_CLI_HOME/.gemini/skills"; '
+    'clear_skill_root "$GEMINI_CLI_HOME/.gemini/extensions"; fi; '
+    'if [ -n "${OPENCODE_CONFIG_DIR:-}" ]; then case "$OPENCODE_CONFIG_DIR" in /*) ;; *) exit 78;; esac; '
+    'clear_skill_root "$OPENCODE_CONFIG_DIR/skills"; fi; '
+    'if [ -n "${XDG_CONFIG_HOME:-}" ]; then case "$XDG_CONFIG_HOME" in /*) ;; *) exit 78;; esac; '
+    'clear_skill_root "$XDG_CONFIG_HOME/opencode/skills"; fi'
+)
+_RUNTIME_PROJECTION_OVERLAP_PREFLIGHT = (
+    'set -eu; check_path() { value=$1; case "$value" in '
+    "/workspace/input|/workspace/input/*|/workspace/repo|/workspace/repo/*|"
+    "/workspace/skills|/workspace/skills/*|"
+    "*/.agents/skills|*/.agents/skills/*|*/.claude/commands|*/.claude/commands/*|"
+    "*/.claude/skills|*/.claude/skills/*|"
+    "*/.codex/skills|*/.codex/skills/*|*/.config/opencode/skills|*/.config/opencode/skills/*|"
+    "*/.cursor/skills|*/.cursor/skills/*|*/.gemini/skills|*/.gemini/skills/*|"
+    "*/.gemini/extensions|*/.gemini/extensions/*|"
+    "*/.opencode/skills|*/.opencode/skills/*) "
+    "echo 'SkillEvaluator agent workdir/home overlaps an evaluator-controlled runtime projection' >&2; "
+    'exit 78;; esac; }; check_control_path() { value=$1; check_path "$value"; '
+    'if [ -d "$value" ]; then canonical=$(CDPATH= cd -P -- "$value" 2>/dev/null && /bin/pwd -P) || exit 78; '
+    'check_path "$canonical"; elif [ -e "$value" ] || [ -L "$value" ]; then '
+    "echo 'SkillEvaluator discovery home must resolve to a directory' >&2; exit 78; fi; }; "
+    'current=$(/bin/pwd -P); check_path "$current"; '
+    'home=${HOME:-/root}; case "$home" in /*) check_control_path "$home";; *) '
+    "echo 'SkillEvaluator requires an absolute HOME for runtime skill isolation' >&2; exit 78;; esac; "
+    'for controlled_home in "${CLAUDE_CONFIG_DIR:-}" "${CODEX_HOME:-}" "${GEMINI_CLI_HOME:-}" '
+    '"${OPENCODE_CONFIG_DIR:-}" '
+    '"${XDG_CONFIG_HOME:-}"; do [ -z "$controlled_home" ] || check_control_path "$controlled_home"; done; '
+    "[ -r /etc/passwd ] || exit 0; while IFS=: read -r _ _ _ _ _ passwd_home _; do "
+    'case "$passwd_home" in /*) '
+    '[ -e "$passwd_home" ] && [ ! -d "$passwd_home" ] && continue; '
+    'check_control_path "$passwd_home";; esac; done < /etc/passwd'
+)
+_RUNTIME_REPO_RESET_LINES = [
+    'RUN ["/bin/rm", "-rf", "/workspace/repo"]',
+    'RUN ["/bin/mkdir", "-p", "/workspace/repo"]',
+]
+_RUNTIME_ROOT_PREFLIGHT = "RUN " + json.dumps(
+    [
+        "/bin/sh",
+        "-c",
+        'PATH="${PATH:+$PATH:}/usr/local/bin:/usr/bin:/bin"; export PATH; '
+        'if [ "$(id -u)" -ne 0 ]; then echo \'SkillEvaluator final runtime projection requires root; '
+        "declare the Dockerfile final USER explicitly so it can be restored' >&2; exit 78; fi",
+    ]
+)
+
+
+def _validated_agent_workdir(agent_workdir: str | None) -> str | None:
+    """Return a normalized absolute container workdir or fail closed."""
+    if agent_workdir is None:
+        return None
+    if not isinstance(agent_workdir, str) or not agent_workdir:
+        raise ValueError("agent_workdir must be a non-empty absolute container path")
+    normalized = posixpath.normpath(agent_workdir)
+    typed_normalized = agent_workdir.rstrip("/") or "/"
+    if (
+        not normalized.startswith("/")
+        or normalized != typed_normalized
+        or re.fullmatch(r"/[A-Za-z0-9._/-]*", normalized) is None
+    ):
+        raise ValueError("agent_workdir must be a normalized absolute POSIX path")
+    reserved_roots = ("/workspace/input", "/workspace/repo", "/workspace/skills")
+    if any(normalized == root or normalized.startswith(f"{root}/") for root in reserved_roots):
+        raise ValueError("agent_workdir must not be inside an evaluator-controlled runtime projection")
+    parts = tuple(part for part in normalized.split("/") if part)
+    discovery_parts = (
+        (".agents", "skills"),
+        (".claude", "skills"),
+        (".codex", "skills"),
+        (".config", "opencode", "skills"),
+        (".cursor", "skills"),
+        (".gemini", "skills"),
+        (".opencode", "skills"),
+    )
+    if any(
+        parts[index : index + len(candidate)] == candidate
+        for candidate in discovery_parts
+        for index in range(len(parts) - len(candidate) + 1)
+    ):
+        raise ValueError("agent_workdir must not be inside an agent skill discovery directory")
+    return normalized
+
+
+def _validate_runtime_discovery_env(runtime_env: dict[str, str] | None) -> None:
+    collisions = sorted(name for name in (runtime_env or {}) if name.upper() in _RUNTIME_DISCOVERY_ENV_NAMES)
+    if collisions:
+        raise ValueError(
+            "harbor.runtime_env cannot override agent skill discovery location(s): " + ", ".join(collisions)
+        )
+
+
+def _validate_runtime_loader_env(runtime_env: dict[str, str] | None) -> None:
+    collisions = sorted(
+        name
+        for name in (runtime_env or {})
+        if name.upper() in _RUNTIME_LOADER_ENV_NAMES or name.upper().startswith(_RUNTIME_LOADER_ENV_PREFIXES)
+    )
+    if collisions:
+        raise ValueError("harbor.runtime_env cannot override process loader environment: " + ", ".join(collisions))
+
+
+def _runtime_skill_reset_lines(agent_workdir: str | None = None) -> list[str]:
+    """Replace fixed, effective-home, and project-ancestor skill roots."""
+    lines = [
+        "RUN " + json.dumps(["/bin/rm", "-rf", *_RUNTIME_SKILL_DIRS]),
+        "RUN " + json.dumps(["/bin/mkdir", "-p", *_RUNTIME_SKILL_DIRS]),
+        "RUN " + json.dumps(["/bin/sh", "-c", _PROJECT_SKILL_ANCESTOR_RESET]),
+        "RUN " + json.dumps(["/bin/sh", "-c", _HOME_SKILL_RESET]),
+        "RUN " + json.dumps(["/bin/sh", "-c", _PASSWD_HOME_SKILL_RESET]),
+        "RUN " + json.dumps(["/bin/sh", "-c", _DISCOVERY_ENV_SKILL_RESET]),
+    ]
+    validated_workdir = _validated_agent_workdir(agent_workdir)
+    if validated_workdir is not None:
+        lines.extend(
+            [
+                f"WORKDIR {validated_workdir}",
+                "RUN " + json.dumps(["/bin/sh", "-c", _PROJECT_SKILL_ANCESTOR_RESET]),
+            ]
+        )
+    return lines
 
 
 def _runtime_copy_lines(
@@ -1279,10 +2958,17 @@ def _runtime_copy_lines(
     include_input: bool,
     include_repo: bool = False,
     include_repo_linked_root: bool = False,
+    agent_workdir: str | None = None,
 ) -> list[str]:
-    lines = [_WORKSPACE_SKILL_PATH, *_AGENT_SKILL_PATHS, *agent_config_lines]
-    if include_input:
-        lines.append("COPY input/ /workspace/input/")
+    _ = include_input
+    lines = [
+        _RUNTIME_ROOT_PREFLIGHT,
+        *_runtime_skill_reset_lines(agent_workdir),
+        *_RUNTIME_REPO_RESET_LINES,
+        _WORKSPACE_SKILL_PATH,
+        *_AGENT_SKILL_PATHS,
+        *agent_config_lines,
+    ]
     if include_repo:
         lines.append("COPY repo/ /workspace/repo/")
     if include_repo_linked_root:
@@ -1290,19 +2976,72 @@ def _runtime_copy_lines(
     return lines
 
 
-def _append_missing_lines(content: str, lines: list[str]) -> str:
-    additions = ""
-    for line in lines:
-        if not line:
-            if additions and not additions.endswith("\n\n"):
-                additions += "\n"
-            continue
-        if line not in content:
-            additions += f"{line}\n"
-    if not additions:
-        return content
+def _append_task_input_projection(
+    content: str,
+    *,
+    include_input: bool,
+    agent_config_lines: list[str],
+    restore_user: str | None = None,
+) -> str:
+    """Append the final evaluator-owned replacement of ``/workspace/input``."""
     separator = "" if content.endswith("\n") else "\n"
-    return content + separator + additions
+    lines = [
+        "",
+        "# SkillEvaluator: replace task input after all authored/base-image layers",
+        'RUN ["/bin/rm", "-rf", "/workspace/input"]',
+        'RUN ["/bin/mkdir", "-p", "/workspace/input"]',
+    ]
+    if include_input:
+        lines.append("COPY input/ /workspace/input/")
+    lines.extend(
+        [
+            "RUN " + json.dumps(["/bin/sh", "-c", _RUNTIME_PROJECTION_OVERLAP_PREFLIGHT]),
+            "RUN " + json.dumps(["/bin/sh", "-c", _PROJECT_SKILL_ANCESTOR_RESET]),
+            _WORKSPACE_SKILL_PATH,
+            *_AGENT_SKILL_PATHS,
+            *agent_config_lines,
+            _RUNTIME_LOADER_ENV_RESET,
+            _RUNTIME_POLICY_ENV_RESET,
+            "ENTRYPOINT []",
+            "HEALTHCHECK NONE",
+        ]
+    )
+    if restore_user is not None and restore_user.casefold() != "root":
+        lines.extend(["", f"USER {restore_user}"])
+    return content + separator + "\n".join(lines) + "\n"
+
+
+def _extend_task_input_projection(lines: list[str], *, include_input: bool, agent_config_lines: list[str]) -> None:
+    """Add the final evaluator-owned input replacement to generated Dockerfiles."""
+    lines.extend(
+        [
+            "",
+            'RUN ["/bin/rm", "-rf", "/workspace/input"]',
+            'RUN ["/bin/mkdir", "-p", "/workspace/input"]',
+        ]
+    )
+    if include_input:
+        lines.append("COPY input/ /workspace/input/")
+    lines.extend(
+        [
+            "RUN " + json.dumps(["/bin/sh", "-c", _RUNTIME_PROJECTION_OVERLAP_PREFLIGHT]),
+            "RUN " + json.dumps(["/bin/sh", "-c", _PROJECT_SKILL_ANCESTOR_RESET]),
+            _WORKSPACE_SKILL_PATH,
+            *_AGENT_SKILL_PATHS,
+            *agent_config_lines,
+            _RUNTIME_LOADER_ENV_RESET,
+            _RUNTIME_POLICY_ENV_RESET,
+            "ENTRYPOINT []",
+            "HEALTHCHECK NONE",
+        ]
+    )
+
+
+def _append_evaluator_runtime_lines(content: str, lines: list[str], *, elevate: bool = False) -> str:
+    """Append evaluator-owned instructions without trusting authored text matches."""
+    separator = "" if content.endswith("\n") else "\n"
+    user_line = "USER root\n" if elevate else ""
+    return content + separator + "\n# SkillEvaluator: final runtime projection\n" + user_line + "\n".join(lines) + "\n"
 
 
 def _write_agent_configs(env_dir: Path) -> list[str]:
@@ -1319,7 +3058,8 @@ def _rebase_custom_dockerfile_content(
     include_input: bool,
     include_repo: bool = False,
     include_repo_linked_root: bool = False,
-) -> tuple[str, str] | None:
+    agent_workdir: str | None = None,
+) -> tuple[str, str]:
     """Return custom Dockerfile content layered on top of the eval base image.
 
     The base image already contains: python:3.12-slim, system packages
@@ -1329,34 +3069,30 @@ def _rebase_custom_dockerfile_content(
     The custom Dockerfile's FROM line is replaced so the skill author's
     additions (extra apt/pip packages, COPY, RUN) layer on top.  Multi-agent
     skill discovery paths are appended if not already present.
-    Returns the rebased content and original ``FROM`` instruction, or ``None``
-    when the content has no ``FROM`` instruction.
+    Returns the rebased content and original ``FROM`` instruction. Rebase mode
+    fails closed for missing or multi-stage ``FROM`` instructions.
     """
-    lines = content.splitlines(keepends=True)
-    rebased: list[str] = []
-    from_replaced = False
-    original_from = ""
-    for line in lines:
-        stripped = line.strip()
-        if not from_replaced and stripped.upper().startswith("FROM "):
-            rebased.append(f"FROM {base_image}\n")
-            rebased.append(f"# SkillEvaluator: original base was {stripped}\n")
-            from_replaced = True
-            original_from = stripped
-        else:
-            rebased.append(line)
-
-    if not from_replaced:
-        return None
-
-    rebased_content = _append_missing_lines(
-        "".join(rebased),
-        _runtime_copy_lines(
-            agent_config_lines,
-            include_input,
-            include_repo=include_repo,
-            include_repo_linked_root=include_repo_linked_root,
-        ),
+    restore_user = _dockerfile_final_explicit_user(content)
+    rebased_source, original_from = _replace_single_from_image(content, base_image)
+    rebased_content = _append_evaluator_runtime_lines(
+        rebased_source + f"\n# SkillEvaluator: original base was {original_from}\n",
+        [
+            *_verifier_install_lines(),
+            *_runtime_copy_lines(
+                agent_config_lines,
+                include_input,
+                include_repo=include_repo,
+                include_repo_linked_root=include_repo_linked_root,
+                agent_workdir=agent_workdir,
+            ),
+        ],
+        elevate=True,
+    )
+    rebased_content = _append_task_input_projection(
+        rebased_content,
+        include_input=include_input,
+        agent_config_lines=agent_config_lines,
+        restore_user=restore_user,
     )
     return rebased_content, original_from
 
@@ -1368,23 +3104,29 @@ def _ensure_verifier_deps(
     include_input: bool,
     include_repo: bool = False,
     include_repo_linked_root: bool = False,
+    agent_workdir: str | None = None,
 ) -> None:
     """Append verifier deps and runtime COPY lines to a custom Dockerfile."""
     content = dockerfile_path.read_text(encoding="utf-8")
-    additions = ""
-    if not ("ragas" in content and "anthropic" in content):
-        additions += f"\nRUN pip install --no-cache-dir {_VERIFIER_DEPS}\n"
-    updated = _append_missing_lines(
+    restore_user = _dockerfile_final_explicit_user(content)
+    user_prefix = "USER root\n" if restore_user is not None else ""
+    additions = f"\n{user_prefix}" + "\n".join(_verifier_install_lines()) + "\n"
+    updated = _append_evaluator_runtime_lines(
         content + additions,
         _runtime_copy_lines(
             agent_config_lines,
             include_input,
             include_repo=include_repo,
             include_repo_linked_root=include_repo_linked_root,
+            agent_workdir=agent_workdir,
         ),
     )
-    if updated == content:
-        return
+    updated = _append_task_input_projection(
+        updated,
+        include_input=include_input,
+        agent_config_lines=agent_config_lines,
+        restore_user=restore_user,
+    )
     dockerfile_path.write_text(updated, encoding="utf-8")
     logger.debug("Appended verifier deps + agent paths to %s", dockerfile_path)
 
@@ -1423,6 +3165,8 @@ def _resolve_entry_file_ref(
     ref_path = Path(ref)
     if ref_path.is_absolute():
         raise ValueError(f"evals.json files entry must be relative to evals/: {ref}")
+    if ".." in ref_path.parts:
+        raise ValueError(f"evals.json files entry cannot traverse parent directories: {ref}")
     if _LOCAL_LINK_SCHEME_RE.match(ref):
         raise ValueError(f"evals.json files entry uses unsupported URI scheme: {ref}")
 
@@ -1431,13 +3175,16 @@ def _resolve_entry_file_ref(
     else:
         candidates = [evals_dir / ref_path, skill_path / ref_path]
 
-    source = next((candidate.resolve() for candidate in candidates if candidate.exists()), None)
-    if source is None:
+    source_path = next((candidate.absolute() for candidate in candidates if candidate.exists()), None)
+    if source_path is None:
         raise FileNotFoundError(f"evals.json files entry does not exist: {ref}")
+    source = source_path.resolve()
 
     resolved_evals_dir = evals_dir.resolve()
     if source == resolved_evals_dir or not _is_relative_to(source, resolved_evals_dir):
         raise ValueError(f"evals.json files entry resolves outside evals/: {ref}")
+    if _has_symlink_component(source_path, evals_dir.absolute()):
+        raise ValueError(f"evals.json files entry must not contain symlinks: {ref}")
 
     resolved_input_files_dir = input_files_dir.resolve() if input_files_dir and input_files_dir.exists() else None
     if resolved_input_files_dir and _is_relative_to(source, resolved_input_files_dir):
@@ -1445,19 +3192,19 @@ def _resolve_entry_file_ref(
     else:
         rel = source.relative_to(resolved_evals_dir)
 
-    return source, rel
+    return source_path, rel
 
 
-def _copy_input_ref(source: Path, input_dir: Path, rel: Path) -> None:
+def _copy_input_ref(source: Path, input_dir: Path, rel: Path, *, allowed_root: Path) -> None:
     dest = input_dir if rel == Path() else input_dir / rel
     if source.is_dir():
         if dest.exists() and dest.is_file():
             dest.unlink()
-        copytree_secure(source, dest, dirs_exist_ok=True)
+        copytree_secure(source, dest, dirs_exist_ok=True, allowed_root=allowed_root)
         return
 
     dest.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(source, dest)
+    copy_file_secure(source, dest, allowed_root=allowed_root)
 
 
 def _stage_task_inputs(
@@ -1469,13 +3216,13 @@ def _stage_task_inputs(
     evals_dir: Path,
 ) -> bool:
     input_dir = env_dir / "input"
-    if os.path.lexists(input_dir) and (input_dir.is_symlink() or not input_dir.is_dir()):
+    if os.path.lexists(input_dir) and (_path_is_link_or_reparse(input_dir) or not input_dir.is_dir()):
         input_dir.unlink()
     elif input_dir.exists():
         shutil.rmtree(input_dir)
 
     if "files" not in entry and input_files_dir and input_files_dir.exists():
-        copytree_secure(input_files_dir, input_dir, dirs_exist_ok=True)
+        copytree_secure(input_files_dir, input_dir, dirs_exist_ok=True, allowed_root=evals_dir)
 
     for ref in _entry_file_refs(entry):
         source, rel = _resolve_entry_file_ref(
@@ -1485,9 +3232,36 @@ def _stage_task_inputs(
             input_files_dir=input_files_dir,
         )
         input_dir.mkdir(parents=True, exist_ok=True)
-        _copy_input_ref(source, input_dir, rel)
+        _copy_input_ref(source, input_dir, rel, allowed_root=evals_dir)
 
     return input_dir.exists()
+
+
+def _entry_declares_task_input(entry: dict[str, Any], input_files_dir: Path | None) -> bool:
+    """Return whether eval metadata should replace a native task's own input."""
+    return "files" in entry or bool(input_files_dir is not None and input_files_dir.exists())
+
+
+def _remove_staged_path(path: Path) -> None:
+    if _path_is_link_or_reparse(path) or not path.is_dir():
+        path.unlink()
+    else:
+        shutil.rmtree(path)
+
+
+def _sanitize_staged_runtime_skills(skills_dir: Path) -> None:
+    """Remove evaluator-only roots from authored or evaluator-copied skill bundles."""
+    if not skills_dir.exists():
+        return
+    eval_roots: set[Path] = set()
+    for manifest in _iter_skill_manifests(skills_dir):
+        skill_root = manifest.parent
+        if not skill_root.is_dir():
+            continue
+        eval_roots.update(child for child in skill_root.iterdir() if child.name.casefold() == "evals")
+    for eval_root in sorted(eval_roots, key=lambda path: len(path.parts), reverse=True):
+        if os.path.lexists(eval_root):
+            _remove_staged_path(eval_root)
 
 
 def _write_dockerfile(
@@ -1505,6 +3279,8 @@ def _write_dockerfile(
     repo_context_skill_path: Path | None = None,
     repo_context_mode: str = "linked",
     compose_env_names: set[str] | None = None,
+    repo_context_exclude_paths: Sequence[Path] = (),
+    agent_workdir: str | None = None,
 ) -> None:
     """Generate a Dockerfile that installs skills into the container.
 
@@ -1517,17 +3293,27 @@ def _write_dockerfile(
     env_dir = task_dir / "environment"
     env_dir.mkdir(parents=True, exist_ok=True)
 
+    if not has_skill and skill_path is not None:
+        _check_baseline_skill_candidates_do_not_alias_target(
+            skill_path,
+            reference_skills_dir,
+            workspace_skill_paths,
+            excluded_roots=repo_context_exclude_paths,
+        )
+
     skills_dir = env_dir / "skills"
     skills_dir.mkdir(parents=True, exist_ok=True)
-
-    def _ignore_results(directory, contents):
-        return [c for c in contents if c in ("results", "__pycache__", ".git")]
 
     if has_skill and skill_path and skill_path.exists():
         dest = skills_dir / skill_path.name
         if dest.exists():
             shutil.rmtree(dest)
-        copytree_secure(skill_path, dest, dirs_exist_ok=True, ignore=_ignore_results)
+        copytree_secure(
+            skill_path,
+            dest,
+            dirs_exist_ok=True,
+            ignore=_runtime_skill_copy_ignore(skill_path, repo_context_exclude_paths),
+        )
 
     if reference_skills_dir and reference_skills_dir.exists():
         for ref_skill in reference_skills_dir.iterdir():
@@ -1536,7 +3322,12 @@ def _write_dockerfile(
                     continue
                 dest = skills_dir / ref_skill.name
                 if not dest.exists():
-                    copytree_secure(ref_skill, dest, dirs_exist_ok=True, ignore=_ignore_results)
+                    copytree_secure(
+                        ref_skill,
+                        dest,
+                        dirs_exist_ok=True,
+                        ignore=_runtime_skill_copy_ignore(ref_skill, repo_context_exclude_paths),
+                    )
 
     for workspace_skill in workspace_skill_paths or []:
         if not workspace_skill.exists() or not workspace_skill.is_dir():
@@ -1546,7 +3337,14 @@ def _write_dockerfile(
         dest = skills_dir / workspace_skill.name
         if dest.exists():
             continue
-        copytree_secure(workspace_skill, dest, dirs_exist_ok=True, ignore=_ignore_results)
+        copytree_secure(
+            workspace_skill,
+            dest,
+            dirs_exist_ok=True,
+            ignore=_runtime_skill_copy_ignore(workspace_skill, repo_context_exclude_paths),
+        )
+
+    _sanitize_staged_runtime_skills(skills_dir)
 
     include_input = False
     if entry is not None and skill_path is not None and evals_dir is not None:
@@ -1564,7 +3362,10 @@ def _write_dockerfile(
         source_skill_path=repo_context_skill_path,
         mode=effective_repo_context_mode,
         exclude_source_skill=repo_context_mode == "full" and not has_skill,
+        excluded_roots=repo_context_exclude_paths,
     )
+    if not has_skill and skill_path is not None:
+        _check_staged_baseline_does_not_contain_target(env_dir, skill_path)
 
     agent_config_lines = _write_agent_configs(env_dir)
     include_repo = (env_dir / "repo").exists()
@@ -1577,7 +3378,7 @@ def _write_dockerfile(
         copytree_secure(custom_env_dir, staged_custom_env, allowed_root=skill_path)
         try:
             if not has_skill and skill_path:
-                _check_custom_environment_does_not_stage_target(staged_custom_env, skill_path.name)
+                _check_custom_environment_does_not_stage_target(staged_custom_env, skill_path)
 
             custom_dockerfile = staged_custom_env / "Dockerfile"
             custom_dockerfile_accepted = False
@@ -1590,10 +3391,8 @@ def _write_dockerfile(
                     custom_dockerfile_accepted = True
                     logger.debug("Using custom Dockerfile from %s", custom_env_dir / "Dockerfile")
 
-            compose_file = staged_custom_env / "docker-compose.yaml"
-            if not compose_file.exists():
-                compose_file = staged_custom_env / "docker-compose.yml"
-            if compose_file.exists():
+            compose_file = _custom_compose_path(staged_custom_env)
+            if compose_file is not None:
                 shutil.copy2(compose_file, env_dir / "docker-compose.yaml")
                 _validate_and_sanitize_custom_compose(
                     env_dir / "docker-compose.yaml",
@@ -1602,13 +3401,20 @@ def _write_dockerfile(
                 logger.debug("Copied docker-compose.yaml from %s", custom_env_dir / compose_file.name)
 
             for subdir in staged_custom_env.iterdir():
-                if subdir.is_dir() and subdir.name not in ("__pycache__", ".git"):
+                if subdir.is_dir() and subdir.name not in ("__pycache__", ".git") and subdir.name.casefold() != "input":
                     dest = env_dir / subdir.name
                     if not dest.exists():
                         copytree_secure(subdir, dest, allowed_root=staged_custom_env)
                         logger.debug("Copied sidecar dir %s", subdir.name)
 
+            _ensure_empty_compose_input_compatibility(env_dir, has_input=include_input)
+
             if custom_dockerfile_accepted:
+                _ensure_empty_custom_docker_input_compatibility(
+                    env_dir,
+                    env_dir / "Dockerfile",
+                    has_input=include_input,
+                )
                 if base_image and custom_dockerfile_mode == "rebase":
                     dockerfile_path = env_dir / "Dockerfile"
                     rebased = _rebase_custom_dockerfile_content(
@@ -1618,6 +3424,7 @@ def _write_dockerfile(
                         include_input=include_input,
                         include_repo=include_repo,
                         include_repo_linked_root=include_repo_linked_root,
+                        agent_workdir=agent_workdir,
                     )
                     if rebased is not None:
                         rebased_content, original_from = rebased
@@ -1634,6 +3441,7 @@ def _write_dockerfile(
                         include_input=include_input,
                         include_repo=include_repo,
                         include_repo_linked_root=include_repo_linked_root,
+                        agent_workdir=agent_workdir,
                     )
                 return
         finally:
@@ -1643,20 +3451,19 @@ def _write_dockerfile(
         dockerfile_lines = [
             f"FROM {base_image}",
             "",
-            "COPY skills/ /workspace/skills/",
-            "",
-            "COPY skills/ /root/.claude/skills/",
-            "COPY skills/ /root/.agents/skills/",
-            "COPY skills/ /root/.config/opencode/skills/",
+            *_runtime_copy_lines(
+                agent_config_lines,
+                include_input,
+                include_repo=include_repo,
+                include_repo_linked_root=include_repo_linked_root,
+                agent_workdir=agent_workdir,
+            ),
         ]
-        dockerfile_lines.extend(agent_config_lines)
-
-        if include_input:
-            dockerfile_lines.append("COPY input/ /workspace/input/")
-        if include_repo:
-            dockerfile_lines.append("COPY repo/ /workspace/repo/")
-        if include_repo_linked_root:
-            dockerfile_lines.append("COPY repo-linked-root/ /workspace/")
+        _extend_task_input_projection(
+            dockerfile_lines,
+            include_input=include_input,
+            agent_config_lines=agent_config_lines,
+        )
 
         (env_dir / "Dockerfile").write_text("\n".join(dockerfile_lines) + "\n", encoding="utf-8")
         return
@@ -1676,20 +3483,7 @@ def _write_dockerfile(
         dockerfile_lines.append("    " + " ".join(apt_pkgs) + " \\")
     dockerfile_lines.append("    && rm -rf /var/lib/apt/lists/*")
 
-    dockerfile_lines.extend(
-        [
-            "",
-            "RUN pip install --no-cache-dir \\",
-            "    ragas~=0.4.0 \\",
-            "    openai>=1.0 \\",
-            "    anthropic>=0.40 \\",
-            "    boto3>=1.34",
-        ]
-    )
-
-    if pip_reqs:
-        escaped = " ".join(f'"{r}"' for r in pip_reqs)
-        dockerfile_lines.append(f"RUN pip install --no-cache-dir {escaped}")
+    dockerfile_lines.extend(["", *_verifier_install_lines(pip_reqs)])
 
     dockerfile_lines.extend(
         [
@@ -1697,22 +3491,20 @@ def _write_dockerfile(
             "RUN mkdir -p /workspace/skills /workspace/input /workspace/output \\",
             "    /logs/verifier /logs/agent",
             "",
-            "COPY skills/ /workspace/skills/",
-            "",
-            "# Multi-agent skill discovery paths",
-            "COPY skills/ /root/.claude/skills/",
-            "COPY skills/ /root/.agents/skills/",
-            "COPY skills/ /root/.config/opencode/skills/",
+            *_runtime_copy_lines(
+                agent_config_lines,
+                include_input,
+                include_repo=include_repo,
+                include_repo_linked_root=include_repo_linked_root,
+                agent_workdir=agent_workdir,
+            ),
         ]
     )
-    dockerfile_lines.extend(agent_config_lines)
-
-    if include_input:
-        dockerfile_lines.append("COPY input/ /workspace/input/")
-    if include_repo:
-        dockerfile_lines.append("COPY repo/ /workspace/repo/")
-    if include_repo_linked_root:
-        dockerfile_lines.append("COPY repo-linked-root/ /workspace/")
+    _extend_task_input_projection(
+        dockerfile_lines,
+        include_input=include_input,
+        agent_config_lines=agent_config_lines,
+    )
 
     dockerfile_lines.extend(
         [
@@ -1732,19 +3524,22 @@ def _copy_skill_dirs(
     workspace_skill_paths: list[Path] | None,
     has_skill: bool,
     exclude_skill_name: str | None,
+    excluded_roots: Sequence[Path] = (),
 ) -> None:
     """Stage target/workspace skills into a task environment."""
     skills_dir = env_dir / "skills"
     skills_dir.mkdir(parents=True, exist_ok=True)
 
-    def _ignore_results(directory, contents):
-        return [c for c in contents if c in ("results", "__pycache__", ".git")]
-
     if has_skill and skill_path and skill_path.exists():
         dest = skills_dir / skill_path.name
         if dest.exists():
             shutil.rmtree(dest)
-        copytree_secure(skill_path, dest, dirs_exist_ok=True, ignore=_ignore_results)
+        copytree_secure(
+            skill_path,
+            dest,
+            dirs_exist_ok=True,
+            ignore=_runtime_skill_copy_ignore(skill_path, excluded_roots),
+        )
 
     if reference_skills_dir and reference_skills_dir.exists():
         for ref_skill in reference_skills_dir.iterdir():
@@ -1753,7 +3548,12 @@ def _copy_skill_dirs(
                     continue
                 dest = skills_dir / ref_skill.name
                 if not dest.exists():
-                    copytree_secure(ref_skill, dest, dirs_exist_ok=True, ignore=_ignore_results)
+                    copytree_secure(
+                        ref_skill,
+                        dest,
+                        dirs_exist_ok=True,
+                        ignore=_runtime_skill_copy_ignore(ref_skill, excluded_roots),
+                    )
 
     for workspace_skill in workspace_skill_paths or []:
         if not workspace_skill.exists() or not workspace_skill.is_dir():
@@ -1763,7 +3563,14 @@ def _copy_skill_dirs(
         dest = skills_dir / workspace_skill.name
         if dest.exists():
             continue
-        copytree_secure(workspace_skill, dest, dirs_exist_ok=True, ignore=_ignore_results)
+        copytree_secure(
+            workspace_skill,
+            dest,
+            dirs_exist_ok=True,
+            ignore=_runtime_skill_copy_ignore(workspace_skill, excluded_roots),
+        )
+
+    _sanitize_staged_runtime_skills(skills_dir)
 
 
 def _write_default_environment_dockerfile(
@@ -1775,24 +3582,25 @@ def _write_default_environment_dockerfile(
     include_repo: bool = False,
     include_repo_linked_root: bool = False,
     include_verifier_deps: bool = True,
+    agent_workdir: str | None = None,
 ) -> None:
     if base_image:
         dockerfile_lines = [
             f"FROM {base_image}",
             "",
-            "COPY skills/ /workspace/skills/",
-            "",
-            "COPY skills/ /root/.claude/skills/",
-            "COPY skills/ /root/.agents/skills/",
-            "COPY skills/ /root/.config/opencode/skills/",
+            *_runtime_copy_lines(
+                agent_config_lines,
+                include_input,
+                include_repo=include_repo,
+                include_repo_linked_root=include_repo_linked_root,
+                agent_workdir=agent_workdir,
+            ),
         ]
-        dockerfile_lines.extend(agent_config_lines)
-        if include_input:
-            dockerfile_lines.append("COPY input/ /workspace/input/")
-        if include_repo:
-            dockerfile_lines.append("COPY repo/ /workspace/repo/")
-        if include_repo_linked_root:
-            dockerfile_lines.append("COPY repo-linked-root/ /workspace/")
+        _extend_task_input_projection(
+            dockerfile_lines,
+            include_input=include_input,
+            agent_config_lines=agent_config_lines,
+        )
         (env_dir / "Dockerfile").write_text("\n".join(dockerfile_lines) + "\n", encoding="utf-8")
         return
 
@@ -1811,40 +3619,29 @@ def _write_default_environment_dockerfile(
         dockerfile_lines.append("    " + " ".join(apt_pkgs) + " \\")
     dockerfile_lines.append("    && rm -rf /var/lib/apt/lists/*")
     if include_verifier_deps:
-        dockerfile_lines.extend(
-            [
-                "",
-                "RUN pip install --no-cache-dir \\",
-                "    ragas~=0.4.0 \\",
-                "    openai>=1.0 \\",
-                "    anthropic>=0.40 \\",
-                "    boto3>=1.34",
-            ]
-        )
-    if pip_reqs:
-        escaped = " ".join(f'"{r}"' for r in pip_reqs)
-        dockerfile_lines.append(f"RUN pip install --no-cache-dir {escaped}")
+        dockerfile_lines.extend(["", *_verifier_install_lines(pip_reqs)])
+    elif pip_reqs:
+        dockerfile_lines.append(_managed_run("python", "-m", "pip", "install", "--no-cache-dir", *pip_reqs))
     dockerfile_lines.extend(
         [
             "",
             "RUN mkdir -p /workspace/skills /workspace/input /workspace/output \\",
             "    /logs/verifier /logs/agent",
             "",
-            "COPY skills/ /workspace/skills/",
-            "",
-            "# Multi-agent skill discovery paths",
-            "COPY skills/ /root/.claude/skills/",
-            "COPY skills/ /root/.agents/skills/",
-            "COPY skills/ /root/.config/opencode/skills/",
+            *_runtime_copy_lines(
+                agent_config_lines,
+                include_input,
+                include_repo=include_repo,
+                include_repo_linked_root=include_repo_linked_root,
+                agent_workdir=agent_workdir,
+            ),
         ]
     )
-    dockerfile_lines.extend(agent_config_lines)
-    if include_input:
-        dockerfile_lines.append("COPY input/ /workspace/input/")
-    if include_repo:
-        dockerfile_lines.append("COPY repo/ /workspace/repo/")
-    if include_repo_linked_root:
-        dockerfile_lines.append("COPY repo-linked-root/ /workspace/")
+    _extend_task_input_projection(
+        dockerfile_lines,
+        include_input=include_input,
+        agent_config_lines=agent_config_lines,
+    )
     dockerfile_lines.extend(["", "WORKDIR /workspace"])
     (env_dir / "Dockerfile").write_text("\n".join(dockerfile_lines) + "\n", encoding="utf-8")
 
@@ -1861,10 +3658,19 @@ def _prepare_native_environment(
     grading_mode: str,
     repo_context_mode: str = "linked",
     compose_env_names: set[str] | None = None,
+    repo_context_exclude_paths: Sequence[Path] = (),
+    agent_workdir: str | None = None,
 ) -> None:
     """Stage SkillEvaluator runtime additions into a copied native Harbor task."""
     env_dir = task_dir / "environment"
     env_dir.mkdir(parents=True, exist_ok=True)
+    if not has_skill:
+        _check_baseline_skill_candidates_do_not_alias_target(
+            skill_path,
+            reference_skills_dir,
+            workspace_skill_paths,
+            excluded_roots=repo_context_exclude_paths,
+        )
     _copy_skill_dirs(
         env_dir=env_dir,
         skill_path=skill_path if has_skill else None,
@@ -1872,6 +3678,7 @@ def _prepare_native_environment(
         workspace_skill_paths=workspace_skill_paths,
         has_skill=has_skill,
         exclude_skill_name=skill_path.name,
+        excluded_roots=repo_context_exclude_paths,
     )
     agent_config_lines = _write_agent_configs(env_dir)
     effective_repo_context_mode = "full" if repo_context_mode == "full" else ("linked" if has_skill else "none")
@@ -1880,19 +3687,30 @@ def _prepare_native_environment(
         source_skill_path=skill_path,
         mode=effective_repo_context_mode,
         exclude_source_skill=repo_context_mode == "full" and not has_skill,
+        excluded_roots=repo_context_exclude_paths,
     )
+    if not has_skill:
+        _check_staged_baseline_does_not_contain_target(env_dir, skill_path)
     include_input = (env_dir / "input").exists()
     include_repo = (env_dir / "repo").exists()
     include_repo_linked_root = (env_dir / "repo-linked-root").exists()
     dockerfile_path = env_dir / "Dockerfile"
-    compose_path = env_dir / "docker-compose.yaml"
-    if compose_path.exists():
+    compose_path = _custom_compose_path(env_dir)
+    if compose_path is not None:
         _validate_and_sanitize_custom_compose(compose_path, allowed_env=compose_env_names or set())
+        if compose_path.name == "docker-compose.yml":
+            compose_path = compose_path.replace(env_dir / "docker-compose.yaml")
+        _ensure_empty_compose_input_compatibility(env_dir, has_input=include_input)
 
     if dockerfile_path.exists():
         err = _validate_custom_dockerfile(dockerfile_path)
         if err:
             raise ValueError(f"{dockerfile_path}: {err}")
+        _ensure_empty_custom_docker_input_compatibility(
+            env_dir,
+            dockerfile_path,
+            has_input=include_input,
+        )
         if base_image and custom_dockerfile_mode == "rebase":
             rebased = _rebase_custom_dockerfile_content(
                 dockerfile_path.read_text(encoding="utf-8"),
@@ -1901,6 +3719,7 @@ def _prepare_native_environment(
                 include_input=include_input,
                 include_repo=include_repo,
                 include_repo_linked_root=include_repo_linked_root,
+                agent_workdir=agent_workdir,
             )
             if rebased is not None:
                 rebased_content, original_from = rebased
@@ -1912,17 +3731,25 @@ def _prepare_native_environment(
                 )
         elif grading_mode == "custom_only":
             content = dockerfile_path.read_text(encoding="utf-8")
-            updated = _append_missing_lines(
+            restore_user = _dockerfile_final_explicit_user(content)
+            updated = _append_evaluator_runtime_lines(
                 content,
                 _runtime_copy_lines(
                     agent_config_lines,
                     include_input,
                     include_repo=include_repo,
                     include_repo_linked_root=include_repo_linked_root,
+                    agent_workdir=agent_workdir,
                 ),
+                elevate=restore_user is not None,
             )
-            if updated != content:
-                dockerfile_path.write_text(updated, encoding="utf-8")
+            updated = _append_task_input_projection(
+                updated,
+                include_input=include_input,
+                agent_config_lines=agent_config_lines,
+                restore_user=restore_user,
+            )
+            dockerfile_path.write_text(updated, encoding="utf-8")
         else:
             _ensure_verifier_deps(
                 dockerfile_path,
@@ -1930,6 +3757,7 @@ def _prepare_native_environment(
                 include_input=include_input,
                 include_repo=include_repo,
                 include_repo_linked_root=include_repo_linked_root,
+                agent_workdir=agent_workdir,
             )
         return
 
@@ -1941,6 +3769,7 @@ def _prepare_native_environment(
         include_repo=include_repo,
         include_repo_linked_root=include_repo_linked_root,
         include_verifier_deps=grading_mode != "custom_only",
+        agent_workdir=agent_workdir,
     )
 
 
@@ -1965,6 +3794,60 @@ def _native_entry_id(task_dir: Path) -> str:
     if isinstance(metadata, dict) and metadata.get("entry_id"):
         return str(metadata["entry_id"])
     return task_dir.name
+
+
+def _native_task_workdir(task_dir: Path, *, allow_docker_image: bool = False) -> str | None:
+    """Read and validate the workdir Harbor will use for a native task."""
+    try:
+        import tomllib
+
+        data = tomllib.loads((task_dir / "task.toml").read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise ValueError(f"Cannot parse native Harbor task config: {task_dir / 'task.toml'}") from exc
+    environment = data.get("environment", {}) if isinstance(data, dict) else {}
+    if not isinstance(environment, dict):
+        raise ValueError(f"Native Harbor task [environment] must be a table: {task_dir / 'task.toml'}")
+    environment_env = environment.get("env", {})
+    if not isinstance(environment_env, dict):
+        raise ValueError(f"Native Harbor task [environment.env] must be a table: {task_dir / 'task.toml'}")
+    _validate_runtime_discovery_env(environment_env)
+    _validate_runtime_loader_env(environment_env)
+    skills_dir = environment.get("skills_dir")
+    if skills_dir not in (None, "/workspace/skills"):
+        raise ValueError(
+            "Native Harbor task skills_dir must use the evaluator-controlled /workspace/skills projection: "
+            f"{task_dir / 'task.toml'}"
+        )
+    docker_image = environment.get("docker_image")
+    if docker_image not in (None, "") and not allow_docker_image:
+        raise ValueError(
+            "Native Harbor task docker_image bypasses the evaluator-controlled runtime projection; "
+            "declare the image in environment/Dockerfile instead: "
+            f"{task_dir / 'task.toml'}"
+        )
+    workdir = environment.get("workdir")
+    if workdir is not None and not isinstance(workdir, str):
+        raise ValueError(f"Native Harbor task workdir must be a string: {task_dir / 'task.toml'}")
+    return _validated_agent_workdir(workdir)
+
+
+def _ensure_native_skills_dir(task_dir: Path) -> None:
+    """Pin native tasks to the evaluator-owned runtime skill projection."""
+    task_toml = task_dir / "task.toml"
+    content = task_toml.read_text(encoding="utf-8")
+    lines = content.splitlines()
+    if "[environment]" in lines:
+        environment_index = lines.index("[environment]")
+        section_end = next(
+            (index for index in range(environment_index + 1, len(lines)) if lines[index].strip().startswith("[")),
+            len(lines),
+        )
+        if any(line.strip().startswith("skills_dir") for line in lines[environment_index + 1 : section_end]):
+            return
+        lines.insert(environment_index + 1, 'skills_dir = "/workspace/skills"')
+    else:
+        lines.extend(["", "[environment]", 'skills_dir = "/workspace/skills"'])
+    task_toml.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
 def _ensure_skill_evaluator_verifier_env(task_dir: Path, *, verifier_env: dict[str, str] | None) -> None:
@@ -2019,8 +3902,7 @@ def _insert_table_block(lines: list[str], anchor: str, block: list[str]) -> None
 
 
 def _ensure_environment_env(task_dir: Path, runtime_env: dict[str, str]) -> None:
-    if not runtime_env:
-        return
+    runtime_env = {**runtime_env, **_EVALUATOR_MANAGED_RUNTIME_ENV}
 
     task_toml = task_dir / "task.toml"
     lines = task_toml.read_text(encoding="utf-8").splitlines()
@@ -2122,13 +4004,20 @@ def _dockerfile_copy_or_add_mentions_skill(line: str, target_skill_name: str) ->
     return False
 
 
-def _check_custom_environment_does_not_stage_target(custom_env_dir: Path, target_skill_name: str) -> None:
-    for skill_md in custom_env_dir.rglob("SKILL.md"):
-        if skill_md.parent.name == target_skill_name:
-            raise ValueError(
-                f"Custom eval environment already stages target skill '{target_skill_name}' at {skill_md}. "
-                "SkillEvaluator must control with-skill and baseline staging so Skill Lift stays uncontaminated."
-            )
+def _check_custom_environment_does_not_stage_target(custom_env_dir: Path, target_skill: Path) -> None:
+    target_skill_name = target_skill.name
+    manifests = _iter_skill_manifests(custom_env_dir)
+    if manifests:
+        raise ValueError(
+            f"Baseline custom eval environment contains an unmanaged skill package at {manifests[0]}. "
+            "Configure reference/workspace skills through SkillEvaluator instead so baseline staging stays uncontaminated."
+        )
+    payload = _find_target_manifest_payload(custom_env_dir, target_skill)
+    if payload is not None:
+        raise ValueError(
+            f"Baseline custom eval environment contains the target skill instructions in {payload}. "
+            "The evaluated skill must not be embedded under an alias."
+        )
     for dockerfile in custom_env_dir.rglob("Dockerfile"):
         try:
             lines = dockerfile.read_text(encoding="utf-8").splitlines()
@@ -2142,14 +4031,50 @@ def _check_custom_environment_does_not_stage_target(custom_env_dir: Path, target
                 )
 
 
-def _check_native_source_does_not_stage_target(native_dir: Path, target_skill_name: str) -> None:
-    for skill_md in native_dir.rglob("SKILL.md"):
-        if skill_md.parent.name == target_skill_name and "environment" in skill_md.parts:
+def _check_native_source_does_not_stage_target(
+    native_dir: Path,
+    target_skill: Path,
+    *,
+    with_skill: bool,
+) -> None:
+    ignored_parts = frozenset({"results", "__pycache__", ".git"})
+
+    def _is_ignored(path: Path) -> bool:
+        return bool(ignored_parts.intersection(path.relative_to(native_dir).parts))
+
+    target_skill_name = target_skill.name
+    for skill_md in _iter_skill_manifests(native_dir):
+        if _is_ignored(skill_md):
+            continue
+        if "environment" not in skill_md.relative_to(native_dir).parts:
+            continue
+        if not with_skill:
+            raise ValueError(
+                f"Baseline native environment contains an unmanaged skill package at {skill_md}. "
+                "Configure reference/workspace skills through SkillEvaluator instead."
+            )
+        if skill_md.parent.name == target_skill_name:
             raise ValueError(
                 f"BYOT source already stages target skill '{target_skill_name}' at {skill_md}. "
                 "SkillEvaluator must control with-skill and baseline staging."
             )
+    if not with_skill:
+        for environment_dir in native_dir.rglob("environment"):
+            if not environment_dir.is_dir() or _is_ignored(environment_dir):
+                continue
+            payload = _find_target_manifest_payload(
+                environment_dir,
+                target_skill,
+                ignored_parts=ignored_parts,
+            )
+            if payload is not None:
+                raise ValueError(
+                    f"Baseline native environment contains the target skill instructions in {payload}. "
+                    "The evaluated skill must not be embedded under an alias."
+                )
     for dockerfile in native_dir.rglob("Dockerfile"):
+        if _is_ignored(dockerfile):
+            continue
         try:
             lines = dockerfile.read_text(encoding="utf-8").splitlines()
         except OSError:
@@ -2174,6 +4099,7 @@ def _stage_native_harbor_tasks_into(
     base_image: str = "",
     custom_dockerfile_mode: str = "rebase",
     copy_repo: bool = False,
+    repo_context_exclude_paths: Sequence[Path] = (),
     runtime_env: dict[str, str] | None = None,
     verifier_env: dict[str, str] | None = None,
     pre_agent_setup: list[str] | None = None,
@@ -2185,20 +4111,38 @@ def _stage_native_harbor_tasks_into(
     The source tree is copied first and all SkillEvaluator injections happen only in the
     staged result directory.
     """
+    _validate_runtime_discovery_env(runtime_env)
+    _validate_runtime_loader_env(runtime_env)
     native_dir = skill_path / "evals" / "harbor"
     if not native_dir.exists():
         raise FileNotFoundError(f"No native Harbor task source found at {native_dir}")
-    _check_native_source_does_not_stage_target(native_dir, skill_path.name)
+    _validate_staging_output_location(
+        skill_path,
+        output_dir,
+        reference_skills_dir=reference_skills_dir,
+        workspace_skill_paths=workspace_skill_paths or (),
+    )
+    _validate_output_roots_outside_evaluator_sources(skill_path, repo_context_exclude_paths)
+    _check_native_source_does_not_stage_target(native_dir, skill_path, with_skill=with_skill)
+    entries_by_id = _load_entries_by_id(skill_path)
+    source_task_dirs = _native_task_dirs(native_dir)
+    if not source_task_dirs:
+        raise ValueError(f"No Harbor task directories with task.toml found in {native_dir}")
+    validate_case_ids(path.name for path in source_task_dirs)
+    for source_task_dir in source_task_dirs:
+        _native_task_workdir(source_task_dir)
     _ = task_resources
     _ = agent_workdir
-    entries_by_id = _load_entries_by_id(skill_path)
 
     if output_dir.exists():
         shutil.rmtree(output_dir)
-    copytree_secure(native_dir, output_dir, ignore=shutil.ignore_patterns("results", "__pycache__", ".git"))
+    copytree_secure(
+        native_dir,
+        output_dir,
+        ignore=shutil.ignore_patterns("results", "__pycache__", ".git", GENERATED_OUTPUT_MARKER),
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
     task_dirs = _native_task_dirs(output_dir)
-    if not task_dirs:
-        raise ValueError(f"No Harbor task directories with task.toml found in {native_dir}")
 
     if grading_mode in ("default", "default_plus_custom") and not entries_by_id:
         raise FileNotFoundError(
@@ -2208,6 +4152,8 @@ def _stage_native_harbor_tasks_into(
     workspace_skill_names = sorted({p.name for p in workspace_skill_paths or []})
     for task_dir in task_dirs:
         entry_id = _native_entry_id(task_dir)
+        native_agent_workdir = _native_task_workdir(task_dir)
+        _ensure_native_skills_dir(task_dir)
         entry = entries_by_id.get(entry_id)
         if grading_mode in ("default", "default_plus_custom") and entry is None:
             raise ValueError(f"Native Harbor task '{entry_id}' has no matching entry in evals/evals.json")
@@ -2260,6 +4206,14 @@ def _stage_native_harbor_tasks_into(
                 f"custom_only native Harbor task '{entry_id}' requires tests/grader.py or tests/test.sh"
             )
 
+        if entry is not None and _entry_declares_task_input(entry, skill_path / "evals" / "files"):
+            _stage_task_inputs(
+                task_dir / "environment",
+                input_files_dir=skill_path / "evals" / "files",
+                entry=entry,
+                source_skill_path=skill_path,
+                evals_dir=skill_path / "evals",
+            )
         _prepare_native_environment(
             task_dir,
             skill_path=skill_path,
@@ -2271,6 +4225,8 @@ def _stage_native_harbor_tasks_into(
             grading_mode=grading_mode,
             repo_context_mode="full" if copy_repo else "linked",
             compose_env_names=set(runtime_env or {}),
+            repo_context_exclude_paths=repo_context_exclude_paths,
+            agent_workdir=native_agent_workdir,
         )
 
     if not (output_dir / "dataset.toml").exists():
@@ -2291,6 +4247,7 @@ def stage_native_harbor_tasks(
     base_image: str = "",
     custom_dockerfile_mode: str = "rebase",
     copy_repo: bool = False,
+    repo_context_exclude_paths: Sequence[Path] = (),
     runtime_env: dict[str, str] | None = None,
     verifier_env: dict[str, str] | None = None,
     pre_agent_setup: list[str] | None = None,
@@ -2298,6 +4255,23 @@ def stage_native_harbor_tasks(
     agent_workdir: str | None = None,
 ) -> list[Path]:
     """Stage native tasks privately, then publish one exact output snapshot."""
+
+    validate_output_provenance_key_location(
+        skill_path,
+        output_dir,
+        reference_skills_dir=reference_skills_dir,
+        workspace_skill_paths=workspace_skill_paths or (),
+    )
+    _validate_staging_output_location(
+        skill_path,
+        output_dir,
+        reference_skills_dir=reference_skills_dir,
+        workspace_skill_paths=workspace_skill_paths or (),
+        declared_output_roots=repo_context_exclude_paths,
+    )
+    output_requires_provenance = _path_is_excluded(output_dir, (skill_path,))
+    if output_requires_provenance:
+        validate_generated_output_replacement(output_dir)
 
     with tempfile.TemporaryDirectory(prefix="skillevaluator-native-tasks-") as temporary:
         private_root = Path(temporary).resolve(strict=True)
@@ -2313,6 +4287,7 @@ def stage_native_harbor_tasks(
             base_image=base_image,
             custom_dockerfile_mode=custom_dockerfile_mode,
             copy_repo=copy_repo,
+            repo_context_exclude_paths=(*repo_context_exclude_paths, output_dir),
             runtime_env=runtime_env,
             verifier_env=verifier_env,
             pre_agent_setup=pre_agent_setup,
@@ -2320,6 +4295,9 @@ def stage_native_harbor_tasks(
             agent_workdir=agent_workdir,
         )
         relative_tasks = [task.relative_to(private_output) for task in private_tasks]
+        if output_requires_provenance:
+            write_generated_output_marker(private_output, destination=output_dir)
+            validate_generated_output_replacement(output_dir)
         copytree_secure(
             private_output,
             output_dir,
@@ -2364,6 +4342,7 @@ def _generate_harbor_tasks_into(
     base_image: str = "",
     custom_dockerfile_mode: str = "rebase",
     copy_repo: bool = False,
+    repo_context_exclude_paths: Sequence[Path] = (),
     runtime_env: dict[str, str] | None = None,
     verifier_env: dict[str, str] | None = None,
     pre_agent_setup: list[str] | None = None,
@@ -2401,8 +4380,18 @@ def _generate_harbor_tasks_into(
     Returns:
         List of generated task directory paths.
     """
+    _validate_runtime_discovery_env(runtime_env)
+    _validate_runtime_loader_env(runtime_env)
+    agent_workdir = _validated_agent_workdir(agent_workdir)
     evals_dir = skill_path / "evals"
     evals_file = find_evals_file(skill_path)
+    _validate_staging_output_location(
+        skill_path,
+        output_dir,
+        reference_skills_dir=reference_skills_dir,
+        workspace_skill_paths=workspace_skill_paths or (),
+    )
+    _validate_output_roots_outside_evaluator_sources(skill_path, repo_context_exclude_paths)
 
     if not evals_file:
         raise FileNotFoundError(f"No evals dataset found in {evals_dir}")
@@ -2475,6 +4464,8 @@ def _generate_harbor_tasks_into(
             repo_context_skill_path=skill_path,
             repo_context_mode="full" if copy_repo else "linked",
             compose_env_names=set(runtime_env or {}),
+            repo_context_exclude_paths=repo_context_exclude_paths,
+            agent_workdir=agent_workdir,
         )
 
         task_dirs.append(case_id)
@@ -2505,6 +4496,7 @@ def generate_harbor_tasks(
     base_image: str = "",
     custom_dockerfile_mode: str = "rebase",
     copy_repo: bool = False,
+    repo_context_exclude_paths: Sequence[Path] = (),
     runtime_env: dict[str, str] | None = None,
     verifier_env: dict[str, str] | None = None,
     pre_agent_setup: list[str] | None = None,
@@ -2512,6 +4504,23 @@ def generate_harbor_tasks(
     agent_workdir: str | None = None,
 ) -> list[Path]:
     """Generate tasks privately, then publish one exact output snapshot."""
+
+    validate_output_provenance_key_location(
+        skill_path,
+        output_dir,
+        reference_skills_dir=reference_skills_dir,
+        workspace_skill_paths=workspace_skill_paths or (),
+    )
+    _validate_staging_output_location(
+        skill_path,
+        output_dir,
+        reference_skills_dir=reference_skills_dir,
+        workspace_skill_paths=workspace_skill_paths or (),
+        declared_output_roots=repo_context_exclude_paths,
+    )
+    output_requires_provenance = _path_is_excluded(output_dir, (skill_path,))
+    if output_requires_provenance:
+        validate_generated_output_replacement(output_dir)
 
     with tempfile.TemporaryDirectory(prefix="skillevaluator-generated-tasks-") as temporary:
         private_root = Path(temporary).resolve(strict=True)
@@ -2527,6 +4536,7 @@ def generate_harbor_tasks(
             base_image=base_image,
             custom_dockerfile_mode=custom_dockerfile_mode,
             copy_repo=copy_repo,
+            repo_context_exclude_paths=(*repo_context_exclude_paths, output_dir),
             runtime_env=runtime_env,
             verifier_env=verifier_env,
             pre_agent_setup=pre_agent_setup,
@@ -2534,6 +4544,9 @@ def generate_harbor_tasks(
             agent_workdir=agent_workdir,
         )
         relative_tasks = [task.relative_to(private_output) for task in private_tasks]
+        if output_requires_provenance:
+            write_generated_output_marker(private_output, destination=output_dir)
+            validate_generated_output_replacement(output_dir)
         copytree_secure(
             private_output,
             output_dir,

--- a/src/skillevaluator/tier3/harbor/adapter.py
+++ b/src/skillevaluator/tier3/harbor/adapter.py
@@ -914,19 +914,41 @@ def _git_context_files(root: Path) -> list[Path]:
     return [root / line for line in result.stdout.splitlines() if line.strip()]
 
 
-def _iter_repo_context_files(root: Path, authenticated_output_roots: set[Path]) -> list[Path]:
+def _iter_repo_context_files(
+    root: Path,
+    authenticated_output_roots: set[Path],
+    excluded_roots: Sequence[Path] = (),
+) -> list[Path]:
+    """Enumerate repository files without inspecting excluded output trees."""
     git_files = _git_context_files(root)
     if git_files:
         return sorted(
             path
             for path in git_files
-            if path.is_file() and not _repo_context_ignore_file(path, root, authenticated_output_roots)
+            if not _path_is_excluded(path, excluded_roots)
+            and path.is_file()
+            and not _repo_context_ignore_file(path, root, authenticated_output_roots)
         )
-    return sorted(
-        path
-        for path in root.rglob("*")
-        if path.is_file() and not _repo_context_ignore_file(path, root, authenticated_output_roots)
-    )
+
+    files: list[Path] = []
+    pending = [root]
+    while pending:
+        directory = pending.pop()
+        with os.scandir(directory) as entries:
+            for entry in entries:
+                path = Path(entry.path)
+                # This lexical-first check must happen before stat/is_file or
+                # descent: result trees can contain unsafe or unreadable user
+                # artifacts and are explicitly outside the staged context.
+                if _path_is_excluded(path, excluded_roots):
+                    continue
+                if _repo_context_ignore_file(path, root, authenticated_output_roots):
+                    continue
+                if entry.is_dir(follow_symlinks=False):
+                    pending.append(path)
+                elif entry.is_file(follow_symlinks=False) or entry.is_symlink():
+                    files.append(path)
+    return sorted(files)
 
 
 def _stage_repo_context(
@@ -974,7 +996,11 @@ def _stage_repo_context(
     staged: list[dict[str, str]] = []
 
     if mode == "full":
-        for src in _iter_repo_context_files(repo_root, authenticated_output_roots):
+        for src in _iter_repo_context_files(
+            repo_root,
+            authenticated_output_roots,
+            resolved_excluded_roots,
+        ):
             if _is_excluded_output(src):
                 continue
             if _repo_context_ignore_file(src, repo_root, authenticated_output_roots):
@@ -1002,14 +1028,25 @@ def _stage_repo_context(
 
     for raw_target in _discover_skill_link_targets(skill_md):
         target = _strip_link_target(raw_target)
-        lexical_target_path = source_skill_path / target if not Path(target).is_absolute() else Path(target)
-        target_path = lexical_target_path.resolve()
-        if not target_path.is_file():
+        raw_target_path = source_skill_path / target if not Path(target).is_absolute() else Path(target)
+        lexical_target_path = Path(os.path.abspath(raw_target_path))  # noqa: PTH100 -- normalize without resolving
+        if _path_is_excluded(lexical_target_path, resolved_excluded_roots):
+            logger.warning("Skipping SKILL.md link into generated output: %s", raw_target)
+            continue
+        try:
+            target_path = lexical_target_path.resolve(strict=True)
+        except (OSError, RuntimeError):
+            logger.warning("Skipping unreadable SKILL.md repo link: %s", raw_target)
+            continue
+        try:
+            if not target_path.is_file():
+                continue
+        except OSError:
             continue
         if not _is_relative_to(target_path, repo_root):
             logger.warning("Skipping SKILL.md link outside repo root: %s", raw_target)
             continue
-        if _is_excluded_output(target_path) or _path_is_excluded(lexical_target_path, resolved_excluded_roots):
+        if _is_excluded_output(target_path):
             logger.warning("Skipping SKILL.md link into generated output: %s", raw_target)
             continue
         if _repo_context_ignore_file(
@@ -1731,7 +1768,7 @@ def _copy_custom_grader(task_dir: Path, skill_path: Path, grading_mode: str) -> 
         if not resolved_evals.is_relative_to(resolved_skill) or not resolved_grader.is_relative_to(resolved_evals):
             raise ValueError(f"custom grader must be a non-symlinked regular file contained under evals/: {grader}")
 
-        shutil.copy2(resolved_grader, destination, follow_symlinks=False)
+        copy_file_secure(grader, destination, allowed_root=skill_path / "evals")
         if destination.suffix == ".sh":
             destination.chmod(0o755)
         return True
@@ -2874,6 +2911,11 @@ _PROJECT_SKILL_RELATIVE_DIRS = (
     ".opencode/skills",
     ".qwen/skills",
 )
+_RUNTIME_PROJECTION_ROOTS = ("/workspace/input", "/workspace/repo", *_RUNTIME_SKILL_DIRS)
+_RUNTIME_PROJECTION_CASE_PATTERNS = (
+    *(pattern for root in _RUNTIME_PROJECTION_ROOTS for pattern in (root, f"{root}/*")),
+    *(pattern for relative in _PROJECT_SKILL_RELATIVE_DIRS for pattern in (f"*/{relative}", f"*/{relative}/*")),
+)
 _RUNTIME_DISCOVERY_ENV_NAMES = frozenset(
     {
         "CLAUDE_CODE_DISABLE_POLICY_SKILLS",
@@ -2965,16 +3007,7 @@ _DISCOVERY_ENV_SKILL_RESET = (
     'clear_skill_root "$XDG_CONFIG_HOME/opencode/skills"; fi'
 )
 _RUNTIME_PROJECTION_OVERLAP_PREFLIGHT = (
-    'set -eu; check_path() { value=$1; case "$value" in '
-    "/workspace/input|/workspace/input/*|/workspace/repo|/workspace/repo/*|"
-    "/workspace/skills|/workspace/skills/*|"
-    "*/.agents/skills|*/.agents/skills/*|*/.claude/commands|*/.claude/commands/*|"
-    "*/.claude/skills|*/.claude/skills/*|*/.cline/skills|*/.cline/skills/*|"
-    "*/.codex/skills|*/.codex/skills/*|*/.config/goose/skills|*/.config/goose/skills/*|"
-    "*/.config/opencode/skills|*/.config/opencode/skills/*|"
-    "*/.cursor/skills|*/.cursor/skills/*|*/.gemini/skills|*/.gemini/skills/*|"
-    "*/.gemini/extensions|*/.gemini/extensions/*|"
-    "*/.opencode/skills|*/.opencode/skills/*|*/.qwen/skills|*/.qwen/skills/*) "
+    'set -eu; check_path() { value=$1; case "$value" in ' + "|".join(_RUNTIME_PROJECTION_CASE_PATTERNS) + ") "
     "echo 'SkillEvaluator agent workdir/home overlaps an evaluator-controlled runtime projection' >&2; "
     'exit 78;; esac; }; check_control_path() { value=$1; check_path "$value"; '
     'if [ -d "$value" ]; then canonical=$(CDPATH= cd -P -- "$value" 2>/dev/null && /bin/pwd -P) || exit 78; '
@@ -3020,22 +3053,10 @@ def _validated_agent_workdir(agent_workdir: str | None) -> str | None:
         or re.fullmatch(r"/[A-Za-z0-9._/-]*", normalized) is None
     ):
         raise ValueError("agent_workdir must be a normalized absolute POSIX path")
-    reserved_roots = ("/workspace/input", "/workspace/repo", "/workspace/skills")
-    if any(normalized == root or normalized.startswith(f"{root}/") for root in reserved_roots):
+    if any(normalized == root or normalized.startswith(f"{root}/") for root in _RUNTIME_PROJECTION_ROOTS):
         raise ValueError("agent_workdir must not be inside an evaluator-controlled runtime projection")
     parts = tuple(part for part in normalized.split("/") if part)
-    discovery_parts = (
-        (".agents", "skills"),
-        (".claude", "skills"),
-        (".cline", "skills"),
-        (".codex", "skills"),
-        (".config", "goose", "skills"),
-        (".config", "opencode", "skills"),
-        (".cursor", "skills"),
-        (".gemini", "skills"),
-        (".opencode", "skills"),
-        (".qwen", "skills"),
-    )
+    discovery_parts = tuple(tuple(relative.split("/")) for relative in _PROJECT_SKILL_RELATIVE_DIRS)
     if any(
         parts[index : index + len(candidate)] == candidate
         for candidate in discovery_parts
@@ -4433,7 +4454,7 @@ def stage_native_harbor_tasks(
             base_image=base_image,
             custom_dockerfile_mode=custom_dockerfile_mode,
             copy_repo=copy_repo,
-            repo_context_exclude_paths=(*repo_context_exclude_paths, output_dir),
+            repo_context_exclude_paths=(*repo_context_exclude_paths, output_dir, private_root),
             runtime_env=runtime_env,
             verifier_env=verifier_env,
             pre_agent_setup=pre_agent_setup,
@@ -4682,7 +4703,7 @@ def generate_harbor_tasks(
             base_image=base_image,
             custom_dockerfile_mode=custom_dockerfile_mode,
             copy_repo=copy_repo,
-            repo_context_exclude_paths=(*repo_context_exclude_paths, output_dir),
+            repo_context_exclude_paths=(*repo_context_exclude_paths, output_dir, private_root),
             runtime_env=runtime_env,
             verifier_env=verifier_env,
             pre_agent_setup=pre_agent_setup,

--- a/src/skillevaluator/tier3/harbor/collector.py
+++ b/src/skillevaluator/tier3/harbor/collector.py
@@ -870,12 +870,46 @@ def _extract_rewards(job_dir: Path) -> list[dict[str, Any]]:
     """Extract reward.json from all trials in a job directory."""
     rewards: list[dict[str, Any]] = []
     scored_trial_roots: set[Path] = set()
+    authoritative_trial_roots: set[Path] = set()
+
+    # Native multi-step Harbor tasks can persist an authoritative aggregate at
+    # the trial root in addition to one reward file per step. Materialize that
+    # single logical row first so both averages and pass@k use the same score.
+    for result_file in sorted(job_dir.glob("*/result.json")):
+        trial_dir = result_file.parent
+        if _trial_failure_reason(trial_dir) or _is_agent_runtime_failure_trial(trial_dir):
+            continue
+        result = _read_json(result_file)
+        if not isinstance(result, dict) or not isinstance(result.get("step_results"), list):
+            continue
+        verifier_result = result.get("verifier_result")
+        if not isinstance(verifier_result, dict) or not isinstance(verifier_result.get("rewards"), dict):
+            continue
+        data = _reward_from_harbor_result(result)
+        if not data:
+            continue
+        trial_name = str(result.get("trial_name") or trial_dir.name)
+        data["_trial_name"] = trial_name
+        data["_trial_root_name"] = trial_dir.name
+        data["_started_at"] = result.get("started_at")
+        if not data.get("entry_id"):
+            entry_id = _entry_id_from_harbor_result(result)
+            if entry_id:
+                data["entry_id"] = entry_id
+        traj_file = _reward_trajectory_path(trial_dir, None)
+        if traj_file.exists():
+            data["_has_trajectory"] = True
+        rewards.append(data)
+        authoritative_trial_roots.add(trial_dir)
+
     for reward_file in sorted(job_dir.rglob("reward.json")):
         if reward_file.parent.name == "verifier":
             try:
+                trial_dir, trial_name, step_name = _reward_trial_context(reward_file)
+                if trial_dir in authoritative_trial_roots:
+                    continue
                 data = json.loads(reward_file.read_text(encoding="utf-8"))
                 _merge_reward_sidecars(data, reward_file.parent)
-                trial_dir, trial_name, step_name = _reward_trial_context(reward_file)
                 if _trial_failure_reason(trial_dir) or _is_agent_runtime_failure_trial(trial_dir):
                     logger.debug(
                         "Skipping reward for failed Harbor trial: %s",
@@ -908,7 +942,8 @@ def _extract_rewards(job_dir: Path) -> list[dict[str, Any]]:
     for result_file in sorted(job_dir.glob("*/result.json")):
         trial_dir = result_file.parent
         if (
-            trial_dir in scored_trial_roots
+            trial_dir in authoritative_trial_roots
+            or trial_dir in scored_trial_roots
             or _trial_failure_reason(trial_dir)
             or _is_agent_runtime_failure_trial(trial_dir)
         ):
@@ -1124,6 +1159,24 @@ def _logical_attempt_rewards(rewards: list[dict[str, Any]]) -> list[dict[str, An
             }
         )
     return logical
+
+
+def harbor_job_passed(job_dir: Path, pass_threshold: float) -> bool:
+    """Return whether a complete logical attempt meets the pass threshold.
+
+    This deliberately shares collection's failure filtering and multi-step
+    reward precedence. A root Harbor ``result.json`` reward is authoritative;
+    step rewards are averaged only when Harbor did not persist one.
+    """
+    job_ok, _ = validate_harbor_job_result(job_dir / "result.json")
+    trial_failures = _extract_trial_failures(job_dir)
+    if not job_ok and not _can_preserve_partial_rewards(job_dir, trial_failures):
+        return False
+    rewards, _ = _partition_scoreable_rewards(_extract_rewards(job_dir))
+    return any(
+        (score := _overall_score(reward)) is not None and score >= pass_threshold
+        for reward in _logical_attempt_rewards(rewards)
+    )
 
 
 def _pass_summary(

--- a/src/skillevaluator/tier3/harbor/local_environment.py
+++ b/src/skillevaluator/tier3/harbor/local_environment.py
@@ -33,6 +33,7 @@ from skillevaluator.tier3.harbor.local_runtime import (
 )
 from skillevaluator.tier3.harbor.secret_redaction import redact_secrets_in_log_line
 from skillevaluator.tier3.harbor.secure_copy import copytree_secure
+from skillevaluator.tier3.output_provenance import output_provenance_key_path
 
 _SAFE_HOST_ENV = frozenset(
     {
@@ -534,6 +535,7 @@ class SkillEvaluatorLocalEnvironment(BaseEnvironment):
             allow_net=self._allow_net,
             extra_ro=self._runtime_ro_binds(),
             strict_reads=self._strict_reads,
+            deny_reads=(output_provenance_key_path(),),
         )
         creation = asyncio.create_task(
             asyncio.create_subprocess_exec(

--- a/src/skillevaluator/tier3/harbor/local_sandbox.py
+++ b/src/skillevaluator/tier3/harbor/local_sandbox.py
@@ -189,6 +189,7 @@ class Sandbox:
         allow_net: bool,
         extra_ro: list[Path],
         strict_reads: bool = False,
+        deny_reads: Iterable[Path] = (),
     ) -> list[str]:
         if self.plan.backend == "bubblewrap":
             return _bwrap_argv(
@@ -200,6 +201,7 @@ class Sandbox:
                 allow_net=allow_net,
                 extra_ro=extra_ro,
                 strict_reads=strict_reads,
+                deny_reads=deny_reads,
             )
         if self.plan.backend == "seatbelt":
             return _seatbelt_argv(
@@ -210,6 +212,7 @@ class Sandbox:
                 extra_ro=extra_ro,
                 allow_net=allow_net,
                 strict_reads=strict_reads,
+                deny_reads=deny_reads,
             )
         return list(argv)
 
@@ -484,6 +487,7 @@ def _bwrap_argv(
     allow_net: bool,
     extra_ro: list[Path],
     strict_reads: bool = False,
+    deny_reads: Iterable[Path] = (),
 ) -> list[str]:
     """Build the bubblewrap launcher argv.
 
@@ -543,6 +547,7 @@ def _bwrap_argv(
         wrapper += ["--bind", str(root), str(root)]
 
     read_roots = _validated_strict_read_roots(extra_ro) if strict_reads else extra_ro
+    published_read_roots: list[Path] = []
     for ro_path in read_roots:
         raw = Path(ro_path).expanduser().absolute()
         try:
@@ -563,6 +568,7 @@ def _bwrap_argv(
         # --ro-bind would re-mount that subtree read-only inside the writable
         # tree, so a skill writing there would get EROFS.
         if resolved.exists() and not any(_is_within(resolved, root) for root in resolved_write_roots):
+            published_read_roots.extend((visible, resolved))
             ensure_bind_parents(visible)
             if visible.is_symlink():
                 # Intermediate aliases are not published, so point the final
@@ -570,6 +576,19 @@ def _bwrap_argv(
                 wrapper += ["--symlink", str(resolved), str(visible)]
             else:
                 wrapper += ["--ro-bind", str(resolved), str(visible)]
+
+    published_roots = (*system_mount_roots, *resolved_write_roots, *published_read_roots)
+    for denied_path in deny_reads:
+        try:
+            raw_denied = Path(denied_path).expanduser().absolute()
+            denied_variants = {raw_denied, raw_denied.resolve(strict=True)}
+        except (OSError, RuntimeError):
+            continue
+        for denied in denied_variants:
+            if not any(_is_within(denied, root) for root in published_roots):
+                continue
+            ensure_bind_parents(denied)
+            wrapper += ["--ro-bind", "/dev/null", str(denied)]
 
     wrapper += [
         "--setenv",
@@ -749,6 +768,7 @@ def _seatbelt_argv(
     extra_ro: list[Path],
     allow_net: bool,
     strict_reads: bool = False,
+    deny_reads: Iterable[Path] = (),
 ) -> list[str]:
     """Build the macOS Seatbelt launcher argv.
 
@@ -829,6 +849,14 @@ def _seatbelt_argv(
             f'(deny file-read* (literal "{_sbpl_quote(path)}"))' for path in _SEATBELT_ABSOLUTE_LITERAL_DENY
         )
         read_policy = f"{home_read_rule}{absolute_read_denies}\n"
+
+    explicit_read_denies = "\n".join(
+        f'(deny file-read* (literal "{_sbpl_quote(path)}"))'
+        for candidate in deny_reads
+        for path in {Path(candidate).expanduser().absolute(), Path(candidate).expanduser().resolve(strict=False)}
+    )
+    if explicit_read_denies:
+        read_policy = f"{read_policy}{explicit_read_denies}\n"
 
     if allow_net:
         # Keep the host IPC boundary while permitting model-serving traffic.

--- a/src/skillevaluator/tier3/harbor/report_data.py
+++ b/src/skillevaluator/tier3/harbor/report_data.py
@@ -338,7 +338,11 @@ def _condition_status(agent_info: dict[str, Any], condition: str) -> str:
     return str(data.get("execution_status") or "unknown") if isinstance(data, dict) else "unknown"
 
 
-def load_agent_data(results_dir: Path) -> dict[str, dict[str, Any]]:
+def load_agent_data(
+    results_dir: Path,
+    *,
+    allow_legacy_missing_status: bool = False,
+) -> dict[str, dict[str, Any]]:
     """Load per-agent summaries, rewards, lift, and execution coverage."""
     agents: dict[str, dict[str, Any]] = {}
     selection_diagnostics: list[dict[str, Any]] = []
@@ -391,6 +395,8 @@ def load_agent_data(results_dir: Path) -> dict[str, dict[str, Any]]:
                     if "pass_at_k" in data:
                         agent_info[pass_key] = data["pass_at_k"]
                     status = data.get("execution_status")
+                    if status is None and allow_legacy_missing_status:
+                        status = "succeeded"
                     if status not in {"succeeded", "failed", "skipped"}:
                         status = "unknown"
                     errors = data.get("execution_errors")

--- a/src/skillevaluator/tier3/harbor/runner.py
+++ b/src/skillevaluator/tier3/harbor/runner.py
@@ -17,7 +17,7 @@ import time
 import tomllib
 from collections.abc import Iterator, Mapping
 from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, as_completed, wait
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from functools import wraps
@@ -25,6 +25,7 @@ from pathlib import Path
 from queue import Empty, SimpleQueue
 from types import MappingProxyType
 from typing import Any
+from uuid import uuid4
 
 from skillevaluator.evaluation.tier3_report import render_agent_eval_html_report
 from skillevaluator.provider_config import ProviderConfig, ProviderConfigurationError, resolve_llm_provider
@@ -34,6 +35,8 @@ from skillevaluator.tier3.harbor.adapter import (
     find_evals_file,
     generate_harbor_tasks,
     stage_native_harbor_tasks,
+    validate_output_provenance_key_location,
+    validate_results_root_location,
 )
 from skillevaluator.tier3.harbor.artifact_retention import HarborArtifactLifecycle, RetentionOutcome
 from skillevaluator.tier3.harbor.collector import collect_harbor_results, validate_harbor_job_result
@@ -49,6 +52,7 @@ from skillevaluator.tier3.harbor.progress import (
 )
 from skillevaluator.tier3.harbor.secure_copy import copytree_secure
 from skillevaluator.tier3.harbor.secure_docker_environment import SECURE_DOCKER_ENV_IMPORT_PATH
+from skillevaluator.tier3.output_provenance import mark_generated_output_root
 from skillevaluator.tier3_environments import DEFAULT_ENV_MODE, ENV_MODE_LOCAL, HARBOR_ENV_MODES
 
 logger = logging.getLogger(__name__)
@@ -56,6 +60,27 @@ logger = logging.getLogger(__name__)
 _NVIDIA_BUILD_FILE_SENTINEL = "skillevaluator-file-backed-nvidia-key"
 _NVIDIA_BUILD_KEY_FILE_ENV = "SKILLEVALUATOR_NVIDIA_API_KEY_FILE"
 _NVIDIA_BUILD_BRIDGED_AGENT_DEFAULT_MODEL = "nvidia/nemotron-3-super-120b-a12b"
+
+
+def _reserve_run_dir(results_root: Path, timestamp: str) -> Path:
+    """Atomically reserve and authenticate a unique run directory."""
+    results_root.mkdir(parents=True, exist_ok=True)
+    for _ in range(100):
+        run_id = f"{timestamp}_{os.getpid()}_{uuid4().hex[:12]}"
+        run_dir = results_root / run_id
+        try:
+            run_dir.mkdir()
+        except FileExistsError:
+            continue
+        try:
+            mark_generated_output_root(run_dir)
+        except Exception:
+            with suppress(OSError):
+                run_dir.rmdir()
+            raise
+        return run_dir
+    raise RuntimeError("Could not reserve a unique Tier 3 run directory")
+
 
 _HARBOR_BASE_ENV_VARS = frozenset(
     {
@@ -145,10 +170,14 @@ _RUNTIME_ENV_HOST_CONTROL_NAMES = (
             "BASHOPTS",
             "BASH_ENV",
             "CDPATH",
+            "CLAUDE_CODE_DISABLE_POLICY_SKILLS",
+            "CLAUDE_CONFIG_DIR",
             "CLASSPATH",
             "COMSPEC",
+            "CODEX_HOME",
             "ENV",
             "GCONV_PATH",
+            "GEMINI_CLI_HOME",
             "HOME",
             "HOSTALIASES",
             "HTTPS_PROXY",
@@ -156,8 +185,12 @@ _RUNTIME_ENV_HOST_CONTROL_NAMES = (
             "IFS",
             "JAVA_TOOL_OPTIONS",
             "LOCPATH",
+            "LUA_CPATH",
+            "LUA_INIT",
+            "LUA_PATH",
             "NLSPATH",
             "NO_PROXY",
+            "OPENCODE_CONFIG_DIR",
             "PATHEXT",
             "PATH",
             "PERL5LIB",
@@ -165,6 +198,7 @@ _RUNTIME_ENV_HOST_CONTROL_NAMES = (
             "REQUESTS_CA_BUNDLE",
             "RES_OPTIONS",
             "RUBYOPT",
+            "RUBYLIB",
             "SHELLOPTS",
             "SSLKEYLOGFILE",
             "SSL_CERT_DIR",
@@ -176,7 +210,9 @@ _RUNTIME_ENV_HOST_CONTROL_NAMES = (
             "TMPDIR",
             "USERPROFILE",
             "WINDIR",
+            "XDG_CONFIG_HOME",
             "XDG_RUNTIME_DIR",
+            "ZDOTDIR",
             "_JAVA_OPTIONS",
         }
     )
@@ -184,6 +220,7 @@ _RUNTIME_ENV_HOST_CONTROL_NAMES = (
     | frozenset().union(*_HARBOR_ENV_MODE_VARS.values())
 )
 _RUNTIME_ENV_HOST_CONTROL_PREFIXES = (
+    "BASH_FUNC_",
     "COMPOSE_",
     "DOCKER_",
     "DYLD_",
@@ -1716,9 +1753,30 @@ def _run_harbor_eval_impl(
         reporter.emit(ProgressEvent(stage="with-skill-tasks", state="failed", detail="invalid task source"))
         return {"error": ["harbor.task_source must be auto, evals_json, or native_harbor"]}
 
-    root = output_dir or (skill_path / "evals" / "results")
-    run_id = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
-    run_dir = root / run_id
+    root = Path(output_dir) if output_dir is not None else skill_path / "evals" / "results"
+    try:
+        validate_output_provenance_key_location(
+            skill_path,
+            root,
+            reference_skills_dir=reference_skills_dir,
+            workspace_skill_paths=workspace_skills,
+        )
+        validate_results_root_location(
+            skill_path,
+            root,
+            reference_skills_dir=reference_skills_dir,
+            workspace_skill_paths=workspace_skills,
+        )
+    except ValueError as exc:
+        reporter.emit(ProgressEvent(stage="with-skill-tasks", state="failed", detail=str(exc)))
+        return {"error": [str(exc)]}
+    timestamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
+    try:
+        run_dir = _reserve_run_dir(root, timestamp)
+    except (OSError, RuntimeError, ValueError) as exc:
+        reporter.emit(ProgressEvent(stage="with-skill-tasks", state="failed", detail=str(exc)))
+        return {"error": [str(exc)]}
+    run_id = run_dir.name
     jobs_dir = run_dir / "_harbor-jobs"
     tasks_dir = run_dir / "_harbor-tasks"
     result_path = run_dir / "result.json"
@@ -1753,6 +1811,7 @@ def _run_harbor_eval_impl(
             skill_path.resolve(),
             reference_skills_dir,
             workspace_skill_paths=workspace_skills,
+            excluded_roots=(root,),
             force_rebuild=base_image_mode == "rebuild",
         )
         if base_image:
@@ -1792,6 +1851,7 @@ def _run_harbor_eval_impl(
                 base_image=base_image,
                 custom_dockerfile_mode=dockerfile_mode,
                 copy_repo=copy_repo,
+                repo_context_exclude_paths=(root,),
                 runtime_env=dict(runtime_plans[agent].staged_env),
                 verifier_env=staged_verifier_env,
                 pre_agent_setup=harbor_config.get("pre_agent_setup", []),
@@ -1821,6 +1881,7 @@ def _run_harbor_eval_impl(
                     base_image=base_image,
                     custom_dockerfile_mode=dockerfile_mode,
                     copy_repo=copy_repo,
+                    repo_context_exclude_paths=(root,),
                     runtime_env=dict(runtime_plans[agent].staged_env),
                     verifier_env=staged_verifier_env,
                     pre_agent_setup=harbor_config.get("pre_agent_setup", []),

--- a/src/skillevaluator/tier3/harbor/runner.py
+++ b/src/skillevaluator/tier3/harbor/runner.py
@@ -1688,7 +1688,7 @@ def _run_harbor_eval_impl(
         with ExitStack() as snapshot_stack:
             try:
                 evaluator_skill_path = snapshot_stack.enter_context(private_evaluator_skill_snapshot(skill_path))
-            except (FileNotFoundError, ValueError) as exc:
+            except (OSError, ValueError) as exc:
                 reporter.emit(ProgressEvent(stage="configuration", state="failed", detail=str(exc)))
                 return {"error": [str(exc)]}
             forwarded["_evaluator_skill_path"] = evaluator_skill_path
@@ -1930,6 +1930,7 @@ def _run_harbor_eval_impl(
             result_path=str(result_path),
         )
     )
+    staging_failure_stage = "with-skill-tasks"
     try:
         for agent in agents:
             with_dir = tasks_dir / agent / "with"
@@ -1962,6 +1963,7 @@ def _run_harbor_eval_impl(
         reporter.emit(ProgressEvent(stage="with-skill-tasks", state="ready", detail="task inputs staged"))
         if not skip_baseline:
             reporter.emit(ProgressEvent(stage="baseline-tasks", state="running"))
+            staging_failure_stage = "baseline-tasks"
         for agent in agents:
             without_dir = agent_task_dirs[agent][1]
             if without_dir is not None:
@@ -1988,8 +1990,8 @@ def _run_harbor_eval_impl(
             reporter.emit(ProgressEvent(stage="baseline-tasks", state="ready", detail="baseline inputs staged"))
         else:
             reporter.emit(ProgressEvent(stage="baseline-tasks", state="skipped", detail="baseline disabled"))
-    except (FileNotFoundError, ValueError) as exc:
-        reporter.emit(ProgressEvent(stage="with-skill-tasks", state="failed", detail=str(exc)))
+    except (OSError, ValueError) as exc:
+        reporter.emit(ProgressEvent(stage=staging_failure_stage, state="failed", detail=str(exc)))
         return {"error": [str(exc)], "run_dir": str(run_dir)}
 
     task_names = expected_task_names or []

--- a/src/skillevaluator/tier3/harbor/runner.py
+++ b/src/skillevaluator/tier3/harbor/runner.py
@@ -18,7 +18,7 @@ import time
 import tomllib
 from collections.abc import Iterator, Mapping
 from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, as_completed, wait
-from contextlib import ExitStack, contextmanager, suppress
+from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from functools import wraps
@@ -32,6 +32,7 @@ from skillevaluator.evaluation.tier3_report import render_agent_eval_html_report
 from skillevaluator.provider_config import ProviderConfig, ProviderConfigurationError, resolve_llm_provider
 from skillevaluator.tier3.evals_config import EvalsConfigError, load_evals_config
 from skillevaluator.tier3.harbor.adapter import (
+    _prevalidate_baseline_skill_candidates,
     build_eval_base_image,
     find_evals_file,
     generate_harbor_tasks,
@@ -58,7 +59,12 @@ from skillevaluator.tier3.harbor.progress import (
 )
 from skillevaluator.tier3.harbor.secure_copy import copytree_secure
 from skillevaluator.tier3.harbor.secure_docker_environment import SECURE_DOCKER_ENV_IMPORT_PATH
-from skillevaluator.tier3.output_provenance import mark_generated_output_root
+from skillevaluator.tier3.output_provenance import (
+    mark_generated_output_root,
+    remove_generated_output_root_if_owned,
+    remove_output_reservation_if_identity_matches,
+    write_output_file_atomically,
+)
 from skillevaluator.tier3.results_location import publish_latest_results
 from skillevaluator.tier3_environments import DEFAULT_ENV_MODE, ENV_MODE_LOCAL, HARBOR_ENV_MODES
 
@@ -79,11 +85,13 @@ def _reserve_run_dir(results_root: Path, timestamp: str) -> Path:
             run_dir.mkdir()
         except FileExistsError:
             continue
+        reservation_metadata = run_dir.lstat()
+        reservation_identity = reservation_metadata.st_dev, reservation_metadata.st_ino
         try:
             mark_generated_output_root(run_dir)
         except Exception:
-            with suppress(OSError):
-                run_dir.rmdir()
+            if not remove_generated_output_root_if_owned(run_dir, expected_identity=reservation_identity):
+                remove_output_reservation_if_identity_matches(run_dir, reservation_identity)
             raise
         return run_dir
     raise RuntimeError("Could not reserve a unique Tier 3 run directory")
@@ -1874,19 +1882,34 @@ def _run_harbor_eval_impl(
     tasks_dir = run_dir / "_harbor-tasks"
     result_path = run_dir / "result.json"
     report_path: Path | None = None
-    jobs_dir.mkdir(parents=True, exist_ok=True)
 
-    def _emit_run_finished(state: str, detail: str) -> None:
+    def _emit_run_finished(state: str, detail: str, *, include_artifacts: bool = True) -> None:
         reporter.emit(
             ProgressEvent(
                 stage="run-finished",
                 state=state,
                 detail=detail,
-                output_dir=str(run_dir),
-                result_path=str(result_path) if result_path.is_file() else None,
-                report_path=str(report_path) if report_path is not None and report_path.is_file() else None,
+                output_dir=str(run_dir) if include_artifacts else None,
+                result_path=str(result_path) if include_artifacts and result_path.is_file() else None,
+                report_path=(
+                    str(report_path)
+                    if include_artifacts and report_path is not None and report_path.is_file()
+                    else None
+                ),
             )
         )
+
+    reservation_identity: tuple[int, int] | None = None
+    try:
+        reservation_metadata = run_dir.lstat()
+        reservation_identity = reservation_metadata.st_dev, reservation_metadata.st_ino
+        jobs_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        reporter.emit(ProgressEvent(stage="with-skill-tasks", state="failed", detail=str(exc)))
+        if reservation_identity is not None:
+            remove_generated_output_root_if_owned(run_dir, expected_identity=reservation_identity)
+        _emit_run_finished("failed", "Harbor jobs directory could not be created", include_artifacts=False)
+        return {"error": [str(exc)]}
 
     emitter = stage_native_harbor_tasks if task_source == "native_harbor" else generate_harbor_tasks
     resource_config = harbor_config.get("resources", {})
@@ -1964,6 +1987,14 @@ def _run_harbor_eval_impl(
         if not skip_baseline:
             reporter.emit(ProgressEvent(stage="baseline-tasks", state="running"))
             staging_failure_stage = "baseline-tasks"
+            baseline_alias_validation = _prevalidate_baseline_skill_candidates(
+                skill_path,
+                reference_skills_dir,
+                workspace_skills,
+                excluded_roots=(root,),
+            )
+        else:
+            baseline_alias_validation = None
         for agent in agents:
             without_dir = agent_task_dirs[agent][1]
             if without_dir is not None:
@@ -1985,6 +2016,7 @@ def _run_harbor_eval_impl(
                     task_resources=resource_config,
                     agent_workdir=harbor_config.get("agent_workdir"),
                     evaluator_skill_path=evaluator_skill_path,
+                    _baseline_alias_validation=baseline_alias_validation,
                 )
         if not skip_baseline:
             reporter.emit(ProgressEvent(stage="baseline-tasks", state="ready", detail="baseline inputs staged"))
@@ -2073,7 +2105,7 @@ def _run_harbor_eval_impl(
                 "result_path": str(result_path),
                 "agents": {},
             }
-            result_path.write_text(json.dumps(failed_result, indent=2), encoding="utf-8")
+            write_output_file_atomically(result_path, json.dumps(failed_result, indent=2).encode("utf-8"))
             _emit_run_finished("failed", "agent runtime preflight failed")
             return failed_result
         reporter.emit(
@@ -2266,7 +2298,7 @@ def _run_harbor_eval_impl(
     results["duration_seconds"] = round(time.monotonic() - started_at, 3)
 
     try:
-        result_path.write_text(json.dumps(results, indent=2), encoding="utf-8")
+        write_output_file_atomically(result_path, json.dumps(results, indent=2).encode("utf-8"))
     except Exception:
         reporter.emit(ProgressEvent(stage="report", state="failed", detail="result write failed"))
         _emit_run_finished("failed", "report artifacts could not be written")
@@ -2326,7 +2358,7 @@ def _finalize_harbor_artifacts(
     result_path_value = result.get("result_path")
     result_path = Path(str(result_path_value)) if result_path_value else run_dir / "result.json"
     if result_path.is_file():
-        result_path.write_text(json.dumps(result, indent=2), encoding="utf-8")
+        write_output_file_atomically(result_path, json.dumps(result, indent=2).encode("utf-8"))
     run_config = result.get("run_config")
     run_config_path = run_dir / "run_config.json"
     if isinstance(run_config, dict) and run_config_path.is_file():

--- a/src/skillevaluator/tier3/harbor/runner.py
+++ b/src/skillevaluator/tier3/harbor/runner.py
@@ -11,6 +11,7 @@ import os
 import re
 import shlex
 import shutil
+import stat
 import subprocess
 import tempfile
 import time
@@ -39,8 +40,12 @@ from skillevaluator.tier3.harbor.adapter import (
     validate_results_root_location,
 )
 from skillevaluator.tier3.harbor.artifact_retention import HarborArtifactLifecycle, RetentionOutcome
-from skillevaluator.tier3.harbor.collector import collect_harbor_results, validate_harbor_job_result
-from skillevaluator.tier3.harbor.metrics import DEFAULT_METRICS, overall_score, score_definition
+from skillevaluator.tier3.harbor.collector import (
+    collect_harbor_results,
+    harbor_job_passed,
+    validate_harbor_job_result,
+)
+from skillevaluator.tier3.harbor.metrics import DEFAULT_METRICS, score_definition
 from skillevaluator.tier3.harbor.progress import (
     NullProgressReporter,
     ProgressEvent,
@@ -53,6 +58,7 @@ from skillevaluator.tier3.harbor.progress import (
 from skillevaluator.tier3.harbor.secure_copy import copytree_secure
 from skillevaluator.tier3.harbor.secure_docker_environment import SECURE_DOCKER_ENV_IMPORT_PATH
 from skillevaluator.tier3.output_provenance import mark_generated_output_root
+from skillevaluator.tier3.results_location import publish_latest_results
 from skillevaluator.tier3_environments import DEFAULT_ENV_MODE, ENV_MODE_LOCAL, HARBOR_ENV_MODES
 
 logger = logging.getLogger(__name__)
@@ -1162,20 +1168,8 @@ def _validate_harbor_job_result(
 
 
 def _job_passed(job_dir: Path, pass_threshold: float) -> bool:
-    """Return True when any reward in a one-task Harbor job reaches threshold."""
-    for reward_file in sorted(job_dir.rglob("reward.json")):
-        if reward_file.parent.name != "verifier":
-            continue
-        try:
-            reward = json.loads(reward_file.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError):
-            continue
-        if not isinstance(reward, dict):
-            continue
-        score = overall_score(reward)
-        if score is not None and score >= pass_threshold:
-            return True
-    return False
+    """Use collector-authoritative logical-attempt semantics for early stop."""
+    return harbor_job_passed(job_dir, pass_threshold)
 
 
 def _attempt_job_stats(
@@ -1228,6 +1222,31 @@ def _attempt_job_stats(
     return total, completed, errored, evals_out
 
 
+def _job_path_is_link_or_reparse(path: Path, metadata: os.stat_result) -> bool:
+    """Return whether an attempt-job root is a symlink, junction, or reparse point."""
+    reparse_flag = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+    if stat.S_ISLNK(metadata.st_mode) or bool(getattr(metadata, "st_file_attributes", 0) & reparse_flag):
+        return True
+    is_junction = getattr(path, "is_junction", None)
+    if not callable(is_junction):
+        return False
+    try:
+        return bool(is_junction())
+    except (OSError, RuntimeError):
+        return True
+
+
+def _job_root_fingerprint(metadata: os.stat_result) -> tuple[int, int, int, int, int, int]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_mode,
+        metadata.st_nlink,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+    )
+
+
 def _merge_attempt_jobs(job_dirs: list[Path], aggregate_dir: Path) -> None:
     """Merge per-attempt Harbor jobs into the job directory shape collection expects.
 
@@ -1235,61 +1254,115 @@ def _merge_attempt_jobs(job_dirs: list[Path], aggregate_dir: Path) -> None:
     per-attempt Harbor ``result.json`` statistics are combined so the merged
     job still satisfies :func:`validate_harbor_job_result`.
     """
-    if aggregate_dir.exists():
-        shutil.rmtree(aggregate_dir)
-    aggregate_dir.mkdir(parents=True, exist_ok=True)
-
-    total_trials = 0
-    completed_trials = 0
-    errored_trials = 0
-    merged_evals: dict[str, dict[str, Any]] = {}
+    aggregate_path = Path(os.path.abspath(aggregate_dir))  # noqa: PTH100 -- compare lexical publication roots
+    source_paths: list[tuple[str, Path, Path, tuple[int, int, int, int, int, int]]] = []
     for job_dir in job_dirs:
-        if not job_dir.is_dir():
+        job_path = Path(os.path.abspath(job_dir))  # noqa: PTH100 -- reject overlap before temp creation
+        if not os.path.lexists(job_path):
             continue
-        renamed: dict[str, str] = {}
-        for child in sorted(job_dir.iterdir()):
-            if not child.is_dir():
+        try:
+            metadata = job_path.lstat()
+        except OSError as exc:
+            raise ValueError(f"cannot inspect attempt Harbor job root: {job_path}") from exc
+        if _job_path_is_link_or_reparse(job_path, metadata) or not stat.S_ISDIR(metadata.st_mode):
+            raise ValueError(f"attempt Harbor job root must be a non-linked directory: {job_path}")
+        try:
+            job_resolved = job_path.resolve(strict=True)
+        except (OSError, RuntimeError) as exc:
+            raise ValueError(f"cannot resolve attempt Harbor job root: {job_path}") from exc
+        aggregate_resolved = aggregate_path.resolve(strict=False)
+        if (
+            aggregate_resolved == job_resolved
+            or aggregate_resolved.is_relative_to(job_resolved)
+            or job_resolved.is_relative_to(aggregate_resolved)
+        ):
+            raise ValueError("aggregate Harbor job directory must not overlap an attempt job directory")
+        source_paths.append((job_path.name, job_path, job_resolved, _job_root_fingerprint(metadata)))
+
+    aggregate_path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(
+        prefix=f".{aggregate_path.name}-merge-",
+        dir=aggregate_path.parent,
+    ) as private_root_raw:
+        private_root = Path(private_root_raw)
+        snapshot_root = private_root / "attempt-jobs"
+        snapshot_root.mkdir()
+        staged_aggregate = private_root / "aggregate"
+        staged_aggregate.mkdir()
+
+        snapshots: list[tuple[str, Path]] = []
+        for index, (job_name, job_path, job_resolved, expected_fingerprint) in enumerate(source_paths):
+            snapshot = snapshot_root / f"{index:04d}-{job_name}"
+            try:
+                before = job_path.lstat()
+            except OSError as exc:
+                raise ValueError(f"attempt Harbor job root changed before snapshot: {job_path}") from exc
+            if _job_path_is_link_or_reparse(job_path, before) or _job_root_fingerprint(before) != expected_fingerprint:
+                raise ValueError(f"attempt Harbor job root changed before snapshot: {job_path}")
+            copytree_secure(job_path, snapshot, allowed_root=job_resolved)
+            try:
+                after = job_path.lstat()
+            except OSError as exc:
+                raise ValueError(f"attempt Harbor job root changed during snapshot: {job_path}") from exc
+            if _job_path_is_link_or_reparse(job_path, after) or _job_root_fingerprint(after) != expected_fingerprint:
+                raise ValueError(f"attempt Harbor job root changed during snapshot: {job_path}")
+            snapshots.append((job_name, snapshot))
+
+        total_trials = 0
+        completed_trials = 0
+        errored_trials = 0
+        merged_evals: dict[str, dict[str, Any]] = {}
+        for job_name, job_dir in snapshots:
+            renamed: dict[str, str] = {}
+            for child in sorted(job_dir.iterdir()):
+                if not child.is_dir():
+                    continue
+                dest = staged_aggregate / f"{job_name}__{child.name}"
+                suffix = 2
+                while dest.exists():
+                    dest = staged_aggregate / f"{job_name}__{child.name}-{suffix}"
+                    suffix += 1
+                copytree_secure(child, dest, allowed_root=job_dir)
+                renamed[child.name] = dest.name
+
+            stats = _attempt_job_stats(job_dir)
+            if stats is None:
                 continue
-            dest = aggregate_dir / f"{job_dir.name}__{child.name}"
-            suffix = 2
-            while dest.exists():
-                dest = aggregate_dir / f"{job_dir.name}__{child.name}-{suffix}"
-                suffix += 1
-            copytree_secure(child, dest, allowed_root=job_dir)
-            renamed[child.name] = dest.name
+            job_total, job_completed, job_errored, job_evals = stats
+            total_trials += job_total
+            completed_trials += job_completed
+            errored_trials += job_errored
+            for eval_name, (eval_trials, eval_errors, reward_stats) in job_evals.items():
+                merged = merged_evals.setdefault(eval_name, {"n_trials": 0, "n_errors": 0, "reward_stats": {}})
+                merged["n_trials"] += eval_trials
+                merged["n_errors"] += eval_errors
+                for metric, buckets in reward_stats.items():
+                    merged_buckets = merged["reward_stats"].setdefault(metric, {})
+                    for bucket, trial_names in buckets.items():
+                        merged_buckets.setdefault(bucket, []).extend(
+                            renamed.get(name, f"{job_name}__{name}") for name in trial_names
+                        )
 
-        stats = _attempt_job_stats(job_dir)
-        if stats is None:
-            continue
-        job_total, job_completed, job_errored, job_evals = stats
-        total_trials += job_total
-        completed_trials += job_completed
-        errored_trials += job_errored
-        for eval_name, (eval_trials, eval_errors, reward_stats) in job_evals.items():
-            merged = merged_evals.setdefault(eval_name, {"n_trials": 0, "n_errors": 0, "reward_stats": {}})
-            merged["n_trials"] += eval_trials
-            merged["n_errors"] += eval_errors
-            for metric, buckets in reward_stats.items():
-                merged_buckets = merged["reward_stats"].setdefault(metric, {})
-                for bucket, trial_names in buckets.items():
-                    merged_buckets.setdefault(bucket, []).extend(
-                        renamed.get(name, f"{job_dir.name}__{name}") for name in trial_names
-                    )
-
-    (aggregate_dir / "result.json").write_text(
-        json.dumps(
-            {
-                "n_total_trials": total_trials,
-                "stats": {
-                    "n_trials": completed_trials,
-                    "n_errors": errored_trials,
-                    "evals": merged_evals,
+        (staged_aggregate / "result.json").write_text(
+            json.dumps(
+                {
+                    "n_total_trials": total_trials,
+                    "stats": {
+                        "n_trials": completed_trials,
+                        "n_errors": errored_trials,
+                        "evals": merged_evals,
+                    },
                 },
-            },
-            indent=2,
-        ),
-        encoding="utf-8",
-    )
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+        copytree_secure(
+            staged_aggregate,
+            aggregate_path,
+            replace_existing=aggregate_path.exists(),
+            allowed_root=private_root,
+        )
 
 
 def _run_stop_on_pass_variant(
@@ -2178,13 +2251,7 @@ def _run_harbor_eval_impl(
     else:
         reporter.emit(ProgressEvent(stage="report", state="complete", detail="result and HTML reports written"))
 
-    latest = root / "latest"
-    try:
-        if latest.is_symlink() or latest.exists():
-            latest.unlink()
-        latest.symlink_to(run_id)
-    except OSError:
-        pass
+    publish_latest_results(root, run_id)
     return results
 
 

--- a/src/skillevaluator/tier3/harbor/runner.py
+++ b/src/skillevaluator/tier3/harbor/runner.py
@@ -18,7 +18,7 @@ import time
 import tomllib
 from collections.abc import Iterator, Mapping
 from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, as_completed, wait
-from contextlib import contextmanager, suppress
+from contextlib import ExitStack, contextmanager, suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from functools import wraps
@@ -35,6 +35,7 @@ from skillevaluator.tier3.harbor.adapter import (
     build_eval_base_image,
     find_evals_file,
     generate_harbor_tasks,
+    private_evaluator_skill_snapshot,
     stage_native_harbor_tasks,
     validate_output_provenance_key_location,
     validate_results_root_location,
@@ -1658,9 +1659,12 @@ def _run_harbor_eval_impl(
     override_memory_mb: int | None = None,
     override_storage_mb: int | None = None,
     progress_reporter: ProgressReporter | None = None,
+    _evaluator_skill_path: Path | None = None,
+    _monotonic_start: float | None = None,
 ) -> dict[str, Any]:
     """Run a public Harbor evaluation with and without the target skill."""
-    started_at = time.monotonic()
+    forwarded = dict(locals()) if _evaluator_skill_path is None else None
+    started_at = _monotonic_start if _monotonic_start is not None else time.monotonic()
     reporter = safe_progress_reporter(progress_reporter or NullProgressReporter())
     if env_mode not in HARBOR_ENV_MODES:
         reporter.emit(ProgressEvent(stage="configuration", state="failed", detail="unsupported environment"))
@@ -1677,9 +1681,25 @@ def _run_harbor_eval_impl(
             reporter.emit(ProgressEvent(stage="configuration", state="failed", detail=str(exc)))
             return {"error": [str(exc)]}
 
+    if _evaluator_skill_path is None:
+        assert forwarded is not None
+        forwarded.pop("skill_path")
+        forwarded.pop("agents")
+        with ExitStack() as snapshot_stack:
+            try:
+                evaluator_skill_path = snapshot_stack.enter_context(private_evaluator_skill_snapshot(skill_path))
+            except (FileNotFoundError, ValueError) as exc:
+                reporter.emit(ProgressEvent(stage="configuration", state="failed", detail=str(exc)))
+                return {"error": [str(exc)]}
+            forwarded["_evaluator_skill_path"] = evaluator_skill_path
+            forwarded["_monotonic_start"] = started_at
+            return _run_harbor_eval_impl(skill_path, agents, **forwarded)
+
+    evaluator_skill_path = _evaluator_skill_path
+
     try:
         provider = resolve_llm_provider()
-        config, config_path = load_evals_config(skill_path)
+        config, config_path = load_evals_config(evaluator_skill_path)
     except (ProviderConfigurationError, EvalsConfigError) as exc:
         reporter.emit(ProgressEvent(stage="configuration", state="failed", detail=str(exc)))
         return {"error": [str(exc)]}
@@ -1812,8 +1832,8 @@ def _run_harbor_eval_impl(
         reporter.emit(ProgressEvent(stage="with-skill-tasks", state="failed", detail=str(exc)))
         return {"error": [str(exc)]}
 
-    evals_exists = find_evals_file(skill_path) is not None
-    native_exists = (skill_path / "evals" / "harbor").exists()
+    evals_exists = find_evals_file(evaluator_skill_path) is not None
+    native_exists = (evaluator_skill_path / "evals" / "harbor").exists()
     if task_source == "auto":
         task_source = "evals_json" if evals_exists else "native_harbor" if native_exists else ""
     if task_source == "evals_json" and not evals_exists:
@@ -1884,6 +1904,7 @@ def _run_harbor_eval_impl(
             skill_path.resolve(),
             reference_skills_dir,
             workspace_skill_paths=workspace_skills,
+            evaluator_skill_path=evaluator_skill_path,
             excluded_roots=(root,),
             force_rebuild=base_image_mode == "rebuild",
         )
@@ -1930,6 +1951,7 @@ def _run_harbor_eval_impl(
                 pre_agent_setup=harbor_config.get("pre_agent_setup", []),
                 task_resources=resource_config,
                 agent_workdir=harbor_config.get("agent_workdir"),
+                evaluator_skill_path=evaluator_skill_path,
             )
             task_names = [task.name for task in task_paths]
             if expected_task_names is None:
@@ -1960,6 +1982,7 @@ def _run_harbor_eval_impl(
                     pre_agent_setup=harbor_config.get("pre_agent_setup", []),
                     task_resources=resource_config,
                     agent_workdir=harbor_config.get("agent_workdir"),
+                    evaluator_skill_path=evaluator_skill_path,
                 )
         if not skip_baseline:
             reporter.emit(ProgressEvent(stage="baseline-tasks", state="ready", detail="baseline inputs staged"))
@@ -2166,7 +2189,7 @@ def _run_harbor_eval_impl(
         raise
     reporter.emit(ProgressEvent(stage="collection", state="complete", detail="Harbor results collected"))
     run_config = {
-        "config_file": str(config_path.relative_to(skill_path)) if config_path else "none",
+        "config_file": str(config_path.relative_to(evaluator_skill_path)) if config_path else "none",
         "harbor": {
             "environment": {"value": env_mode, "source": env_mode_source},
             "n_attempts": n_attempts,

--- a/src/skillevaluator/tier3/harbor/secure_copy.py
+++ b/src/skillevaluator/tier3/harbor/secure_copy.py
@@ -39,6 +39,7 @@ _REPARSE_POINT = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
 _DIRECTORY_FLAGS = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
 _FILE_FLAGS = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0) | getattr(os, "O_NOCTTY", 0)
 _WINDOWS_CHMOD_SEMANTICS = os.name == "nt"
+_PATH_DESCRIPTOR_IDENTITIES_COMPARABLE = os.name == "posix"
 _DESCRIPTOR_BACKEND = (
     os.name == "posix"
     and hasattr(os, "O_NOFOLLOW")
@@ -209,6 +210,25 @@ def _node_identity(metadata: os.stat_result) -> tuple[int, int, int, int, int]:
         metadata.st_nlink,
         metadata.st_size,
     )
+
+
+def _fallback_opened_matches_named(opened: os.stat_result, named: os.stat_result) -> bool:
+    """Compare fallback file metadata without assuming Windows stat identities."""
+    if _PATH_DESCRIPTOR_IDENTITIES_COMPARABLE:
+        return _fingerprint(opened) == _fingerprint(named)
+    return (
+        stat.S_IFMT(opened.st_mode) == stat.S_IFMT(named.st_mode)
+        and opened.st_nlink == named.st_nlink
+        and opened.st_size == named.st_size
+    )
+
+
+def _portable_fingerprint_mode(mode: int) -> int:
+    """Normalize mode bits to the semantics the active copier preserves."""
+    normalized = stat.S_IMODE(mode) & 0o777
+    if _WINDOWS_CHMOD_SEMANTICS:
+        return int(bool(normalized & stat.S_IWRITE))
+    return normalized
 
 
 def _entry_from_stat(
@@ -501,8 +521,13 @@ def _open_fallback_regular(
         raise UnsafeStagingError(f"cannot safely open {role} file {path}: {exc}") from exc
     try:
         opened = os.fstat(descriptor)
-        _validate_type(opened, path=path, role=role, root_device=root_device)
-        if _fingerprint(opened) != _fingerprint(before):
+        _validate_type(
+            opened,
+            path=path,
+            role=role,
+            root_device=root_device if _PATH_DESCRIPTOR_IDENTITIES_COMPARABLE else None,
+        )
+        if not _fallback_opened_matches_named(opened, before):
             raise _changed(path, "file was replaced")
         return descriptor
     except BaseException:
@@ -513,6 +538,7 @@ def _open_fallback_regular(
 def _hash_path_checked(path: Path, before: os.stat_result, *, role: str, root_device: int) -> str:
     descriptor = _open_fallback_regular(path, before, role=role, root_device=root_device)
     try:
+        opened = os.fstat(descriptor)
         digest = _hash_descriptor(descriptor)
         after = os.fstat(descriptor)
     finally:
@@ -521,7 +547,11 @@ def _hash_path_checked(path: Path, before: os.stat_result, *, role: str, root_de
         named = path.lstat()
     except OSError as exc:
         raise _changed(path, "file disappeared after reading") from exc
-    if _fingerprint(after) != _fingerprint(before) or _fingerprint(named) != _fingerprint(before):
+    if (
+        _fingerprint(after) != _fingerprint(opened)
+        or _fingerprint(named) != _fingerprint(before)
+        or not _fallback_opened_matches_named(after, named)
+    ):
         raise _changed(path, "file changed while it was validated")
     return digest
 
@@ -606,6 +636,32 @@ def _build_tree_manifest(
     if _DESCRIPTOR_BACKEND:
         return _build_tree_manifest_posix(source_path, root_path, role=role, ignore=ignore)
     return _build_tree_manifest_fallback(source_path, root_path, role=role, ignore=ignore)
+
+
+def tree_content_fingerprint_secure(
+    source: Path | str,
+    *,
+    allowed_root: Path | str | None = None,
+    ignore: IgnoreCallback | None = None,
+) -> str:
+    """Return a deterministic content fingerprint for one securely validated tree.
+
+    Filesystem identity and timestamps intentionally do not participate: a
+    securely copied tree has different inodes and may have different directory
+    metadata.  Relative paths, node kinds, and regular-file bytes do, so the
+    result can bind source selection to the exact tree later staged elsewhere.
+    """
+    manifest = _build_tree_manifest(source, allowed_root=allowed_root, ignore=ignore)
+    digest = hashlib.sha256()
+    for entry in sorted((manifest.root, *manifest.entries), key=lambda item: item.parts):
+        path = os.fsencode("/".join(entry.parts))
+        kind = entry.kind.encode("ascii")
+        mode = _portable_fingerprint_mode(entry.mode).to_bytes(2, "big")
+        content = (entry.digest or "").encode("ascii")
+        for field in (path, kind, mode, content):
+            digest.update(len(field).to_bytes(8, "big"))
+            digest.update(field)
+    return digest.hexdigest()
 
 
 def _verify_entry(entry: _ManifestEntry, metadata: os.stat_result, path: Path) -> None:
@@ -1568,7 +1624,7 @@ def _apply_fallback_open_file_mode(path: Path, descriptor: int, mode: int) -> No
         or not stat.S_ISREG(named_before.st_mode)
         or opened_before.st_nlink != 1
         or named_before.st_nlink != 1
-        or _node_identity(named_before) != _node_identity(opened_before)
+        or not _fallback_opened_matches_named(opened_before, named_before)
     ):
         raise UnsafeStagingError("fallback staging file changed before its mode was applied")
     fchmod = getattr(os, "fchmod", None)
@@ -1581,7 +1637,8 @@ def _apply_fallback_open_file_mode(path: Path, descriptor: int, mode: int) -> No
     if (
         _is_link(named_after)
         or _node_identity(opened_after) != _node_identity(opened_before)
-        or _node_identity(named_after) != _node_identity(opened_after)
+        or _node_identity(named_after) != _node_identity(named_before)
+        or not _fallback_opened_matches_named(opened_after, named_after)
         or not _fallback_mode_matches(opened_after.st_mode, mode)
         or not _fallback_mode_matches(named_after.st_mode, mode)
     ):
@@ -1606,6 +1663,7 @@ def _copy_manifest_file_fallback(manifest: _TreeManifest, entry: _ManifestEntry,
     )
     destination_descriptor = -1
     try:
+        source_opened = os.fstat(source_descriptor)
         destination_descriptor = os.open(destination, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
         _apply_fallback_open_file_mode(destination, destination_descriptor, 0o600)
         digest = hashlib.sha256()
@@ -1615,8 +1673,13 @@ def _copy_manifest_file_fallback(manifest: _TreeManifest, entry: _ManifestEntry,
             while view:
                 written = os.write(destination_descriptor, view)
                 view = view[written:]
-        _verify_entry(entry, os.fstat(source_descriptor), source)
-        _verify_entry(entry, source.lstat(), source)
+        source_after = os.fstat(source_descriptor)
+        named_after = source.lstat()
+        if _fingerprint(source_after) != _fingerprint(source_opened) or not _fallback_opened_matches_named(
+            source_after, named_after
+        ):
+            raise _changed(source, "file changed while it was copied")
+        _verify_entry(entry, named_after, source)
         if digest.hexdigest() != entry.digest:
             raise _changed(source, "file contents changed")
     finally:
@@ -2137,6 +2200,7 @@ def _stage_fallback_file(manifest: _FileManifest, stage: Path) -> None:
     )
     destination_descriptor = -1
     try:
+        source_opened = os.fstat(source_descriptor)
         destination_descriptor = os.open(stage, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
         _apply_fallback_open_file_mode(stage, destination_descriptor, 0o600)
         digest = hashlib.sha256()
@@ -2146,8 +2210,13 @@ def _stage_fallback_file(manifest: _FileManifest, stage: Path) -> None:
             while view:
                 written = os.write(destination_descriptor, view)
                 view = view[written:]
-        _verify_entry(manifest.entry, os.fstat(source_descriptor), manifest.source)
-        _verify_entry(manifest.entry, manifest.source.lstat(), manifest.source)
+        source_after = os.fstat(source_descriptor)
+        named_after = manifest.source.lstat()
+        if _fingerprint(source_after) != _fingerprint(source_opened) or not _fallback_opened_matches_named(
+            source_after, named_after
+        ):
+            raise _changed(manifest.source, "file changed while it was copied")
+        _verify_entry(manifest.entry, named_after, manifest.source)
         if digest.hexdigest() != manifest.entry.digest:
             raise _changed(manifest.source, "file contents changed")
     finally:

--- a/src/skillevaluator/tier3/harbor/secure_copy.py
+++ b/src/skillevaluator/tier3/harbor/secure_copy.py
@@ -36,8 +36,15 @@ IgnoreCallback = Callable[[str, list[str]], Iterable[str]]
 
 _CHUNK_SIZE = 1024 * 1024
 _REPARSE_POINT = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+_BINARY_FLAG = getattr(os, "O_BINARY", 0)
 _DIRECTORY_FLAGS = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
-_FILE_FLAGS = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0) | getattr(os, "O_NOCTTY", 0)
+_FILE_FLAGS = (
+    os.O_RDONLY
+    | _BINARY_FLAG
+    | getattr(os, "O_NOFOLLOW", 0)
+    | getattr(os, "O_NONBLOCK", 0)
+    | getattr(os, "O_NOCTTY", 0)
+)
 _WINDOWS_CHMOD_SEMANTICS = os.name == "nt"
 _PATH_DESCRIPTOR_IDENTITIES_COMPARABLE = os.name == "posix"
 _DESCRIPTOR_BACKEND = (
@@ -728,7 +735,7 @@ def _create_staged_node(parent_descriptor: int, *, prefix: str, kind: str) -> _S
             else:
                 descriptor = os.open(
                     name,
-                    os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+                    os.O_WRONLY | os.O_CREAT | os.O_EXCL | _BINARY_FLAG | getattr(os, "O_NOFOLLOW", 0),
                     0o600,
                     dir_fd=parent_descriptor,
                 )
@@ -924,7 +931,7 @@ def _copy_manifest_file(
             os.unlink(entry.parts[-1], dir_fd=destination_parent)
         destination_descriptor = os.open(
             entry.parts[-1],
-            os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | _BINARY_FLAG | getattr(os, "O_NOFOLLOW", 0),
             0o600,
             dir_fd=destination_parent,
         )
@@ -1664,7 +1671,11 @@ def _copy_manifest_file_fallback(manifest: _TreeManifest, entry: _ManifestEntry,
     destination_descriptor = -1
     try:
         source_opened = os.fstat(source_descriptor)
-        destination_descriptor = os.open(destination, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        destination_descriptor = os.open(
+            destination,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | _BINARY_FLAG,
+            0o600,
+        )
         _apply_fallback_open_file_mode(destination, destination_descriptor, 0o600)
         digest = hashlib.sha256()
         while data := os.read(source_descriptor, _CHUNK_SIZE):
@@ -2201,7 +2212,11 @@ def _stage_fallback_file(manifest: _FileManifest, stage: Path) -> None:
     destination_descriptor = -1
     try:
         source_opened = os.fstat(source_descriptor)
-        destination_descriptor = os.open(stage, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        destination_descriptor = os.open(
+            stage,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | _BINARY_FLAG,
+            0o600,
+        )
         _apply_fallback_open_file_mode(stage, destination_descriptor, 0o600)
         digest = hashlib.sha256()
         while data := os.read(source_descriptor, _CHUNK_SIZE):

--- a/src/skillevaluator/tier3/harbor/secure_copy.py
+++ b/src/skillevaluator/tier3/harbor/secure_copy.py
@@ -38,6 +38,7 @@ _CHUNK_SIZE = 1024 * 1024
 _REPARSE_POINT = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
 _DIRECTORY_FLAGS = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
 _FILE_FLAGS = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0) | getattr(os, "O_NOCTTY", 0)
+_WINDOWS_CHMOD_SEMANTICS = os.name == "nt"
 _DESCRIPTOR_BACKEND = (
     os.name == "posix"
     and hasattr(os, "O_NOFOLLOW")
@@ -1548,6 +1549,45 @@ def _safe_remove_fallback(path: Path) -> None:
         raise UnsafeStagingError(f"refusing to remove unsafe fallback staging entry: {path}")
 
 
+def _fallback_mode_matches(actual: int, expected: int) -> bool:
+    """Check the mode bits that the platform's path-based chmod can set."""
+
+    if _WINDOWS_CHMOD_SEMANTICS:
+        return bool(actual & stat.S_IWRITE) == bool(expected & stat.S_IWRITE)
+    return stat.S_IMODE(actual) & 0o777 == expected
+
+
+def _apply_fallback_open_file_mode(path: Path, descriptor: int, mode: int) -> None:
+    """Apply a mode through the strongest API available and verify identity."""
+
+    opened_before = os.fstat(descriptor)
+    named_before = path.lstat()
+    if (
+        _is_link(named_before)
+        or not stat.S_ISREG(opened_before.st_mode)
+        or not stat.S_ISREG(named_before.st_mode)
+        or opened_before.st_nlink != 1
+        or named_before.st_nlink != 1
+        or _node_identity(named_before) != _node_identity(opened_before)
+    ):
+        raise UnsafeStagingError("fallback staging file changed before its mode was applied")
+    fchmod = getattr(os, "fchmod", None)
+    if fchmod is not None:
+        fchmod(descriptor, mode)
+    else:
+        path.chmod(mode)
+    opened_after = os.fstat(descriptor)
+    named_after = path.lstat()
+    if (
+        _is_link(named_after)
+        or _node_identity(opened_after) != _node_identity(opened_before)
+        or _node_identity(named_after) != _node_identity(opened_after)
+        or not _fallback_mode_matches(opened_after.st_mode, mode)
+        or not _fallback_mode_matches(named_after.st_mode, mode)
+    ):
+        raise UnsafeStagingError("fallback staging file identity or mode changed while applying its mode")
+
+
 def _copy_manifest_file_fallback(manifest: _TreeManifest, entry: _ManifestEntry, destination: Path) -> None:
     source = manifest.source.joinpath(*entry.parts)
     before = source.lstat()
@@ -1567,7 +1607,7 @@ def _copy_manifest_file_fallback(manifest: _TreeManifest, entry: _ManifestEntry,
     destination_descriptor = -1
     try:
         destination_descriptor = os.open(destination, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
-        os.fchmod(destination_descriptor, 0o600)
+        _apply_fallback_open_file_mode(destination, destination_descriptor, 0o600)
         digest = hashlib.sha256()
         while data := os.read(source_descriptor, _CHUNK_SIZE):
             digest.update(data)
@@ -1613,13 +1653,13 @@ def _apply_modes_fallback(stage: Path, manifests: tuple[_TreeManifest, ...]) -> 
     for entry in (item for item in entries.values() if item.kind == "file"):
         path = stage.joinpath(*entry.parts)
         path.chmod(entry.mode)
-        if stat.S_IMODE(path.lstat().st_mode) & 0o777 != entry.mode:
+        if not _fallback_mode_matches(path.lstat().st_mode, entry.mode):
             raise UnsafeStagingError("published fallback file mode could not be applied")
     directories = [item for item in entries.values() if item.kind == "directory"]
     for entry in sorted(directories, key=lambda item: len(item.parts), reverse=True):
         path = stage.joinpath(*entry.parts)
         path.chmod(entry.mode)
-        if stat.S_IMODE(path.lstat().st_mode) & 0o777 != entry.mode:
+        if not _fallback_mode_matches(path.lstat().st_mode, entry.mode):
             raise UnsafeStagingError("published fallback directory mode could not be applied")
 
 
@@ -1645,7 +1685,7 @@ def _validate_fallback_tree_exact_pass(
             _is_link(before)
             or not stat.S_ISDIR(before.st_mode)
             or before.st_dev != root_device
-            or stat.S_IMODE(before.st_mode) & 0o777 != expected_mode
+            or not _fallback_mode_matches(before.st_mode, expected_mode)
         ):
             raise UnsafeStagingError("fallback staging directory is unsafe")
         before_fingerprint = _fingerprint(before)
@@ -1667,7 +1707,7 @@ def _validate_fallback_tree_exact_pass(
                     not stat.S_ISREG(metadata.st_mode)
                     or metadata.st_nlink != 1
                     or metadata.st_size != child_entry.size
-                    or stat.S_IMODE(metadata.st_mode) & 0o777 != expected_file_mode
+                    or not _fallback_mode_matches(metadata.st_mode, expected_file_mode)
                 ):
                     raise UnsafeStagingError("fallback staging file is unsafe")
                 if (
@@ -1741,7 +1781,7 @@ def _expose_fallback_tree_root_exact(stage: Path, manifests: tuple[_TreeManifest
     root_mode = manifests[-1].root.mode
     stage.chmod(root_mode)
     after = stage.lstat()
-    if _node_identity(after) != _node_identity(before) or stat.S_IMODE(after.st_mode) & 0o777 != root_mode:
+    if _node_identity(after) != _node_identity(before) or not _fallback_mode_matches(after.st_mode, root_mode):
         raise UnsafeStagingError("published fallback root identity or mode changed during exposure")
 
 
@@ -1773,7 +1813,7 @@ def _prepare_fallback_moved_backup(
     private_mode = 0o700 if kind == "directory" else 0o600
     backup.chmod(private_mode)
     private = backup.lstat()
-    if _node_identity(private) != _node_identity(expected) or stat.S_IMODE(private.st_mode) & 0o777 != private_mode:
+    if _node_identity(private) != _node_identity(expected) or not _fallback_mode_matches(private.st_mode, private_mode):
         raise UnsafeStagingError("fallback destination backup could not be made private")
 
 
@@ -2076,7 +2116,7 @@ def _validate_fallback_file_exact(
         or not stat.S_ISREG(metadata.st_mode)
         or metadata.st_nlink != 1
         or metadata.st_size != manifest.entry.size
-        or stat.S_IMODE(metadata.st_mode) & 0o777 != expected_mode
+        or not _fallback_mode_matches(metadata.st_mode, expected_mode)
     ):
         raise UnsafeStagingError("fallback staging file has an unsafe type, link count, size, or mode")
     if (
@@ -2098,7 +2138,7 @@ def _stage_fallback_file(manifest: _FileManifest, stage: Path) -> None:
     destination_descriptor = -1
     try:
         destination_descriptor = os.open(stage, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
-        os.fchmod(destination_descriptor, 0o600)
+        _apply_fallback_open_file_mode(stage, destination_descriptor, 0o600)
         digest = hashlib.sha256()
         while data := os.read(source_descriptor, _CHUNK_SIZE):
             digest.update(data)

--- a/src/skillevaluator/tier3/output_provenance.py
+++ b/src/skillevaluator/tier3/output_provenance.py
@@ -16,6 +16,8 @@ import time
 from pathlib import Path
 
 from skillevaluator.tier3.case_ids import validate_output_directory_path
+from skillevaluator.tier3.harbor.secure_copy import _DESCRIPTOR_BACKEND, _DIRECTORY_FLAGS, _remove_tree_at
+from skillevaluator.utils.secure_fs import SecurePathError, SecureRoot
 
 GENERATED_OUTPUT_MARKER = ".skillevaluator-generated-output"
 OUTPUT_PROVENANCE_KEY_ENV = "SKILLEVALUATOR_OUTPUT_PROVENANCE_KEY_FILE"
@@ -26,6 +28,7 @@ _KEY_TEMP_PREFIX = ".output-provenance.key.tmp-"
 _MARKER_PREFIX = b"SkillEvaluator generated output v2\n"
 _MARKER_CONTEXT = b"skillevaluator.generated-output.v2\0"
 _MARKER_SIZE = len(_MARKER_PREFIX) + len(base64.urlsafe_b64encode(bytes(_KEY_BYTES)).rstrip(b"=")) + 1
+_PATH_DESCRIPTOR_IDENTITIES_COMPARABLE = os.name == "posix"
 
 
 def _is_link_or_reparse(metadata: os.stat_result) -> bool:
@@ -35,6 +38,157 @@ def _is_link_or_reparse(metadata: os.stat_result) -> bool:
 
 def _node_fingerprint(metadata: os.stat_result) -> tuple[int, int, int, int, int]:
     return metadata.st_dev, metadata.st_ino, metadata.st_mode, metadata.st_nlink, metadata.st_size
+
+
+def _artifact_fingerprint(metadata: os.stat_result) -> tuple[int, int, int, int, int, int, int]:
+    """Return identity and content-change fields from one stat API family."""
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_mode,
+        metadata.st_nlink,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+    )
+
+
+def _stable_read_metadata(
+    before: os.stat_result,
+    opened: os.stat_result,
+    after: os.stat_result,
+) -> os.stat_result | None:
+    """Select comparable metadata after a descriptor-pinned read."""
+    if _PATH_DESCRIPTOR_IDENTITIES_COMPARABLE:
+        if _artifact_fingerprint(opened) != _artifact_fingerprint(before) or _artifact_fingerprint(
+            after
+        ) != _artifact_fingerprint(opened):
+            return None
+        return opened
+    if _artifact_fingerprint(after) != _artifact_fingerprint(before) or opened.st_size != after.st_size:
+        return None
+    return after
+
+
+def _fsync_directory(path: Path) -> None:
+    """Durably publish a directory entry where the platform supports it."""
+    if os.name != "posix":
+        return
+    descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _unlink_if_same_file(path: Path, expected: os.stat_result) -> bool:
+    """Unlink only the exact regular file created by the current operation."""
+    try:
+        observed = path.lstat()
+    except OSError:
+        return False
+    if _is_link_or_reparse(observed) or not stat.S_ISREG(observed.st_mode):
+        return False
+    if not os.path.samestat(expected, observed):
+        return False
+    try:
+        path.unlink()
+    except OSError:
+        return False
+    return True
+
+
+def _inspect_atomic_destination(path: Path) -> os.stat_result | None:
+    """Return destination metadata after rejecting unsafe file types."""
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        return None
+    if _is_link_or_reparse(metadata) or not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+        raise ValueError(f"Generated output artifact must be a single-link regular file: {path}")
+    return metadata
+
+
+def write_output_file_atomically(path: Path, payload: bytes) -> None:
+    """Durably replace one evaluator-owned output file with complete bytes."""
+    validate_output_directory_path(path.parent)
+    existing = _inspect_atomic_destination(path)
+    existing_mode = stat.S_IMODE(existing.st_mode) if existing is not None else None
+    temporary: Path | None = None
+    temporary_named_metadata: os.stat_result | None = None
+    descriptor = -1
+    try:
+        for _ in range(32):
+            candidate = path.parent / f".{path.name}.{os.getpid()}-{secrets.token_hex(8)}.tmp"
+            try:
+                descriptor = os.open(
+                    candidate,
+                    os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0),
+                    0o666,
+                )
+            except FileExistsError:
+                continue
+            temporary = candidate
+            break
+        if temporary is None or descriptor < 0:
+            raise OSError(f"Cannot allocate a temporary output artifact for: {path}")
+
+        temporary_opened = os.fstat(descriptor)
+        temporary_named_metadata = temporary.lstat()
+        if (
+            _is_link_or_reparse(temporary_opened)
+            or _is_link_or_reparse(temporary_named_metadata)
+            or not stat.S_ISREG(temporary_opened.st_mode)
+            or not stat.S_ISREG(temporary_named_metadata.st_mode)
+            or temporary_opened.st_nlink != 1
+            or temporary_named_metadata.st_nlink != 1
+            or (
+                _PATH_DESCRIPTOR_IDENTITIES_COMPARABLE
+                and not os.path.samestat(temporary_opened, temporary_named_metadata)
+            )
+        ):
+            raise ValueError(f"Generated output temporary artifact is unsafe: {temporary}")
+        if existing_mode is not None and hasattr(os, "fchmod"):
+            os.fchmod(descriptor, existing_mode)
+
+        handle = os.fdopen(descriptor, "wb", closefd=True)
+        descriptor = -1
+        with handle:
+            if handle.write(payload) != len(payload):
+                raise OSError(f"Short write while publishing generated output: {path}")
+            handle.flush()
+            os.fsync(handle.fileno())
+            written = os.fstat(handle.fileno())
+
+        observed = temporary.lstat()
+        temporary_identity_matches = os.path.samestat(temporary_named_metadata, observed) and (
+            not _PATH_DESCRIPTOR_IDENTITIES_COMPARABLE or os.path.samestat(written, observed)
+        )
+        if (
+            _is_link_or_reparse(observed)
+            or not stat.S_ISREG(observed.st_mode)
+            or observed.st_nlink != 1
+            or written.st_size != len(payload)
+            or observed.st_size != len(payload)
+            or not temporary_identity_matches
+        ):
+            raise ValueError(f"Generated output temporary artifact changed while writing: {temporary}")
+        validate_output_directory_path(path.parent)
+        destination = _inspect_atomic_destination(path)
+        if (existing is None) != (destination is None) or (
+            existing is not None
+            and destination is not None
+            and _artifact_fingerprint(existing) != _artifact_fingerprint(destination)
+        ):
+            raise ValueError(f"Generated output destination changed while writing: {path}")
+        os.replace(temporary, path)  # noqa: PTH105 -- same-directory atomic replacement is the contract
+        temporary = None
+        _fsync_directory(path.parent)
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        if temporary is not None and temporary_named_metadata is not None:
+            _unlink_if_same_file(temporary, temporary_named_metadata)
 
 
 def _protect_key_for_storage(key: bytes) -> bytes:
@@ -149,21 +303,16 @@ def _validate_key_metadata(path: Path, metadata: os.stat_result) -> None:
 def _read_key(path: Path) -> bytes:
     before = path.lstat()
     _validate_key_metadata(path, before)
-    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
-    descriptor = os.open(path, flags)
     try:
-        opened = os.fstat(descriptor)
-        _validate_key_metadata(path, opened)
-        if _node_fingerprint(opened) != _node_fingerprint(before):
-            raise ValueError(f"Output provenance key changed while it was opened: {path}")
-        payload = os.read(descriptor, before.st_size + 1)
-        after = os.fstat(descriptor)
-        _validate_key_metadata(path, after)
-        if _node_fingerprint(after) != _node_fingerprint(before):
-            raise ValueError(f"Output provenance key changed while it was read: {path}")
-    finally:
-        os.close(descriptor)
-    if len(payload) != before.st_size:
+        with SecureRoot(path.parent) as secure_root:
+            payload, opened = secure_root.read_bytes(Path(path.name), before.st_size, expected=before)
+            after = path.lstat()
+    except SecurePathError as exc:
+        raise ValueError(f"Output provenance key changed while it was read: {path}") from exc
+    _validate_key_metadata(path, opened)
+    _validate_key_metadata(path, after)
+    stable = _stable_read_metadata(before, opened, after)
+    if stable is None or len(payload) != before.st_size or len(payload) != stable.st_size:
         raise ValueError(f"Output provenance key has an invalid size: {path}")
     return _unprotect_stored_key(payload)
 
@@ -344,30 +493,26 @@ def _read_marker(path: Path, expected_size: int) -> bytes | None:
         or before.st_size != expected_size
     ):
         return None
-    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
     try:
-        descriptor = os.open(path, flags)
-    except OSError:
-        return None
-    try:
-        opened = os.fstat(descriptor)
+        with SecureRoot(path.parent) as secure_root:
+            payload, opened = secure_root.read_bytes(Path(path.name), expected_size, expected=before)
+            after = path.lstat()
         if (
             _is_link_or_reparse(opened)
             or not stat.S_ISREG(opened.st_mode)
             or opened.st_nlink != 1
             or opened.st_size != expected_size
-            or _node_fingerprint(opened) != _node_fingerprint(before)
+            or _is_link_or_reparse(after)
+            or not stat.S_ISREG(after.st_mode)
+            or after.st_nlink != 1
+            or after.st_size != expected_size
+            or _stable_read_metadata(before, opened, after) is None
+            or len(payload) != expected_size
         ):
             return None
-        payload = os.read(descriptor, expected_size + 1)
-        after = os.fstat(descriptor)
-        if _node_fingerprint(after) != _node_fingerprint(before):
-            return None
         return payload
-    except OSError:
+    except (OSError, SecurePathError, ValueError):
         return None
-    finally:
-        os.close(descriptor)
 
 
 def is_generated_output_root(path: Path) -> bool:
@@ -420,10 +565,50 @@ def write_generated_output_marker(root: Path, *, destination: Path | None = None
         if observed is None or not hmac.compare_digest(observed, expected):
             raise ValueError(f"Generated output marker is invalid or unsafe: {marker}") from None
         return
-    with os.fdopen(descriptor, "wb", closefd=True) as handle:
-        handle.write(expected)
-        handle.flush()
-        os.fsync(handle.fileno())
+    created_named: os.stat_result | None = None
+    try:
+        created_opened = os.fstat(descriptor)
+        created_named = marker.lstat()
+        if (
+            _is_link_or_reparse(created_opened)
+            or _is_link_or_reparse(created_named)
+            or not stat.S_ISREG(created_opened.st_mode)
+            or not stat.S_ISREG(created_named.st_mode)
+            or created_opened.st_nlink != 1
+            or created_named.st_nlink != 1
+            or (_PATH_DESCRIPTOR_IDENTITIES_COMPARABLE and not os.path.samestat(created_opened, created_named))
+        ):
+            raise ValueError(f"Generated output marker is unsafe: {marker}")
+        handle = os.fdopen(descriptor, "wb", closefd=True)
+        descriptor = -1
+        with handle:
+            if handle.write(expected) != len(expected):
+                raise OSError(f"Short write while publishing generated output marker: {marker}")
+            handle.flush()
+            os.fsync(handle.fileno())
+            written = os.fstat(handle.fileno())
+        observed = marker.lstat()
+        if (
+            _is_link_or_reparse(observed)
+            or not stat.S_ISREG(observed.st_mode)
+            or observed.st_nlink != 1
+            or written.st_size != len(expected)
+            or observed.st_size != len(expected)
+            or not os.path.samestat(created_named, observed)
+            or (_PATH_DESCRIPTOR_IDENTITIES_COMPARABLE and not os.path.samestat(written, observed))
+        ):
+            raise ValueError(f"Generated output marker changed while it was written: {marker}")
+        _fsync_directory(root)
+    except BaseException:
+        if descriptor >= 0:
+            os.close(descriptor)
+            descriptor = -1
+        if created_named is not None:
+            _unlink_if_same_file(marker, created_named)
+        raise
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
 
 
 def mark_generated_output_root(path: Path) -> None:
@@ -432,3 +617,115 @@ def mark_generated_output_root(path: Path) -> None:
     path.mkdir(parents=True, exist_ok=True)
     validate_output_directory_path(path)
     write_generated_output_marker(path)
+
+
+def _remove_output_tree_at_identity(path: Path, expected_identity: tuple[int, int]) -> bool:
+    """Remove only one no-follow tree matching a previously observed identity."""
+    if not _DESCRIPTOR_BACKEND:
+        return False
+    parent_descriptor = -1
+    try:
+        validate_output_directory_path(path.parent)
+        parent_descriptor = os.open(path.parent, _DIRECTORY_FLAGS)
+        _remove_tree_at(parent_descriptor, path.name, expected_identity=expected_identity)
+        os.fsync(parent_descriptor)
+    except (OSError, ValueError):
+        return False
+    finally:
+        if parent_descriptor >= 0:
+            os.close(parent_descriptor)
+    return not os.path.lexists(path)
+
+
+def _remove_empty_output_tree_fallback(
+    path: Path,
+    expected_identity: tuple[int, int],
+    *,
+    remove_authenticated_marker: bool,
+) -> bool:
+    """Conservatively remove an empty exact reservation without recursive deletion."""
+    marker = path / GENERATED_OUTPUT_MARKER
+    marker_metadata: os.stat_result | None = None
+    try:
+        validate_output_directory_path(path)
+        before = path.lstat()
+        if (
+            _is_link_or_reparse(before)
+            or not stat.S_ISDIR(before.st_mode)
+            or (before.st_dev, before.st_ino) != expected_identity
+        ):
+            return False
+        entries = list(path.iterdir())
+        if remove_authenticated_marker:
+            if len(entries) != 1 or entries[0].name != GENERATED_OUTPUT_MARKER or not is_generated_output_root(path):
+                return False
+            marker_metadata = marker.lstat()
+            if (
+                _is_link_or_reparse(marker_metadata)
+                or not stat.S_ISREG(marker_metadata.st_mode)
+                or marker_metadata.st_nlink != 1
+            ):
+                return False
+        elif entries:
+            return False
+
+        current = path.lstat()
+        if (current.st_dev, current.st_ino) != expected_identity or _is_link_or_reparse(current):
+            return False
+        if marker_metadata is not None and not _unlink_if_same_file(marker, marker_metadata):
+            return False
+        current = path.lstat()
+        if (current.st_dev, current.st_ino) != expected_identity or _is_link_or_reparse(current):
+            return False
+        if next(path.iterdir(), None) is not None:
+            return False
+        path.rmdir()
+        _fsync_directory(path.parent)
+    except (OSError, ValueError):
+        return False
+    return not os.path.lexists(path)
+
+
+def remove_output_reservation_if_identity_matches(path: Path, expected_identity: tuple[int, int]) -> bool:
+    """Clean an exact new reservation; fallback platforms require it to be empty."""
+    if not _DESCRIPTOR_BACKEND:
+        return _remove_empty_output_tree_fallback(
+            path,
+            expected_identity,
+            remove_authenticated_marker=False,
+        )
+    return _remove_output_tree_at_identity(path, expected_identity)
+
+
+def remove_generated_output_root_if_owned(
+    path: Path,
+    *,
+    expected_identity: tuple[int, int] | None = None,
+) -> bool:
+    """Remove an authenticated failed reservation without following replacements.
+
+    Descriptor-capable platforms use identity-bound recursive removal. Other
+    platforms remove only a marker-only directory and never recursively delete.
+    """
+    try:
+        validate_output_directory_path(path)
+        before = path.lstat()
+        if not stat.S_ISDIR(before.st_mode) or _is_link_or_reparse(before):
+            return False
+        identity = before.st_dev, before.st_ino
+        if expected_identity is not None and identity != expected_identity:
+            return False
+        if not is_generated_output_root(path):
+            return False
+        after = path.lstat()
+        if _node_fingerprint(after) != _node_fingerprint(before):
+            return False
+    except (OSError, ValueError):
+        return False
+    if not _DESCRIPTOR_BACKEND:
+        return _remove_empty_output_tree_fallback(
+            path,
+            identity,
+            remove_authenticated_marker=True,
+        )
+    return _remove_output_tree_at_identity(path, identity)

--- a/src/skillevaluator/tier3/output_provenance.py
+++ b/src/skillevaluator/tier3/output_provenance.py
@@ -1,0 +1,434 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Path-bound provenance for evaluator-owned generated output trees."""
+
+from __future__ import annotations
+
+import base64
+import contextlib
+import hmac
+import os
+import secrets
+import stat
+import sys
+import time
+from pathlib import Path
+
+from skillevaluator.tier3.case_ids import validate_output_directory_path
+
+GENERATED_OUTPUT_MARKER = ".skillevaluator-generated-output"
+OUTPUT_PROVENANCE_KEY_ENV = "SKILLEVALUATOR_OUTPUT_PROVENANCE_KEY_FILE"
+
+_KEY_BYTES = 32
+_MAX_STORED_KEY_BYTES = 4096
+_KEY_TEMP_PREFIX = ".output-provenance.key.tmp-"
+_MARKER_PREFIX = b"SkillEvaluator generated output v2\n"
+_MARKER_CONTEXT = b"skillevaluator.generated-output.v2\0"
+_MARKER_SIZE = len(_MARKER_PREFIX) + len(base64.urlsafe_b64encode(bytes(_KEY_BYTES)).rstrip(b"=")) + 1
+
+
+def _is_link_or_reparse(metadata: os.stat_result) -> bool:
+    reparse_flag = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+    return stat.S_ISLNK(metadata.st_mode) or bool(getattr(metadata, "st_file_attributes", 0) & reparse_flag)
+
+
+def _node_fingerprint(metadata: os.stat_result) -> tuple[int, int, int, int, int]:
+    return metadata.st_dev, metadata.st_ino, metadata.st_mode, metadata.st_nlink, metadata.st_size
+
+
+def _protect_key_for_storage(key: bytes) -> bytes:
+    """Bind key bytes to the current Windows user with DPAPI."""
+    if os.name != "nt":
+        return key
+    import ctypes
+    from ctypes import wintypes
+
+    class _DataBlob(ctypes.Structure):
+        _fields_ = [("cbData", wintypes.DWORD), ("pbData", ctypes.POINTER(ctypes.c_ubyte))]
+
+    source = ctypes.create_string_buffer(key)
+    source_blob = _DataBlob(len(key), ctypes.cast(source, ctypes.POINTER(ctypes.c_ubyte)))
+    protected_blob = _DataBlob()
+    crypt32 = ctypes.WinDLL("crypt32", use_last_error=True)
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    crypt32.CryptProtectData.restype = wintypes.BOOL
+    kernel32.LocalFree.argtypes = [wintypes.HLOCAL]
+    kernel32.LocalFree.restype = wintypes.HLOCAL
+    if not crypt32.CryptProtectData(
+        ctypes.byref(source_blob),
+        None,
+        None,
+        None,
+        None,
+        0x1,
+        ctypes.byref(protected_blob),
+    ):
+        raise ValueError("Cannot protect output provenance key for the current Windows user") from ctypes.WinError(
+            ctypes.get_last_error()
+        )
+    try:
+        return ctypes.string_at(protected_blob.pbData, protected_blob.cbData)
+    finally:
+        kernel32.LocalFree(ctypes.cast(protected_blob.pbData, wintypes.HLOCAL))
+
+
+def _unprotect_stored_key(payload: bytes) -> bytes:
+    """Decode DPAPI-protected Windows bytes or return POSIX bytes unchanged."""
+    if os.name != "nt":
+        return payload
+    import ctypes
+    from ctypes import wintypes
+
+    class _DataBlob(ctypes.Structure):
+        _fields_ = [("cbData", wintypes.DWORD), ("pbData", ctypes.POINTER(ctypes.c_ubyte))]
+
+    source = ctypes.create_string_buffer(payload)
+    source_blob = _DataBlob(len(payload), ctypes.cast(source, ctypes.POINTER(ctypes.c_ubyte)))
+    key_blob = _DataBlob()
+    crypt32 = ctypes.WinDLL("crypt32", use_last_error=True)
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    crypt32.CryptUnprotectData.restype = wintypes.BOOL
+    kernel32.LocalFree.argtypes = [wintypes.HLOCAL]
+    kernel32.LocalFree.restype = wintypes.HLOCAL
+    if not crypt32.CryptUnprotectData(
+        ctypes.byref(source_blob),
+        None,
+        None,
+        None,
+        None,
+        0x1,
+        ctypes.byref(key_blob),
+    ):
+        raise ValueError("Output provenance key is not protected for the current Windows user") from ctypes.WinError(
+            ctypes.get_last_error()
+        )
+    try:
+        key = ctypes.string_at(key_blob.pbData, key_blob.cbData)
+    finally:
+        kernel32.LocalFree(ctypes.cast(key_blob.pbData, wintypes.HLOCAL))
+    if len(key) != _KEY_BYTES:
+        raise ValueError("Output provenance key has an invalid decrypted size")
+    return key
+
+
+def _stored_key_size_is_valid(size: int) -> bool:
+    return 0 < size <= _MAX_STORED_KEY_BYTES if os.name == "nt" else size == _KEY_BYTES
+
+
+def _default_key_path() -> Path:
+    override = os.environ.get(OUTPUT_PROVENANCE_KEY_ENV)
+    if override:
+        return Path(override).expanduser().absolute()
+    if os.name == "nt":
+        base = Path(os.environ.get("LOCALAPPDATA", Path.home() / "AppData" / "Local"))
+    elif sys.platform == "darwin":
+        base = Path.home() / "Library" / "Application Support"
+    else:
+        base = Path(os.environ.get("XDG_STATE_HOME", Path.home() / ".local" / "state"))
+    return base / "skillevaluator" / "output-provenance.key"
+
+
+def output_provenance_key_path() -> Path:
+    """Return the configured private-key path without creating the key."""
+    return _default_key_path()
+
+
+def _validate_key_metadata(path: Path, metadata: os.stat_result) -> None:
+    if _is_link_or_reparse(metadata) or not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+        raise ValueError(f"Output provenance key must be a single-link regular file: {path}")
+    if not _stored_key_size_is_valid(metadata.st_size):
+        raise ValueError(f"Output provenance key has an invalid size: {path}")
+    if os.name == "posix":
+        if metadata.st_uid != os.getuid():
+            raise ValueError(f"Output provenance key is not owned by the current user: {path}")
+        if stat.S_IMODE(metadata.st_mode) & 0o077:
+            raise ValueError(f"Output provenance key must not be accessible by group or other users: {path}")
+
+
+def _read_key(path: Path) -> bytes:
+    before = path.lstat()
+    _validate_key_metadata(path, before)
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+    descriptor = os.open(path, flags)
+    try:
+        opened = os.fstat(descriptor)
+        _validate_key_metadata(path, opened)
+        if _node_fingerprint(opened) != _node_fingerprint(before):
+            raise ValueError(f"Output provenance key changed while it was opened: {path}")
+        payload = os.read(descriptor, before.st_size + 1)
+        after = os.fstat(descriptor)
+        _validate_key_metadata(path, after)
+        if _node_fingerprint(after) != _node_fingerprint(before):
+            raise ValueError(f"Output provenance key changed while it was read: {path}")
+    finally:
+        os.close(descriptor)
+    if len(payload) != before.st_size:
+        raise ValueError(f"Output provenance key has an invalid size: {path}")
+    return _unprotect_stored_key(payload)
+
+
+def _validate_key_directory(path: Path, metadata: os.stat_result) -> None:
+    if _is_link_or_reparse(metadata) or not stat.S_ISDIR(metadata.st_mode):
+        raise ValueError(f"Output provenance key directory must be a real directory: {path}")
+    if os.name == "posix":
+        if metadata.st_uid != os.getuid():
+            raise ValueError(f"Output provenance key directory is not owned by the current user: {path}")
+        if stat.S_IMODE(metadata.st_mode) & 0o077:
+            raise ValueError(f"Output provenance key directory must not be accessible by group or other users: {path}")
+
+
+def _load_existing_key() -> bytes | None:
+    path = _default_key_path()
+    try:
+        parent_metadata = path.parent.lstat()
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        raise ValueError(f"Cannot inspect output provenance key directory: {path.parent}") from exc
+    _validate_key_directory(path.parent, parent_metadata)
+    try:
+        return _read_key(path)
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        raise ValueError(f"Cannot safely read output provenance key: {path}") from exc
+
+
+def _recover_interrupted_key_publish(path: Path) -> bool:
+    """Remove only same-inode private temp links left by an interrupted publish."""
+    try:
+        target = path.lstat()
+    except OSError:
+        return False
+    if _is_link_or_reparse(target) or not stat.S_ISREG(target.st_mode) or not _stored_key_size_is_valid(target.st_size):
+        return False
+    if os.name == "posix" and target.st_uid != os.getuid():
+        return False
+    recovered = False
+    for candidate in path.parent.iterdir():
+        if not candidate.name.startswith(_KEY_TEMP_PREFIX):
+            continue
+        try:
+            metadata = candidate.lstat()
+            if (
+                not _is_link_or_reparse(metadata)
+                and stat.S_ISREG(metadata.st_mode)
+                and metadata.st_dev == target.st_dev
+                and metadata.st_ino == target.st_ino
+            ):
+                candidate.unlink()
+                recovered = True
+        except OSError:
+            continue
+    return recovered
+
+
+def _read_key_after_concurrent_publish(path: Path) -> bytes:
+    last_error: OSError | ValueError | None = None
+    for _ in range(50):
+        try:
+            return _read_key(path)
+        except (OSError, ValueError) as exc:
+            last_error = exc
+            _recover_interrupted_key_publish(path)
+            time.sleep(0.002)
+    if last_error is not None:
+        raise last_error
+    raise ValueError(f"Cannot safely read concurrently published output provenance key: {path}")
+
+
+def _load_or_create_key() -> bytes:
+    path = _default_key_path()
+    path.parent.mkdir(parents=True, mode=0o700, exist_ok=True)
+    try:
+        parent_metadata = path.parent.lstat()
+    except OSError as exc:
+        raise ValueError(f"Cannot inspect output provenance key directory: {path.parent}") from exc
+    _validate_key_directory(path.parent, parent_metadata)
+    try:
+        return _read_key(path)
+    except FileNotFoundError:
+        pass
+    except ValueError:
+        return _read_key_after_concurrent_publish(path)
+    except OSError as exc:
+        raise ValueError(f"Cannot safely read output provenance key: {path}") from exc
+
+    key = secrets.token_bytes(_KEY_BYTES)
+    stored_key = _protect_key_for_storage(key)
+    temporary = path.parent / f"{_KEY_TEMP_PREFIX}{os.getpid()}-{secrets.token_hex(8)}"
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(temporary, flags, 0o600)
+        with os.fdopen(descriptor, "wb", closefd=True) as handle:
+            handle.write(stored_key)
+            handle.flush()
+            os.fsync(handle.fileno())
+        try:
+            os.link(temporary, path)
+        except FileExistsError:
+            return _read_key_after_concurrent_publish(path)
+        with contextlib.suppress(FileNotFoundError):
+            temporary.unlink()
+        try:
+            directory_descriptor = os.open(path.parent, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+        except OSError:
+            directory_descriptor = None
+        if directory_descriptor is not None:
+            try:
+                os.fsync(directory_descriptor)
+            finally:
+                os.close(directory_descriptor)
+    finally:
+        with contextlib.suppress(FileNotFoundError):
+            temporary.unlink()
+    return _read_key(path)
+
+
+def _canonical_output_binding(path: Path) -> bytes:
+    try:
+        resolved = path.expanduser().resolve(strict=False)
+    except (OSError, RuntimeError) as exc:
+        raise ValueError(f"Cannot resolve generated output path for provenance: {path}") from exc
+    normalized = os.path.normcase(os.path.normpath(os.fspath(resolved)))
+    return os.fsencode(normalized)
+
+
+def _path_is_contained(path: Path, root: Path) -> bool:
+    for candidate, candidate_root in (
+        (path.expanduser().absolute(), root.expanduser().absolute()),
+        (path.expanduser().resolve(strict=False), root.expanduser().resolve(strict=False)),
+    ):
+        normalized = Path(os.path.normcase(os.path.normpath(os.fspath(candidate))))
+        normalized_root = Path(os.path.normcase(os.path.normpath(os.fspath(candidate_root))))
+        try:
+            normalized.relative_to(normalized_root)
+        except ValueError:
+            continue
+        return True
+    return False
+
+
+def validate_provenance_key_outside(workspace_root: Path) -> None:
+    """Reject a private-key location that could enter an evaluated or generated tree."""
+    try:
+        inside_workspace = _path_is_contained(_default_key_path(), workspace_root)
+    except (OSError, RuntimeError) as exc:
+        raise ValueError(f"Cannot validate output provenance key location against: {workspace_root}") from exc
+    if inside_workspace:
+        raise ValueError(f"Output provenance key must be outside evaluated and generated trees: {workspace_root}")
+
+
+def _marker_payload(destination: Path, key: bytes) -> bytes:
+    digest = hmac.digest(key, _MARKER_CONTEXT + _canonical_output_binding(destination), "sha256")
+    signature = base64.urlsafe_b64encode(digest).rstrip(b"=")
+    return _MARKER_PREFIX + signature + b"\n"
+
+
+def generated_output_marker_payload(destination: Path) -> bytes:
+    """Return marker bytes signed for one canonical public destination."""
+    validate_provenance_key_outside(destination)
+    return _marker_payload(destination, _load_or_create_key())
+
+
+def _read_marker(path: Path, expected_size: int) -> bytes | None:
+    try:
+        before = path.lstat()
+    except OSError:
+        return None
+    if (
+        _is_link_or_reparse(before)
+        or not stat.S_ISREG(before.st_mode)
+        or before.st_nlink != 1
+        or before.st_size != expected_size
+    ):
+        return None
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError:
+        return None
+    try:
+        opened = os.fstat(descriptor)
+        if (
+            _is_link_or_reparse(opened)
+            or not stat.S_ISREG(opened.st_mode)
+            or opened.st_nlink != 1
+            or opened.st_size != expected_size
+            or _node_fingerprint(opened) != _node_fingerprint(before)
+        ):
+            return None
+        payload = os.read(descriptor, expected_size + 1)
+        after = os.fstat(descriptor)
+        if _node_fingerprint(after) != _node_fingerprint(before):
+            return None
+        return payload
+    except OSError:
+        return None
+    finally:
+        os.close(descriptor)
+
+
+def is_generated_output_root(path: Path) -> bool:
+    """Return whether *path* has a valid marker bound to its canonical location."""
+    observed = _read_marker(path / GENERATED_OUTPUT_MARKER, _MARKER_SIZE)
+    if observed is None or not observed.startswith(_MARKER_PREFIX):
+        return False
+    validate_provenance_key_outside(path)
+    key = _load_existing_key()
+    if key is None:
+        return False
+    return hmac.compare_digest(observed, _marker_payload(path, key))
+
+
+def validate_generated_output_replacement(path: Path) -> None:
+    """Allow replacement only for absent, empty, or authentically owned roots."""
+    validate_output_directory_path(path)
+    if not os.path.lexists(path):
+        return
+    try:
+        metadata = path.lstat()
+    except OSError as exc:
+        raise ValueError(f"Cannot inspect generated output root before replacement: {path}") from exc
+    if not stat.S_ISDIR(metadata.st_mode):
+        raise ValueError(f"Generated output root must be a real directory: {path}")
+    try:
+        has_contents = next(path.iterdir(), None) is not None
+    except OSError as exc:
+        raise ValueError(f"Cannot inspect generated output root before replacement: {path}") from exc
+    if has_contents and not is_generated_output_root(path):
+        raise ValueError(f"Generated output marker is missing, invalid, or bound to another path: {path}")
+
+
+def write_generated_output_marker(root: Path, *, destination: Path | None = None) -> None:
+    """Write provenance into a caller-owned tree, optionally for a later public path."""
+    validate_provenance_key_outside(root)
+    validate_output_directory_path(root)
+    root.mkdir(parents=True, exist_ok=True)
+    validate_output_directory_path(root)
+    expected = generated_output_marker_payload(destination or root)
+    marker = root / GENERATED_OUTPUT_MARKER
+    try:
+        descriptor = os.open(
+            marker,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0),
+            0o600,
+        )
+    except FileExistsError:
+        observed = _read_marker(marker, len(expected))
+        if observed is None or not hmac.compare_digest(observed, expected):
+            raise ValueError(f"Generated output marker is invalid or unsafe: {marker}") from None
+        return
+    with os.fdopen(descriptor, "wb", closefd=True) as handle:
+        handle.write(expected)
+        handle.flush()
+        os.fsync(handle.fileno())
+
+
+def mark_generated_output_root(path: Path) -> None:
+    """Claim or validate an output root before any generated child is replaced."""
+    validate_generated_output_replacement(path)
+    path.mkdir(parents=True, exist_ok=True)
+    validate_output_directory_path(path)
+    write_generated_output_marker(path)

--- a/src/skillevaluator/tier3/reference_skills/create-custom-grader/SKILL.md
+++ b/src/skillevaluator/tier3/reference_skills/create-custom-grader/SKILL.md
@@ -74,9 +74,13 @@ grader to replace the default evaluator metrics.
 
 2. Map benchmark fields into evaluator inputs.
    Use benchmark prompts or prompt variants as `question` entries. Use the
-   target skill as `expected_skill`. Put required starter files under
-   `evals/files/`. Preserve benchmark-specific rubric text in the entry only
-   when the grader needs to read it.
+   target skill as `expected_skill`. Put each case's required starter files
+   under `evals/files/<case-id>/`, and declare
+   `files: ["evals/files/<case-id>"]` on every corresponding eval entry. Do not
+   omit `files` in a multi-case dataset, because omission intentionally stages
+   the entire shared directory for legacy compatibility. Preserve
+   benchmark-specific rubric text in the entry only when the grader needs to
+   read it.
 
 3. Scaffold the evaluator contract.
    For generated tasks:
@@ -114,7 +118,8 @@ Python and shell graders run inside the Harbor verifier context. They may read:
 
 - `/logs/agent/trajectory.json` for agent actions and final answer evidence
 - `/tests/entry.json` for the eval case metadata
-- `/workspace/input/` for committed fixture files from `evals/files/`
+- `/workspace/input/` for the entry's declared committed fixtures from
+  `evals/files/`
 - `/solution/` or other task outputs only when the task environment produces
   them
 
@@ -171,7 +176,8 @@ For a benchmark task with `task.yaml`, `code/`, prompt variants, coverage, and a
 rubric:
 
 1. Copy `code/` into `evals/files/<case-id>/`.
-2. Create one or more `evals/evals.json` entries from the prompt variants.
+2. Create one or more `evals/evals.json` entries from the prompt variants, and
+   set `files: ["evals/files/<case-id>"]` on each corresponding entry.
 3. Set `expected_skill` to the benchmark's target skill.
 4. Implement `evals/grader.py` to inspect the agent trajectory and changed
    workspace files.

--- a/src/skillevaluator/tier3/results_location.py
+++ b/src/skillevaluator/tier3/results_location.py
@@ -12,7 +12,7 @@ from datetime import datetime
 from pathlib import Path
 
 ENV_RESULTS_DIR = "SKILLEVALUATOR_RESULTS_DIR"
-_RUN_TIMESTAMP_FORMATS = ("%Y%m%d_%H%M%S", "%Y-%m-%d_%H%M%S")
+_RUN_TIMESTAMP_FORMATS = (("%Y%m%d_%H%M%S", 15), ("%Y-%m-%d_%H%M%S", 17))
 
 
 def _expand(path: str | Path) -> Path:
@@ -91,9 +91,13 @@ def iter_candidate_results_roots(
 
 
 def _run_timestamp(name: str) -> datetime | None:
-    for timestamp_format in _RUN_TIMESTAMP_FORMATS:
+    for timestamp_format, prefix_length in _RUN_TIMESTAMP_FORMATS:
+        prefix = name[:prefix_length]
+        suffix = name[prefix_length:]
+        if suffix and not suffix.startswith("_"):
+            continue
         try:
-            return datetime.strptime(name, timestamp_format)  # noqa: DTZ007 -- directory names have no timezone
+            return datetime.strptime(prefix, timestamp_format)  # noqa: DTZ007 -- directory names have no timezone
         except ValueError:
             continue
     return None
@@ -106,7 +110,7 @@ def _newest_completed_run(root: Path) -> Path | None:
     except OSError:
         return None
 
-    completed: list[tuple[datetime, Path]] = []
+    completed: list[tuple[datetime, int, str, Path]] = []
     try:
         for candidate in children:
             timestamp = _run_timestamp(candidate.name)
@@ -115,14 +119,16 @@ def _newest_completed_run(root: Path) -> Path | None:
             try:
                 if not candidate.is_dir():
                     continue
-                result = json.loads((candidate / "result.json").read_text(encoding="utf-8"))
+                result_path = candidate / "result.json"
+                result = json.loads(result_path.read_text(encoding="utf-8"))
+                completion_mtime = result_path.stat().st_mtime_ns
             except (FileNotFoundError, json.JSONDecodeError, OSError):
                 continue
             if isinstance(result, dict) and result.get("run_id") == candidate.name:
-                completed.append((timestamp, candidate))
+                completed.append((timestamp, completion_mtime, candidate.name, candidate))
     except OSError:
         return None
-    return max(completed, default=(None, None), key=lambda item: item[0])[1]
+    return max(completed, default=(None, -1, "", None), key=lambda item: (item[0], item[1], item[2]))[3]
 
 
 def resolve_latest_results(

--- a/src/skillevaluator/tier3/results_location.py
+++ b/src/skillevaluator/tier3/results_location.py
@@ -7,9 +7,12 @@ from __future__ import annotations
 
 import json
 import os
+import stat
 import subprocess
+from contextlib import suppress
 from datetime import datetime
 from pathlib import Path
+from uuid import uuid4
 
 ENV_RESULTS_DIR = "SKILLEVALUATOR_RESULTS_DIR"
 _RUN_TIMESTAMP_FORMATS = (("%Y%m%d_%H%M%S", 15), ("%Y-%m-%d_%H%M%S", 17))
@@ -103,32 +106,110 @@ def _run_timestamp(name: str) -> datetime | None:
     return None
 
 
-def _newest_completed_run(root: Path) -> Path | None:
-    """Return the newest complete timestamped run without relying on symlinks."""
+def _path_is_link_or_reparse(path: Path, metadata: os.stat_result) -> bool:
+    """Return whether a result path is a symlink, junction, or reparse point."""
+    reparse_flag = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+    if stat.S_ISLNK(metadata.st_mode) or bool(getattr(metadata, "st_file_attributes", 0) & reparse_flag):
+        return True
+    is_junction = getattr(path, "is_junction", None)
+    if not callable(is_junction):
+        return False
     try:
-        children = root.iterdir()
+        return bool(is_junction())
+    except (OSError, RuntimeError):
+        return True
+
+
+def run_directory_sort_key(
+    candidate: Path,
+    *,
+    require_completed_result: bool = False,
+) -> tuple[datetime, int, str] | None:
+    """Return shared newest-first ordering metadata for a result directory.
+
+    Timestamp-shaped directories are current runs and are visible only after
+    their final ``result.json`` identifies the directory's run id. Historical
+    non-timestamp summary directories remain available to compare workflows.
+    """
+    if candidate.name.startswith((".", "_")) or candidate.name == "latest":
+        return None
+    try:
+        candidate_metadata = candidate.lstat()
+        if _path_is_link_or_reparse(candidate, candidate_metadata) or not stat.S_ISDIR(candidate_metadata.st_mode):
+            return None
     except OSError:
         return None
 
-    completed: list[tuple[datetime, int, str, Path]] = []
+    timestamp = _run_timestamp(candidate.name)
+    is_current_run = timestamp is not None
+    if not is_current_run:
+        if require_completed_result:
+            return None
+        timestamp = datetime.min  # noqa: DTZ901 -- result directory timestamps are intentionally timezone-free
+
+    completed = False
+    completion_mtime = -1
     try:
-        for candidate in children:
-            timestamp = _run_timestamp(candidate.name)
-            if timestamp is None or candidate.name.startswith((".", "_")) or candidate.is_symlink():
-                continue
-            try:
-                if not candidate.is_dir():
-                    continue
-                result_path = candidate / "result.json"
-                result = json.loads(result_path.read_text(encoding="utf-8"))
-                completion_mtime = result_path.stat().st_mtime_ns
-            except (FileNotFoundError, json.JSONDecodeError, OSError):
-                continue
-            if isinstance(result, dict) and result.get("run_id") == candidate.name:
-                completed.append((timestamp, completion_mtime, candidate.name, candidate))
-    except OSError:
+        result_path = candidate / "result.json"
+        before = result_path.lstat()
+        if _path_is_link_or_reparse(result_path, before) or not stat.S_ISREG(before.st_mode) or before.st_nlink != 1:
+            return None
+        result = json.loads(result_path.read_text(encoding="utf-8"))
+        after = result_path.lstat()
+        if (
+            _path_is_link_or_reparse(result_path, after)
+            or not stat.S_ISREG(after.st_mode)
+            or after.st_nlink != 1
+            or (before.st_dev, before.st_ino, before.st_size, before.st_mtime_ns)
+            != (after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns)
+        ):
+            return None
+        completion_mtime = after.st_mtime_ns
+        completed = isinstance(result, dict) and result.get("run_id") == candidate.name
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        pass
+    if (is_current_run or require_completed_result) and not completed:
         return None
-    return max(completed, default=(None, -1, "", None), key=lambda item: (item[0], item[1], item[2]))[3]
+    if not completed:
+        completion_mtime = -1
+    return timestamp, completion_mtime, candidate.name
+
+
+def ordered_run_directories(root: Path, *, completed_only: bool = False) -> list[Path]:
+    """Return result directories in shared newest-first order."""
+    try:
+        candidates = root.iterdir()
+    except OSError:
+        return []
+
+    ordered: list[tuple[tuple[datetime, int, str], Path]] = []
+    try:
+        for candidate in candidates:
+            key = run_directory_sort_key(candidate, require_completed_result=completed_only)
+            if key is not None:
+                ordered.append((key, candidate))
+    except OSError:
+        return []
+    ordered.sort(key=lambda item: item[0], reverse=True)
+    return [candidate for _, candidate in ordered]
+
+
+def _newest_completed_run(root: Path) -> Path | None:
+    """Return the newest complete timestamped run without relying on symlinks."""
+    return next(iter(ordered_run_directories(root, completed_only=True)), None)
+
+
+def publish_latest_results(root: Path, run_id: str) -> bool:
+    """Atomically replace ``latest`` with a relative symlink to ``run_id``."""
+    temporary = root / f".latest-{os.getpid()}-{uuid4().hex}.tmp"
+    try:
+        temporary.symlink_to(run_id)
+        os.replace(temporary, root / "latest")  # noqa: PTH105 -- explicit atomic replacement is the contract
+    except OSError:
+        with suppress(OSError):
+            temporary.unlink()
+        return False
+    return True
 
 
 def resolve_latest_results(
@@ -143,14 +224,36 @@ def resolve_latest_results(
         cli_results_dir,
         environ=environ,
     )
+    first_missing_latest: Path | None = None
     for root in roots:
         latest = root / "latest"
-        if latest.exists():
-            return latest
+        if not os.path.lexists(latest) and first_missing_latest is None:
+            first_missing_latest = latest
+        if latest.is_symlink():
+            try:
+                link_target = latest.readlink()
+                if link_target.is_absolute() or len(link_target.parts) != 1 or link_target.parts[0] in {"", ".", ".."}:
+                    raise ValueError("latest must name one relative run directory")
+                resolved_root = root.resolve(strict=True)
+                target = latest.resolve(strict=True)
+            except (OSError, RuntimeError, ValueError):
+                pass
+            else:
+                if (
+                    link_target.name == target.name
+                    and target.parent == resolved_root
+                    and run_directory_sort_key(target, require_completed_result=True) is not None
+                ):
+                    return latest
         fallback = _newest_completed_run(root)
         if fallback is not None:
             return fallback
-    return roots[0] / "latest"
+    if first_missing_latest is not None:
+        return first_missing_latest
+    while True:
+        unavailable = roots[0] / f".latest-unavailable-{uuid4().hex}"
+        if not os.path.lexists(unavailable):
+            return unavailable
 
 
 def resolve_explicit_or_latest_results(

--- a/src/skillevaluator/tier3/results_location.py
+++ b/src/skillevaluator/tier3/results_location.py
@@ -29,6 +29,12 @@ _RUN_TIMESTAMP_FORMATS = (("%Y%m%d_%H%M%S", 15), ("%Y-%m-%d_%H%M%S", 17))
 # historical summary carries status or attempt coverage, those must be complete.
 _RUN_COMPLETION_ARTIFACTS = ("run_config.json",)
 _FINAL_RESULT_ARTIFACT = "result.json"
+# The writer emits a small enumeration; this generous cap rejects pathological
+# metadata without relying on Python's bounded decimal-to-int conversion.
+_MAX_LEGACY_OCCURRENCE_DIGITS = 32
+# These runtime-owned directories predate canonical run-level ``result.json``;
+# ``staged/`` arrived with that artifact and is intentionally not legacy-safe.
+_LEGACY_RUNTIME_SIDECAR_DIRS = frozenset({"harbor-run-logs", "astra-cleanup"})
 
 
 def _expand(path: str | Path) -> Path:
@@ -218,9 +224,16 @@ def _legacy_run_agents(payload: object) -> tuple[str, ...] | None:
             or not metadata["model"].strip()
             or not isinstance(metadata.get("source"), str)
             or not metadata["source"].strip()
-            or not isinstance(metadata.get("occurrence"), str)
-            or not metadata["occurrence"].isdigit()
-            or int(metadata["occurrence"]) < 1
+            or (
+                "occurrence" in metadata
+                and (
+                    not isinstance(metadata["occurrence"], str)
+                    or not 1 <= len(metadata["occurrence"]) <= _MAX_LEGACY_OCCURRENCE_DIGITS
+                    or not metadata["occurrence"].isascii()
+                    or not metadata["occurrence"].isdigit()
+                    or not any(character != "0" for character in metadata["occurrence"])
+                )
+            )
         ):
             return None
         normalized.append(agent)
@@ -516,6 +529,8 @@ def _legacy_completion_mtime(
             if _path_is_link_or_reparse(child, child_metadata):
                 return None
             if not stat.S_ISDIR(child_metadata.st_mode):
+                continue
+            if child.name in _LEGACY_RUNTIME_SIDECAR_DIRS:
                 continue
             if child.name not in expected_agents:
                 return None

--- a/src/skillevaluator/tier3/results_location.py
+++ b/src/skillevaluator/tier3/results_location.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import json
+import math
 import os
 import stat
 import subprocess
@@ -14,8 +15,20 @@ from datetime import datetime
 from pathlib import Path
 from uuid import uuid4
 
+from skillevaluator.tier3.output_provenance import GENERATED_OUTPUT_MARKER
+from skillevaluator.utils.secure_fs import SecurePathError, SecureRoot
+
 ENV_RESULTS_DIR = "SKILLEVALUATOR_RESULTS_DIR"
+
 _RUN_TIMESTAMP_FORMATS = (("%Y%m%d_%H%M%S", 15), ("%Y-%m-%d_%H%M%S", 17))
+
+# A current completed run carries ``run_config.json`` plus an atomically
+# written ``result.json`` whose run identity matches its directory. Historical
+# runs created before run-level results instead require a usable per-agent
+# summary and must predate the generated-output provenance marker. When a
+# historical summary carries status or attempt coverage, those must be complete.
+_RUN_COMPLETION_ARTIFACTS = ("run_config.json",)
+_FINAL_RESULT_ARTIFACT = "result.json"
 
 
 def _expand(path: str | Path) -> Path:
@@ -94,13 +107,14 @@ def iter_candidate_results_roots(
 
 
 def _run_timestamp(name: str) -> datetime | None:
+    """Parse the timestamp prefix shared by current and legacy run names."""
     for timestamp_format, prefix_length in _RUN_TIMESTAMP_FORMATS:
         prefix = name[:prefix_length]
         suffix = name[prefix_length:]
         if suffix and not suffix.startswith("_"):
             continue
         try:
-            return datetime.strptime(prefix, timestamp_format)  # noqa: DTZ007 -- directory names have no timezone
+            return datetime.strptime(prefix, timestamp_format)  # noqa: DTZ007 -- run names have no timezone
         except ValueError:
             continue
     return None
@@ -120,16 +134,453 @@ def _path_is_link_or_reparse(path: Path, metadata: os.stat_result) -> bool:
         return True
 
 
+def _node_fingerprint(metadata: os.stat_result) -> tuple[int, int, int, int, int, int, int]:
+    """Return the fields that must remain stable while reading an artifact."""
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_mode,
+        metadata.st_nlink,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+    )
+
+
+def _is_single_link_regular(path: Path, metadata: os.stat_result) -> bool:
+    return not _path_is_link_or_reparse(path, metadata) and stat.S_ISREG(metadata.st_mode) and metadata.st_nlink == 1
+
+
+def _read_stable_json(
+    secure_root: SecureRoot,
+    path: Path,
+    before: os.stat_result,
+) -> tuple[object, os.stat_result, bytes] | None:
+    """Read one JSON artifact through the pinned run root."""
+    if not _is_single_link_regular(path, before):
+        return None
+    try:
+        relative_path = path.absolute().relative_to(secure_root.root)
+        raw, opened = secure_root.read_bytes(relative_path, before.st_size, expected=before)
+        after = path.lstat()
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError, OSError, SecurePathError, ValueError):
+        return None
+    if (
+        not _is_single_link_regular(path, after)
+        or _node_fingerprint(opened) != _node_fingerprint(before)
+        or _node_fingerprint(after) != _node_fingerprint(opened)
+        or len(raw) != opened.st_size
+    ):
+        return None
+    return payload, opened, raw
+
+
+def _artifact_snapshot_is_unchanged(
+    secure_root: SecureRoot,
+    snapshot: tuple[Path, bytes, os.stat_result],
+) -> bool:
+    """Re-read one artifact to detect ordinary changes during validation."""
+    path, expected_raw, expected_metadata = snapshot
+    try:
+        current_metadata = path.lstat()
+    except OSError:
+        return False
+    observed = _read_stable_json(secure_root, path, current_metadata)
+    return bool(
+        observed is not None
+        and observed[2] == expected_raw
+        and _node_fingerprint(observed[1]) == _node_fingerprint(expected_metadata)
+    )
+
+
+def _legacy_run_agents(payload: object) -> tuple[str, ...] | None:
+    """Return configured result-agent keys from an authentic historical config."""
+    if not isinstance(payload, dict) or not isinstance(payload.get("harbor"), dict) or not payload["harbor"]:
+        return None
+    if payload.get("task_source") not in {"evals_json", "native_harbor"}:
+        return None
+    agents = payload.get("agents")
+    if not isinstance(agents, dict) or not agents:
+        return None
+    normalized: list[str] = []
+    for agent, metadata in agents.items():
+        if (
+            not isinstance(agent, str)
+            or not agent
+            or agent in {".", ".."}
+            or "/" in agent
+            or "\\" in agent
+            or not isinstance(metadata, dict)
+            or not isinstance(metadata.get("agent"), str)
+            or not metadata["agent"].strip()
+            or not isinstance(metadata.get("model"), str)
+            or not metadata["model"].strip()
+            or not isinstance(metadata.get("source"), str)
+            or not metadata["source"].strip()
+            or not isinstance(metadata.get("occurrence"), str)
+            or not metadata["occurrence"].isdigit()
+            or int(metadata["occurrence"]) < 1
+        ):
+            return None
+        normalized.append(agent)
+    return tuple(sorted(normalized))
+
+
+def _is_finite_number(value: object) -> bool:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return False
+    try:
+        return math.isfinite(value)
+    except OverflowError:
+        return False
+
+
+def _is_nonnegative_int(value: object) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value >= 0
+
+
+def _legacy_pass_at_k_is_complete(
+    payload: object,
+    *,
+    num_trials: int,
+    require_scored_attempt: bool,
+    expected_scored_attempts: int | None = None,
+    allow_coverage_failure: bool = False,
+) -> bool:
+    """Validate the historical collector's complete pass-at-k structure."""
+    if not isinstance(payload, dict):
+        return False
+    k = payload.get("k")
+    threshold = payload.get("pass_threshold")
+    stop_on_pass = payload.get("stop_on_pass")
+    passed_cases = payload.get("passed_cases")
+    failed_cases = payload.get("failed_cases")
+    attempts_used = payload.get("attempts_used")
+    total_cases = payload.get("total_cases")
+    max_attempts = payload.get("max_attempts_possible")
+    rate = payload.get("rate")
+    average_attempts = payload.get("avg_attempts_used")
+    if (
+        not isinstance(k, int)
+        or isinstance(k, bool)
+        or k < 1
+        or not _is_finite_number(threshold)
+        or not 0 <= threshold <= 1
+        or not isinstance(stop_on_pass, bool)
+        or any(not _is_nonnegative_int(value) for value in (passed_cases, failed_cases, attempts_used, max_attempts))
+        or not isinstance(total_cases, int)
+        or isinstance(total_cases, bool)
+        or total_cases < 1
+        or passed_cases + failed_cases != total_cases
+        or max_attempts != total_cases * k
+        or (not allow_coverage_failure and attempts_used > max_attempts)
+        or not _is_finite_number(rate)
+        or not 0 <= rate <= 1
+        or not math.isclose(rate, round(passed_cases / total_cases, 4), abs_tol=1e-9)
+        or not _is_finite_number(average_attempts)
+        or average_attempts < 0
+        or not math.isclose(average_attempts, round(attempts_used / total_cases, 4), abs_tol=1e-9)
+    ):
+        return False
+    extra_cases = payload.get("extra_cases")
+    if (
+        not isinstance(extra_cases, list)
+        or any(not isinstance(case, str) or not case for case in extra_cases)
+        or len(extra_cases) != len(set(extra_cases))
+    ):
+        return False
+    extra_case_names = set(extra_cases)
+    cases = payload.get("cases")
+    if not isinstance(cases, dict) or not cases:
+        return False
+    total_attempt_rows = 0
+    expected_attempt_rows = 0
+    observed_passed_cases = 0
+    observed_expected_cases = 0
+    for case_name, case in cases.items():
+        if not isinstance(case_name, str) or not isinstance(case, dict):
+            return False
+        case_attempts_used = case.get("attempts_used")
+        attempts_skipped = case.get("attempts_skipped")
+        attempts_missing = case.get("attempts_missing")
+        attempts = case.get("attempts")
+        if (
+            not isinstance(case.get("passed"), bool)
+            or not _is_nonnegative_int(case_attempts_used)
+            or not _is_nonnegative_int(attempts_skipped)
+            or not _is_nonnegative_int(attempts_missing)
+            or not isinstance(attempts, list)
+            or len(attempts) != case_attempts_used
+        ):
+            return False
+        first_pass_attempt = case.get("first_pass_attempt")
+        if first_pass_attempt is not None and (
+            not isinstance(first_pass_attempt, int)
+            or isinstance(first_pass_attempt, bool)
+            or first_pass_attempt < 1
+            or first_pass_attempt > len(attempts)
+        ):
+            return False
+        for ordinal, attempt in enumerate(attempts, start=1):
+            if (
+                not isinstance(attempt, dict)
+                or attempt.get("attempt") != ordinal
+                or not isinstance(attempt.get("trial"), str)
+                or not _is_finite_number(attempt.get("score"))
+                or not isinstance(attempt.get("passed"), bool)
+            ):
+                return False
+            score = attempt.get("score")
+            if attempt["passed"] != (score >= threshold):
+                return False
+        passing_ordinals = [ordinal for ordinal, attempt in enumerate(attempts, start=1) if attempt["passed"]]
+        expected_first_pass = passing_ordinals[0] if passing_ordinals else None
+        attempt_scores = [attempt["score"] for attempt in attempts]
+        expected_best_score = max(attempt_scores) if attempt_scores else None
+        best_score = case.get("best_score")
+        if (
+            case["passed"] != bool(passing_ordinals)
+            or first_pass_attempt != expected_first_pass
+            or (
+                (expected_best_score is None and best_score is not None)
+                or (
+                    expected_best_score is not None
+                    and (
+                        not _is_finite_number(best_score)
+                        or not math.isclose(best_score, expected_best_score, abs_tol=1e-9)
+                    )
+                )
+            )
+        ):
+            return False
+        total_attempt_rows += len(attempts)
+        if case_name not in extra_case_names:
+            observed_expected_cases += 1
+            observed_passed_cases += int(case["passed"])
+            expected_attempt_rows += len(attempts)
+            if not allow_coverage_failure and case_attempts_used + attempts_skipped + attempts_missing != k:
+                return False
+        elif case.get("extra_case") is not True:
+            return False
+    return (
+        extra_case_names.issubset(cases)
+        and observed_expected_cases == total_cases
+        and observed_passed_cases == passed_cases
+        and expected_attempt_rows == attempts_used
+        and total_attempt_rows <= num_trials
+        and (expected_scored_attempts is None or total_attempt_rows == expected_scored_attempts)
+        and (not require_scored_attempt or total_attempt_rows > 0)
+    )
+
+
+def _legacy_dimensions_are_valid(payload: object) -> bool:
+    if not isinstance(payload, dict):
+        return False
+    for name, dimension in payload.items():
+        if (
+            not isinstance(name, str)
+            or not isinstance(dimension, dict)
+            or not _is_finite_number(dimension.get("score"))
+        ):
+            return False
+        sources = dimension.get("sources")
+        if not isinstance(sources, dict) or any(
+            not isinstance(source, str) or not _is_finite_number(weight) for source, weight in sources.items()
+        ):
+            return False
+    return True
+
+
+def _legacy_summary_is_complete(payload: object, *, expected_agent: str) -> bool:
+    """Return whether a pre-result summary satisfies an authentic era schema."""
+    if not isinstance(payload, dict):
+        return False
+    if payload.get("agent") != expected_agent:
+        return False
+    if (
+        not isinstance(payload.get("model"), str)
+        or not payload["model"].strip()
+        or not isinstance(payload.get("model_source"), str)
+        or not payload["model_source"].strip()
+    ):
+        return False
+    metric_set = payload.get("metric_set")
+    metrics = payload.get("metrics")
+    if not isinstance(metric_set, str) or not metric_set or not isinstance(metrics, list):
+        return False
+    if any(not isinstance(metric, str) or not metric for metric in metrics) or not _legacy_dimensions_are_valid(
+        payload.get("dimensions")
+    ):
+        return False
+
+    num_trials = payload.get("num_trials")
+    if not _is_nonnegative_int(num_trials):
+        return False
+
+    completion_fields = {
+        "execution_status",
+        "execution_errors",
+        "expected_attempts",
+        "scored_attempts",
+        "job_failure",
+        "trial_failures",
+    }
+    present_completion_fields = completion_fields.intersection(payload)
+    scored_attempts: int | None = None
+    if present_completion_fields and present_completion_fields != completion_fields:
+        return False
+    if present_completion_fields:
+        execution_status = payload.get("execution_status")
+        execution_errors = payload.get("execution_errors")
+        job_failure = payload.get("job_failure")
+        trial_failures = payload.get("trial_failures")
+        if (
+            execution_status not in {"succeeded", "failed"}
+            or not isinstance(execution_errors, list)
+            or any(not isinstance(error, str) or not error for error in execution_errors)
+            or not isinstance(job_failure, str)
+            or not isinstance(trial_failures, list)
+            or any(not isinstance(failure, dict) for failure in trial_failures)
+        ):
+            return False
+        expected_attempts = payload.get("expected_attempts")
+        scored_attempts = payload.get("scored_attempts")
+        if not _is_nonnegative_int(expected_attempts) or not _is_nonnegative_int(scored_attempts):
+            return False
+        if execution_status == "succeeded" and (
+            execution_errors
+            or job_failure
+            or trial_failures
+            or expected_attempts < 1
+            or scored_attempts != expected_attempts
+        ):
+            return False
+        if execution_status == "failed" and not execution_errors:
+            return False
+    elif num_trials < 1:
+        return False
+
+    scores = payload.get("scores")
+    custom_scores = payload.get("custom_scores")
+    if not isinstance(scores, dict) or not isinstance(custom_scores, dict):
+        return False
+    for score_group in (scores, custom_scores):
+        for value in score_group.values():
+            if isinstance(value, bool) or not isinstance(value, int | float):
+                return False
+            try:
+                if not math.isfinite(value):
+                    return False
+            except OverflowError:
+                return False
+    if scores and any(metric not in metrics for metric in scores):
+        return False
+    status = payload.get("execution_status")
+    require_scored_attempt = status != "failed"
+    if not _legacy_pass_at_k_is_complete(
+        payload.get("pass_at_k"),
+        num_trials=num_trials,
+        require_scored_attempt=require_scored_attempt,
+        expected_scored_attempts=scored_attempts,
+        allow_coverage_failure=status == "failed",
+    ):
+        return False
+    if status == "failed":
+        return True
+    return bool(scores or custom_scores) or (metric_set == "custom-only" and metrics == [])
+
+
+def _legacy_completion_mtime(
+    candidate: Path,
+    secure_root: SecureRoot,
+    snapshots: list[tuple[Path, bytes, os.stat_result]],
+    expected_agents: tuple[str, ...],
+) -> int | None:
+    """Return completion time for an unmarked pre-result run, if safely readable."""
+    marker = candidate / GENERATED_OUTPUT_MARKER
+    if os.path.lexists(marker):
+        # Current runs are marked before any evaluation artifact is written.
+        # Any marker presence, including a corrupt marker, prevents an
+        # incomplete current run from downgrading into the legacy contract.
+        return None
+
+    completion_mtimes: list[int] = []
+    try:
+        children = sorted(candidate.iterdir(), key=lambda path: path.name)
+        agent_dirs: dict[str, Path] = {}
+        for child in children:
+            if child.name.startswith("_"):
+                continue
+            child_metadata = child.lstat()
+            if _path_is_link_or_reparse(child, child_metadata):
+                return None
+            if not stat.S_ISDIR(child_metadata.st_mode):
+                continue
+            if child.name not in expected_agents:
+                return None
+            agent_dirs[child.name] = child
+
+        if set(agent_dirs) != set(expected_agents):
+            return None
+
+        for agent_name in expected_agents:
+            agent_dir = agent_dirs[agent_name]
+
+            condition_dir = agent_dir / "with-skill"
+            if os.path.lexists(condition_dir):
+                condition_metadata = condition_dir.lstat()
+                if _path_is_link_or_reparse(condition_dir, condition_metadata):
+                    return None
+                if not stat.S_ISDIR(condition_metadata.st_mode):
+                    return None
+            nested_summary = condition_dir / "summary.json"
+            flat_summary = agent_dir / "summary.json"
+            summary_paths = [path for path in (nested_summary, flat_summary) if os.path.lexists(path)]
+            if len(summary_paths) != 1:
+                return None
+
+            baseline_dir = agent_dir / "without-skill"
+            if os.path.lexists(baseline_dir):
+                baseline_metadata = baseline_dir.lstat()
+                if _path_is_link_or_reparse(baseline_dir, baseline_metadata) or not stat.S_ISDIR(
+                    baseline_metadata.st_mode
+                ):
+                    return None
+                baseline_summary = baseline_dir / "summary.json"
+                if not os.path.lexists(baseline_summary):
+                    return None
+                summary_paths.append(baseline_summary)
+
+            for summary_path in summary_paths:
+                summary_metadata = summary_path.lstat()
+                if not _is_single_link_regular(summary_path, summary_metadata):
+                    return None
+                observed = _read_stable_json(secure_root, summary_path, summary_metadata)
+                if observed is None or not _legacy_summary_is_complete(observed[0], expected_agent=agent_name):
+                    return None
+                snapshots.append((summary_path, observed[2], observed[1]))
+                completion_mtimes.append(observed[1].st_mtime_ns)
+    except OSError:
+        return None
+
+    if os.path.lexists(marker):
+        return None
+    return max(completion_mtimes, default=None)
+
+
 def run_directory_sort_key(
     candidate: Path,
     *,
     require_completed_result: bool = False,
 ) -> tuple[datetime, int, str] | None:
-    """Return shared newest-first ordering metadata for a result directory.
+    """Return shared ordering metadata for one result directory.
 
-    Timestamp-shaped directories are current runs and are visible only after
-    their final ``result.json`` identifies the directory's run id. Historical
-    non-timestamp summary directories remain available to compare workflows.
+    Timestamped runs are accepted when they carry either a valid final result
+    matching the directory's run ID or the stricter pre-result legacy contract,
+    and are ordered by parsed timestamp, completion mtime, then name. Compare
+    also keeps accepting summary-only non-timestamp directories, placing them
+    behind timestamped runs.
     """
     if candidate.name.startswith((".", "_")) or candidate.name == "latest":
         return None
@@ -141,37 +592,57 @@ def run_directory_sort_key(
         return None
 
     timestamp = _run_timestamp(candidate.name)
-    is_current_run = timestamp is not None
-    if not is_current_run:
+    if timestamp is None:
         if require_completed_result:
             return None
-        timestamp = datetime.min  # noqa: DTZ901 -- result directory timestamps are intentionally timezone-free
+        return datetime.min, -1, candidate.name  # noqa: DTZ901 -- legacy names have no timezone
 
-    completed = False
-    completion_mtime = -1
     try:
-        result_path = candidate / "result.json"
-        before = result_path.lstat()
-        if _path_is_link_or_reparse(result_path, before) or not stat.S_ISREG(before.st_mode) or before.st_nlink != 1:
+        snapshots: list[tuple[Path, bytes, os.stat_result]] = []
+        with SecureRoot(candidate, expected=candidate_metadata) as secure_root:
+            run_config_path = candidate / _RUN_COMPLETION_ARTIFACTS[0]
+            run_config_metadata = run_config_path.lstat()
+            observed_run_config = _read_stable_json(secure_root, run_config_path, run_config_metadata)
+            if observed_run_config is None or not isinstance(observed_run_config[0], dict):
+                return None
+            snapshots.append((run_config_path, observed_run_config[2], observed_run_config[1]))
+
+            result_path = candidate / _FINAL_RESULT_ARTIFACT
+            try:
+                result_metadata = result_path.lstat()
+            except FileNotFoundError:
+                expected_agents = _legacy_run_agents(observed_run_config[0])
+                if expected_agents is None:
+                    return None
+                legacy_completion_mtime = _legacy_completion_mtime(
+                    candidate,
+                    secure_root,
+                    snapshots,
+                    expected_agents,
+                )
+                if legacy_completion_mtime is None:
+                    return None
+                completion_mtime = max(legacy_completion_mtime, observed_run_config[1].st_mtime_ns)
+            else:
+                observed_result = _read_stable_json(secure_root, result_path, result_metadata)
+                if observed_result is None:
+                    return None
+                result = observed_result[0]
+                if not isinstance(result, dict) or result.get("run_id") != candidate.name:
+                    return None
+                snapshots.append((result_path, observed_result[2], observed_result[1]))
+                completion_mtime = observed_result[1].st_mtime_ns
+
+            if not all(_artifact_snapshot_is_unchanged(secure_root, snapshot) for snapshot in snapshots):
+                return None
+
+        candidate_after = candidate.lstat()
+        if _path_is_link_or_reparse(candidate, candidate_after) or _node_fingerprint(
+            candidate_after
+        ) != _node_fingerprint(candidate_metadata):
             return None
-        result = json.loads(result_path.read_text(encoding="utf-8"))
-        after = result_path.lstat()
-        if (
-            _path_is_link_or_reparse(result_path, after)
-            or not stat.S_ISREG(after.st_mode)
-            or after.st_nlink != 1
-            or (before.st_dev, before.st_ino, before.st_size, before.st_mtime_ns)
-            != (after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns)
-        ):
-            return None
-        completion_mtime = after.st_mtime_ns
-        completed = isinstance(result, dict) and result.get("run_id") == candidate.name
-    except (FileNotFoundError, json.JSONDecodeError, OSError):
-        pass
-    if (is_current_run or require_completed_result) and not completed:
+    except (OSError, SecurePathError):
         return None
-    if not completed:
-        completion_mtime = -1
     return timestamp, completion_mtime, candidate.name
 
 
@@ -194,8 +665,35 @@ def ordered_run_directories(root: Path, *, completed_only: bool = False) -> list
     return [candidate for _, candidate in ordered]
 
 
-def _newest_completed_run(root: Path) -> Path | None:
-    """Return the newest complete timestamped run without relying on symlinks."""
+def _is_completed_run_dir(path: Path) -> bool:
+    """Return whether ``path`` is a *completed* timestamped run directory.
+
+    A candidate must match the run-name timestamp pattern, carry its run
+    configuration, and satisfy either the current final-result contract or the
+    pre-result legacy-summary contract. This keeps the symlink-less fallback in
+    :func:`resolve_latest_results` from resolving aborted/empty runs,
+    ``_harbor-*`` staging dirs, ``astra-cleanup``, or the ``<plugin>-plugin-eval``
+    wrapper directory (MR !29 review 59316310).
+    """
+    return run_directory_sort_key(path, require_completed_result=True) is not None
+
+
+def is_legacy_completed_run_dir(path: Path) -> bool:
+    """Return whether ``path`` satisfies the authenticated pre-result contract."""
+    if _run_timestamp(path.name) is None:
+        return False
+    if os.path.lexists(path / _FINAL_RESULT_ARTIFACT) or os.path.lexists(path / GENERATED_OUTPUT_MARKER):
+        return False
+    return run_directory_sort_key(path, require_completed_result=True) is not None
+
+
+def _newest_run_dir(root: Path) -> Path | None:
+    """Return the newest *completed* timestamped run directory under ``root``.
+
+    This is the cross-platform fallback for when the ``latest`` symlink was
+    never created. Only completed runs are considered, with same-second runs
+    ordered by their completion artifact mtime and then deterministic name.
+    """
     return next(iter(ordered_run_directories(root, completed_only=True)), None)
 
 
@@ -204,11 +702,12 @@ def publish_latest_results(root: Path, run_id: str) -> bool:
     temporary = root / f".latest-{os.getpid()}-{uuid4().hex}.tmp"
     try:
         temporary.symlink_to(run_id)
-        os.replace(temporary, root / "latest")  # noqa: PTH105 -- explicit atomic replacement is the contract
+        os.replace(temporary, root / "latest")  # noqa: PTH105 -- atomic replacement is the contract
     except OSError:
+        return False
+    finally:
         with suppress(OSError):
             temporary.unlink()
-        return False
     return True
 
 
@@ -218,42 +717,52 @@ def resolve_latest_results(
     *,
     environ: dict[str, str] | None = None,
 ) -> Path:
-    """Return the best available ``latest`` results path for read workflows."""
+    """Return the best available ``latest`` results path for read workflows.
+
+    Prefers each root's valid ``latest`` symlink. The link must resolve to an
+    immediate, completed child of that root. When it is absent or invalid
+    (including native Windows where symlink creation is not permitted), falls
+    back to the newest completed timestamped run directory.
+    """
     roots = iter_candidate_results_roots(
         skill_path,
         cli_results_dir,
         environ=environ,
     )
-    first_missing_latest: Path | None = None
+    first_absent_latest: Path | None = None
     for root in roots:
-        latest = root / "latest"
-        if not os.path.lexists(latest) and first_missing_latest is None:
-            first_missing_latest = latest
-        if latest.is_symlink():
+        candidate = root / "latest"
+        if not os.path.lexists(candidate) and first_absent_latest is None:
+            first_absent_latest = candidate
+        if candidate.is_symlink():
             try:
-                link_target = latest.readlink()
-                if link_target.is_absolute() or len(link_target.parts) != 1 or link_target.parts[0] in {"", ".", ".."}:
-                    raise ValueError("latest must name one relative run directory")
+                link_target = candidate.readlink()
                 resolved_root = root.resolve(strict=True)
-                target = latest.resolve(strict=True)
-            except (OSError, RuntimeError, ValueError):
+                target = candidate.resolve(strict=True)
+            except (OSError, RuntimeError):
                 pass
             else:
                 if (
-                    link_target.name == target.name
+                    not link_target.is_absolute()
+                    and len(link_target.parts) == 1
+                    and link_target.name == target.name
                     and target.parent == resolved_root
-                    and run_directory_sort_key(target, require_completed_result=True) is not None
+                    and _is_completed_run_dir(target)
                 ):
-                    return latest
-        fallback = _newest_completed_run(root)
-        if fallback is not None:
-            return fallback
-    if first_missing_latest is not None:
-        return first_missing_latest
+                    return candidate
+        newest = _newest_run_dir(root)
+        if newest is not None:
+            return newest
+    if first_absent_latest is not None:
+        return first_absent_latest
+    # Never hand an invalid existing ``latest`` entry back to callers: most
+    # immediately test ``exists()`` or resolve symlinks and would otherwise
+    # consume the very directory/link rejected above. A unique non-existent
+    # path preserves the historical Path-returning API and its absence check.
     while True:
-        unavailable = roots[0] / f".latest-unavailable-{uuid4().hex}"
-        if not os.path.lexists(unavailable):
-            return unavailable
+        unresolved = roots[0] / f".latest-unavailable-{uuid4().hex}"
+        if not os.path.lexists(unresolved):
+            return unresolved
 
 
 def resolve_explicit_or_latest_results(

--- a/src/skillevaluator/tier3/results_location.py
+++ b/src/skillevaluator/tier3/results_location.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import json
 import math
 import os
+import re
 import stat
 import subprocess
 from contextlib import suppress
@@ -15,12 +16,16 @@ from datetime import datetime
 from pathlib import Path
 from uuid import uuid4
 
-from skillevaluator.tier3.output_provenance import GENERATED_OUTPUT_MARKER
+from skillevaluator.tier3.output_provenance import GENERATED_OUTPUT_MARKER, is_generated_output_root
 from skillevaluator.utils.secure_fs import SecurePathError, SecureRoot
 
 ENV_RESULTS_DIR = "SKILLEVALUATOR_RESULTS_DIR"
 
 _RUN_TIMESTAMP_FORMATS = (("%Y%m%d_%H%M%S", 15), ("%Y-%m-%d_%H%M%S", 17))
+# Pre-provenance releases emitted exact timestamp names. The collision-safe
+# PID/UUID suffix and run-level marker were introduced together, so a suffix is
+# a reliable format boundary and must never fall back to the historical parser.
+_CURRENT_RUN_SUFFIX = re.compile(r"_[1-9][0-9]{0,19}_[0-9a-f]{12}\Z")
 
 # A current completed run carries ``run_config.json`` plus an atomically
 # written ``result.json`` whose run identity matches its directory. Historical
@@ -32,6 +37,10 @@ _FINAL_RESULT_ARTIFACT = "result.json"
 # The writer emits a small enumeration; this generous cap rejects pathological
 # metadata without relying on Python's bounded decimal-to-int conversion.
 _MAX_LEGACY_OCCURRENCE_DIGITS = 32
+_CURRENT_BASE_IMAGE_MODES = frozenset({"reuse", "rebuild", "disabled"})
+_CURRENT_GRADING_MODES = frozenset({"default", "default_plus_custom", "custom_only"})
+_CURRENT_EXECUTION_STATUSES = frozenset({"succeeded", "failed", "skipped"})
+_PATH_DESCRIPTOR_IDENTITIES_COMPARABLE = os.name == "posix"
 # These runtime-owned directories predate canonical run-level ``result.json``;
 # ``staged/`` arrived with that artifact and is intentionally not legacy-safe.
 _LEGACY_RUNTIME_SIDECAR_DIRS = frozenset({"harbor-run-logs", "astra-cleanup"})
@@ -112,18 +121,25 @@ def iter_candidate_results_roots(
     return roots
 
 
-def _run_timestamp(name: str) -> datetime | None:
-    """Parse the timestamp prefix shared by current and legacy run names."""
+def _run_timestamp_parts(name: str) -> tuple[datetime, str] | None:
+    """Parse a supported run timestamp and return its remaining suffix."""
     for timestamp_format, prefix_length in _RUN_TIMESTAMP_FORMATS:
         prefix = name[:prefix_length]
         suffix = name[prefix_length:]
         if suffix and not suffix.startswith("_"):
             continue
         try:
-            return datetime.strptime(prefix, timestamp_format)  # noqa: DTZ007 -- run names have no timezone
+            timestamp = datetime.strptime(prefix, timestamp_format)  # noqa: DTZ007 -- run names have no timezone
         except ValueError:
             continue
+        return timestamp, suffix
     return None
+
+
+def _run_timestamp(name: str) -> datetime | None:
+    """Parse the timestamp prefix shared by current and legacy run names."""
+    parsed = _run_timestamp_parts(name)
+    return parsed[0] if parsed is not None else None
 
 
 def _path_is_link_or_reparse(path: Path, metadata: os.stat_result) -> bool:
@@ -157,27 +173,52 @@ def _is_single_link_regular(path: Path, metadata: os.stat_result) -> bool:
     return not _path_is_link_or_reparse(path, metadata) and stat.S_ISREG(metadata.st_mode) and metadata.st_nlink == 1
 
 
-def _read_stable_json(
+def _read_stable_bytes(
     secure_root: SecureRoot,
     path: Path,
     before: os.stat_result,
-) -> tuple[object, os.stat_result, bytes] | None:
-    """Read one JSON artifact through the pinned run root."""
+) -> tuple[os.stat_result, bytes] | None:
+    """Read one regular artifact through the pinned run root."""
     if not _is_single_link_regular(path, before):
         return None
     try:
         relative_path = path.absolute().relative_to(secure_root.root)
         raw, opened = secure_root.read_bytes(relative_path, before.st_size, expected=before)
         after = path.lstat()
-        payload = json.loads(raw.decode("utf-8"))
-    except (UnicodeDecodeError, json.JSONDecodeError, OSError, SecurePathError, ValueError):
+    except (OSError, SecurePathError, ValueError):
         return None
-    if (
-        not _is_single_link_regular(path, after)
-        or _node_fingerprint(opened) != _node_fingerprint(before)
-        or _node_fingerprint(after) != _node_fingerprint(opened)
-        or len(raw) != opened.st_size
-    ):
+    if not _is_single_link_regular(path, after) or len(raw) != opened.st_size:
+        return None
+    if _PATH_DESCRIPTOR_IDENTITIES_COMPARABLE:
+        if _node_fingerprint(opened) != _node_fingerprint(before) or _node_fingerprint(after) != _node_fingerprint(
+            opened
+        ):
+            return None
+        stable_metadata = opened
+    else:
+        # Windows path ``lstat`` and CRT descriptor ``fstat`` expose
+        # incompatible identity fields. ``SecureRoot._open_windows`` pins the
+        # native handle and validates the declared name before the read, so the
+        # caller completes that proof with same-family path snapshots here.
+        if _node_fingerprint(after) != _node_fingerprint(before) or len(raw) != after.st_size:
+            return None
+        stable_metadata = after
+    return stable_metadata, raw
+
+
+def _read_stable_json(
+    secure_root: SecureRoot,
+    path: Path,
+    before: os.stat_result,
+) -> tuple[object, os.stat_result, bytes] | None:
+    """Read one JSON artifact through the pinned run root."""
+    observed = _read_stable_bytes(secure_root, path, before)
+    if observed is None:
+        return None
+    opened, raw = observed
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
         return None
     return payload, opened, raw
 
@@ -192,11 +233,156 @@ def _artifact_snapshot_is_unchanged(
         current_metadata = path.lstat()
     except OSError:
         return False
-    observed = _read_stable_json(secure_root, path, current_metadata)
+    observed = _read_stable_bytes(secure_root, path, current_metadata)
     return bool(
         observed is not None
-        and observed[2] == expected_raw
-        and _node_fingerprint(observed[1]) == _node_fingerprint(expected_metadata)
+        and observed[1] == expected_raw
+        and _node_fingerprint(observed[0]) == _node_fingerprint(expected_metadata)
+    )
+
+
+def _recorded_path_matches(recorded: object, expected: Path) -> bool:
+    """Match absolute paths canonically and relative paths by safe suffix."""
+    if not isinstance(recorded, str) or not recorded:
+        return False
+    try:
+        recorded_path = Path(recorded).expanduser()
+        expected_path = expected.expanduser().resolve(strict=False)
+    except (OSError, RuntimeError):
+        return False
+    if recorded_path.is_absolute():
+        try:
+            return recorded_path.resolve(strict=False) == expected_path
+        except (OSError, RuntimeError):
+            return False
+    if not recorded_path.parts or any(part == ".." for part in recorded_path.parts):
+        return False
+    recorded_parts = tuple(os.path.normcase(part) for part in recorded_path.parts if part != ".")
+    expected_parts = tuple(os.path.normcase(part) for part in expected_path.parts)
+    return (
+        bool(recorded_parts)
+        and len(recorded_parts) <= len(expected_parts)
+        and expected_parts[-len(recorded_parts) :] == recorded_parts
+    )
+
+
+def _is_non_bool_int(value: object, *, minimum: int = 0) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value >= minimum
+
+
+def _is_finite_number(value: object, *, minimum: float | None = None, maximum: float | None = None) -> bool:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return False
+    try:
+        numeric = float(value)
+    except (OverflowError, ValueError):
+        return False
+    if not math.isfinite(numeric):
+        return False
+    return (minimum is None or numeric >= minimum) and (maximum is None or numeric <= maximum)
+
+
+def _is_string_list(value: object) -> bool:
+    return isinstance(value, list) and all(isinstance(item, str) for item in value)
+
+
+def _score_mapping_is_valid(value: object) -> bool:
+    return isinstance(value, dict) and all(
+        isinstance(metric, str) and bool(metric) and _is_finite_number(score) for metric, score in value.items()
+    )
+
+
+def _current_agent_result_is_valid(
+    candidate: Path,
+    agent: str,
+    configured: dict[object, object],
+    payload: object,
+) -> bool:
+    if not isinstance(payload, dict):
+        return False
+    model = configured.get("model")
+    source = configured.get("source")
+    model_resolution = payload.get("model_resolution")
+    if (
+        payload.get("model") != model
+        or payload.get("model_source") != source
+        or not isinstance(model_resolution, dict)
+        or model_resolution.get("model") != model
+        or model_resolution.get("source") != source
+    ):
+        return False
+    for field in ("with_skill", "without_skill", "custom_with_skill", "custom_without_skill"):
+        if not _score_mapping_is_valid(payload.get(field)):
+            return False
+    for field in (
+        "dimensions_with_skill",
+        "dimensions_without_skill",
+        "lift",
+        "custom_lift",
+        "security_attribution",
+        "conditions",
+    ):
+        if not isinstance(payload.get(field), dict):
+            return False
+    pass_at_k = payload.get("pass_at_k")
+    if not isinstance(pass_at_k, dict) or any(
+        not isinstance(pass_at_k.get(condition), dict) for condition in ("with_skill", "without_skill", "lift")
+    ):
+        return False
+    for field in ("agent_runtime_failures", "trial_failures"):
+        failures = payload.get(field)
+        if not isinstance(failures, dict) or any(
+            not isinstance(failures.get(condition), list) for condition in ("with_skill", "without_skill")
+        ):
+            return False
+    job_failures = payload.get("job_failures")
+    if not isinstance(job_failures, dict) or any(
+        not isinstance(job_failures.get(condition), str) for condition in ("with_skill", "without_skill")
+    ):
+        return False
+    if payload.get("execution_status") not in _CURRENT_EXECUTION_STATUSES or not _is_string_list(
+        payload.get("execution_errors")
+    ):
+        return False
+    if any(
+        not _is_non_bool_int(payload.get(field))
+        for field in ("expected_attempts", "scored_attempts", "num_trials_with", "num_trials_without")
+    ):
+        return False
+    return _recorded_path_matches(payload.get("output_dir"), candidate / agent)
+
+
+def _current_result_identity_is_valid(candidate: Path, run_config: dict[object, object], result: object) -> bool:
+    """Validate identities emitted together for an authenticated current run."""
+    if not isinstance(result, dict) or result.get("run_id") != candidate.name or result.get("run_config") != run_config:
+        return False
+    configured_agents = _current_run_config_agents(run_config)
+    result_agents = result.get("agents")
+    if configured_agents is None or not isinstance(result_agents, dict) or set(result_agents) != set(configured_agents):
+        return False
+    if not all(
+        _current_agent_result_is_valid(candidate, agent, configured_agents[agent], result_agents[agent])
+        for agent in configured_agents
+    ):
+        return False
+    attempt_policy = result.get("attempt_policy")
+    if (
+        not isinstance(result.get("skill_name"), str)
+        or not result["skill_name"]
+        or result.get("execution_status") not in _CURRENT_EXECUTION_STATUSES
+        or not _is_string_list(result.get("execution_errors"))
+        or result.get("report_status") not in {"complete", "degraded"}
+        or not _is_finite_number(result.get("duration_seconds"), minimum=0)
+        or not isinstance(attempt_policy, dict)
+        or not _is_non_bool_int(attempt_policy.get("max_attempts"), minimum=1)
+        or not _is_finite_number(attempt_policy.get("pass_threshold"), minimum=0, maximum=1)
+        or not isinstance(attempt_policy.get("stop_on_pass"), bool)
+        or not isinstance(attempt_policy.get("score_definition"), str)
+        or not attempt_policy["score_definition"]
+    ):
+        return False
+    return _recorded_path_matches(result.get("run_dir"), candidate) and _recorded_path_matches(
+        result.get("result_path"), candidate / _FINAL_RESULT_ARTIFACT
     )
 
 
@@ -240,13 +426,53 @@ def _legacy_run_agents(payload: object) -> tuple[str, ...] | None:
     return tuple(sorted(normalized))
 
 
-def _is_finite_number(value: object) -> bool:
-    if isinstance(value, bool) or not isinstance(value, int | float):
-        return False
-    try:
-        return math.isfinite(value)
-    except OverflowError:
-        return False
+def _current_run_config_agents(payload: object) -> dict[str, dict[object, object]] | None:
+    """Return agent metadata only for the complete current runner config schema."""
+    expected_agents = _legacy_run_agents(payload)
+    if expected_agents is None or not isinstance(payload, dict):
+        return None
+    config_file = payload.get("config_file")
+    harbor = payload.get("harbor")
+    provider = payload.get("provider")
+    grading = payload.get("grading")
+    agents = payload.get("agents")
+    if (
+        not isinstance(config_file, str)
+        or not config_file
+        or not isinstance(harbor, dict)
+        or not isinstance(provider, dict)
+        or not isinstance(grading, dict)
+        or not isinstance(agents, dict)
+    ):
+        return None
+    environment = harbor.get("environment")
+    if (
+        not isinstance(environment, dict)
+        or not isinstance(environment.get("value"), str)
+        or not environment["value"]
+        or not isinstance(environment.get("source"), str)
+        or not environment["source"]
+        or not _is_non_bool_int(harbor.get("n_attempts"), minimum=1)
+        or not isinstance(harbor.get("stop_on_pass"), bool)
+        or not _is_non_bool_int(harbor.get("n_concurrent"), minimum=1)
+        or not _is_finite_number(harbor.get("timeout_multiplier"), minimum=0)
+        or harbor.get("timeout_multiplier") == 0
+        or harbor.get("base_image_mode") not in _CURRENT_BASE_IMAGE_MODES
+        or not isinstance(harbor.get("jobs_retained"), bool)
+        or not isinstance(provider.get("name"), str)
+        or not provider["name"]
+        or not isinstance(provider.get("model"), str)
+        or not provider["model"]
+        or grading.get("mode") not in _CURRENT_GRADING_MODES
+    ):
+        return None
+    normalized: dict[str, dict[object, object]] = {}
+    for agent in expected_agents:
+        metadata = agents.get(agent)
+        if not isinstance(metadata, dict) or metadata.get("agent") != agent:
+            return None
+        normalized[agent] = metadata
+    return normalized
 
 
 def _is_nonnegative_int(value: object) -> bool:
@@ -591,11 +817,11 @@ def run_directory_sort_key(
 ) -> tuple[datetime, int, str] | None:
     """Return shared ordering metadata for one result directory.
 
-    Timestamped runs are accepted when they carry either a valid final result
-    matching the directory's run ID or the stricter pre-result legacy contract,
-    and are ordered by parsed timestamp, completion mtime, then name. Compare
-    also keeps accepting summary-only non-timestamp directories, placing them
-    behind timestamped runs.
+    Exact-timestamp historical runs retain the prior result or pre-result
+    summary contracts. Collision-safe suffixed runs require their path-bound
+    generated-output marker plus matching result/config identities. Accepted
+    runs are ordered by parsed timestamp, completion mtime, then name. Compare
+    also keeps summary-only non-timestamp directories behind timestamped runs.
     """
     if candidate.name.startswith((".", "_")) or candidate.name == "latest":
         return None
@@ -606,15 +832,27 @@ def run_directory_sort_key(
     except OSError:
         return None
 
-    timestamp = _run_timestamp(candidate.name)
-    if timestamp is None:
+    parsed_run_name = _run_timestamp_parts(candidate.name)
+    if parsed_run_name is None:
         if require_completed_result:
             return None
         return datetime.min, -1, candidate.name  # noqa: DTZ901 -- legacy names have no timezone
+    timestamp, suffix = parsed_run_name
+    is_current_run = bool(suffix)
+    if is_current_run and _CURRENT_RUN_SUFFIX.fullmatch(suffix) is None:
+        return None
 
     try:
         snapshots: list[tuple[Path, bytes, os.stat_result]] = []
         with SecureRoot(candidate, expected=candidate_metadata) as secure_root:
+            if is_current_run:
+                marker_path = candidate / GENERATED_OUTPUT_MARKER
+                marker_metadata = marker_path.lstat()
+                observed_marker = _read_stable_bytes(secure_root, marker_path, marker_metadata)
+                if observed_marker is None or not is_generated_output_root(candidate):
+                    return None
+                snapshots.append((marker_path, observed_marker[1], observed_marker[0]))
+
             run_config_path = candidate / _RUN_COMPLETION_ARTIFACTS[0]
             run_config_metadata = run_config_path.lstat()
             observed_run_config = _read_stable_json(secure_root, run_config_path, run_config_metadata)
@@ -643,7 +881,10 @@ def run_directory_sort_key(
                 if observed_result is None:
                     return None
                 result = observed_result[0]
-                if not isinstance(result, dict) or result.get("run_id") != candidate.name:
+                if is_current_run:
+                    if not _current_result_identity_is_valid(candidate, observed_run_config[0], result):
+                        return None
+                elif not isinstance(result, dict) or result.get("run_id") != candidate.name:
                     return None
                 snapshots.append((result_path, observed_result[2], observed_result[1]))
                 completion_mtime = observed_result[1].st_mtime_ns
@@ -656,7 +897,7 @@ def run_directory_sort_key(
             candidate_after
         ) != _node_fingerprint(candidate_metadata):
             return None
-    except (OSError, SecurePathError):
+    except (OSError, SecurePathError, ValueError):
         return None
     return timestamp, completion_mtime, candidate.name
 

--- a/src/skillevaluator/utils/secure_fs.py
+++ b/src/skillevaluator/utils/secure_fs.py
@@ -259,7 +259,12 @@ class SecureRoot:
 
         try:
             opened = os.fstat(descriptor)
-            _validate_opened_file(opened, relative_path, expected)
+            # Windows path stat and CRT descriptor stat do not expose a
+            # reliably comparable st_dev/st_ino pair. _open_windows rechecks
+            # the declared name with path lstat around its native no-follow
+            # handle open; only POSIX compares the descriptor to discovery
+            # metadata here.
+            _validate_opened_file(opened, relative_path, expected if os.name == "posix" else None)
             if opened.st_size > max_bytes:
                 raise SecurePathError(
                     "file_size_limit",
@@ -361,6 +366,7 @@ class SecureRoot:
 
         directory_handles: list[int] = []
         parent_handle = self._windows_root_handles[-1]
+        declared_path = self.root / relative_path
         descriptor = -1
         native_file_handle = -1
         try:
@@ -382,6 +388,20 @@ class SecureRoot:
                 directory_handles.append(native_directory_handle)
                 parent_handle = native_directory_handle
 
+            # Revalidate with the same path-stat family used during discovery,
+            # then pin that name through a native handle which denies write and
+            # delete sharing. CRT fstat identity is not comparable to lstat on
+            # Windows, so name stability is established before conversion.
+            try:
+                before_open = declared_path.lstat()
+            except OSError as exc:
+                raise SecurePathError(
+                    "unsafe_path",
+                    f"Cannot inspect selected file securely: {relative_path.as_posix()}: {exc}",
+                    relative_path=relative_path.as_posix(),
+                ) from exc
+            _validate_opened_file(before_open, relative_path, expected)
+
             native_file_handle = _windows_open_relative_handle(
                 parent_handle,
                 relative_path.name,
@@ -395,13 +415,22 @@ class SecureRoot:
                 create_options=_WINDOWS_FILE_OPEN_OPTIONS,
             )
             _validate_windows_read_file_handle(native_file_handle, relative_path)
+            try:
+                after_open = declared_path.lstat()
+            except OSError as exc:
+                raise SecurePathError(
+                    "unsafe_path",
+                    f"Cannot revalidate selected file securely: {relative_path.as_posix()}: {exc}",
+                    relative_path=relative_path.as_posix(),
+                ) from exc
+            _validate_opened_file(after_open, relative_path, before_open)
             descriptor = msvcrt.open_osfhandle(
                 native_file_handle,
                 os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_NOINHERIT", 0),
             )
             native_file_handle = -1
             opened = os.fstat(descriptor)
-            _validate_opened_file(opened, relative_path, expected)
+            _validate_opened_file(opened, relative_path, None)
             return descriptor
         except OSError as exc:
             if descriptor >= 0:

--- a/src/skillevaluator/utils/secure_fs.py
+++ b/src/skillevaluator/utils/secure_fs.py
@@ -1,0 +1,729 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Descriptor-anchored, bounded reads for evaluator-owned artifacts.
+
+Selected files are opened relative to a pinned root without following links.
+The reader verifies identity, type, link count, size, and timestamps before and
+after the read. Native Windows file handles allow reads but deny concurrent
+writes and deletes until the selected-file descriptor closes.
+"""
+
+from __future__ import annotations
+
+import errno
+import os
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+
+_OPEN_SUPPORTS_DIR_FD = os.open in os.supports_dir_fd
+
+_WINDOWS_FILE_READ_DATA = 0x1
+_WINDOWS_FILE_TRAVERSE = 0x20
+_WINDOWS_FILE_READ_ATTRIBUTES = 0x80
+_WINDOWS_SYNCHRONIZE = 0x100000
+_WINDOWS_SHARE_READ = 0x1
+_WINDOWS_SHARE_READ_WRITE = _WINDOWS_SHARE_READ | 0x2
+_WINDOWS_FILE_OPEN = 1
+_WINDOWS_FILE_DIRECTORY_FILE = 0x1
+_WINDOWS_FILE_SYNCHRONOUS_IO_NONALERT = 0x20
+_WINDOWS_FILE_NON_DIRECTORY_FILE = 0x40
+_WINDOWS_FILE_OPEN_FOR_BACKUP_INTENT = 0x00004000
+_WINDOWS_FILE_OPEN_REPARSE_POINT = 0x00200000
+_WINDOWS_OBJ_CASE_INSENSITIVE = 0x40
+_WINDOWS_OBJ_DONT_REPARSE = 0x1000
+_WINDOWS_OBJECT_ATTRIBUTES_FLAGS = _WINDOWS_OBJ_CASE_INSENSITIVE | _WINDOWS_OBJ_DONT_REPARSE
+_WINDOWS_DIRECTORY_READ_ACCESS = _WINDOWS_FILE_READ_ATTRIBUTES | _WINDOWS_FILE_TRAVERSE | _WINDOWS_SYNCHRONIZE
+_WINDOWS_FILE_READ_ACCESS = _WINDOWS_FILE_READ_DATA | _WINDOWS_FILE_READ_ATTRIBUTES | _WINDOWS_SYNCHRONIZE
+_WINDOWS_DIRECTORY_OPEN_OPTIONS = (
+    _WINDOWS_FILE_DIRECTORY_FILE
+    | _WINDOWS_FILE_SYNCHRONOUS_IO_NONALERT
+    | _WINDOWS_FILE_OPEN_FOR_BACKUP_INTENT
+    | _WINDOWS_FILE_OPEN_REPARSE_POINT
+)
+_WINDOWS_FILE_OPEN_OPTIONS = (
+    _WINDOWS_FILE_NON_DIRECTORY_FILE | _WINDOWS_FILE_SYNCHRONOUS_IO_NONALERT | _WINDOWS_FILE_OPEN_REPARSE_POINT
+)
+
+
+class SecurePathError(ValueError):
+    """An unsafe, racy, inaccessible, or unbounded filesystem input."""
+
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        *,
+        relative_path: str = ".",
+        metadata: dict[str, int] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.relative_path = relative_path
+        self.metadata = metadata or {}
+
+
+@dataclass(frozen=True)
+class _WindowsHandleMetadata:
+    """Stable metadata queried from one open native Windows handle."""
+
+    attributes: int
+    volume_serial: int
+    file_id: int
+    size: int
+    link_count: int
+    last_write_time: int = 0
+
+
+def stat_is_link_or_reparse(metadata: os.stat_result) -> bool:
+    """Return whether metadata identifies a symlink or Windows reparse point."""
+    reparse_flag = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+    return stat.S_ISLNK(metadata.st_mode) or bool(getattr(metadata, "st_file_attributes", 0) & reparse_flag)
+
+
+def _absolute_no_resolve(path: Path) -> Path:
+    """Return an absolute lexical path without resolving links."""
+    return Path(os.path.abspath(os.fspath(path)))  # noqa: PTH100
+
+
+def _relative_path(path: Path) -> Path:
+    if path.is_absolute() or not path.parts or any(part in {"", ".", ".."} for part in path.parts):
+        raise SecurePathError("unsafe_path", f"Path must be relative and normalized: {path.as_posix()}")
+    return path
+
+
+def _raise_unsafe_file(relative: Path, *, hardlink: bool = False) -> None:
+    if hardlink:
+        raise SecurePathError(
+            "unsafe_hardlink",
+            f"Refusing hard-linked selected file with link count greater than one: {relative.as_posix()}",
+            relative_path=relative.as_posix(),
+        )
+    raise SecurePathError(
+        "unsafe_path",
+        f"Refusing selected path that is not a regular file: {relative.as_posix()}",
+        relative_path=relative.as_posix(),
+    )
+
+
+def _validate_opened_file(
+    metadata: os.stat_result,
+    relative_path: Path,
+    expected: os.stat_result | None,
+) -> None:
+    if stat_is_link_or_reparse(metadata):
+        raise SecurePathError(
+            "unsafe_path",
+            f"Refusing selected symlink or reparse point: {relative_path.as_posix()}",
+            relative_path=relative_path.as_posix(),
+        )
+    if not stat.S_ISREG(metadata.st_mode):
+        _raise_unsafe_file(relative_path)
+    if getattr(metadata, "st_nlink", 1) != 1:
+        _raise_unsafe_file(relative_path, hardlink=True)
+    if expected is not None:
+        changed = not os.path.samestat(metadata, expected)
+        for attribute in ("st_size", "st_mtime_ns", "st_ctime_ns"):
+            if getattr(metadata, attribute, None) != getattr(expected, attribute, None):
+                changed = True
+        if changed:
+            raise SecurePathError(
+                "unsafe_path",
+                f"Selected file changed identity or contents while being opened: {relative_path.as_posix()}",
+                relative_path=relative_path.as_posix(),
+            )
+
+
+def _validate_directory_snapshot(
+    metadata: os.stat_result,
+    relative_path: Path,
+    expected: os.stat_result,
+) -> None:
+    """Require one directory identity and entry snapshot to stay stable."""
+    changed = (
+        stat_is_link_or_reparse(metadata)
+        or not stat.S_ISDIR(metadata.st_mode)
+        or not os.path.samestat(metadata, expected)
+    )
+    for attribute in ("st_size", "st_mtime_ns", "st_ctime_ns"):
+        if getattr(metadata, attribute, None) != getattr(expected, attribute, None):
+            changed = True
+    if changed:
+        label = relative_path.as_posix()
+        raise SecurePathError(
+            "unsafe_path",
+            f"Secure root directory changed identity or snapshot: {label}",
+            relative_path=label,
+        )
+
+
+def _open_absolute_directory_posix(path: Path) -> int:
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
+    try:
+        expected = path.lstat()
+    except OSError as exc:
+        raise SecurePathError("unsafe_root", f"Cannot inspect declared root safely: {exc}") from exc
+    if stat_is_link_or_reparse(expected) or not stat.S_ISDIR(expected.st_mode):
+        raise SecurePathError("unsafe_root", f"Declared root is a symlink or non-directory: {path}")
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        raise SecurePathError("unsafe_root", f"Cannot securely open declared root: {exc}") from exc
+    try:
+        opened = os.fstat(descriptor)
+        if not stat.S_ISDIR(opened.st_mode) or not os.path.samestat(expected, opened):
+            raise SecurePathError("unsafe_root", "Declared root changed while being opened.")
+        return descriptor
+    except BaseException:
+        os.close(descriptor)
+        raise
+
+
+class SecureRoot:
+    """Descriptor-anchored reads beneath one verified regular root."""
+
+    def __init__(self, root: Path, *, expected: os.stat_result | None = None) -> None:
+        self.root = _absolute_no_resolve(root)
+        self._expected = expected
+        self._root_fd: int | None = None
+        self._windows_root_handles: list[int] = []
+        self._entered = False
+
+    def __enter__(self) -> SecureRoot:
+        if self._entered:
+            raise SecurePathError("unsafe_root", "Secure root context is already active.")
+        try:
+            metadata = self.root.lstat()
+        except OSError as exc:
+            raise SecurePathError("invalid_root", f"Cannot inspect secure root: {exc}") from exc
+        if stat_is_link_or_reparse(metadata):
+            raise SecurePathError("unsafe_root", f"Secure root is a symlink or reparse point: {self.root.name}")
+        if not stat.S_ISDIR(metadata.st_mode):
+            raise SecurePathError("invalid_root", f"Secure root is not a regular directory: {self.root}")
+        if self._expected is not None:
+            _validate_directory_snapshot(metadata, Path(), self._expected)
+
+        if os.name == "posix":
+            if not (hasattr(os, "O_DIRECTORY") and hasattr(os, "O_NOFOLLOW") and _OPEN_SUPPORTS_DIR_FD):
+                raise SecurePathError(
+                    "secure_open_unavailable",
+                    "This platform cannot guarantee descriptor-anchored no-follow reads.",
+                )
+            root_fd = _open_absolute_directory_posix(self.root)
+            try:
+                opened = os.fstat(root_fd)
+                if not stat.S_ISDIR(opened.st_mode) or not os.path.samestat(metadata, opened):
+                    raise SecurePathError("unsafe_root", "Secure root changed while being opened.")
+            except BaseException:
+                os.close(root_fd)
+                raise
+            self._root_fd = root_fd
+            self._entered = True
+            return self
+
+        if os.name == "nt":
+            self._windows_root_handles = _windows_open_anchored_directory_chain(self.root, expected=metadata)
+            self._entered = True
+            return self
+
+        raise SecurePathError("secure_open_unavailable", "This platform cannot guarantee no-follow reads.")
+
+    def __exit__(self, _exc_type, _exc, _traceback) -> None:
+        if self._root_fd is not None:
+            os.close(self._root_fd)
+            self._root_fd = None
+        while self._windows_root_handles:
+            _windows_close_handle(self._windows_root_handles.pop())
+        self._entered = False
+
+    def read_bytes(
+        self,
+        relative_path: Path,
+        max_bytes: int,
+        *,
+        expected: os.stat_result | None = None,
+    ) -> tuple[bytes, os.stat_result]:
+        """Read one bounded regular single-link file without following redirects."""
+        if not self._entered:
+            raise SecurePathError("secure_open_unavailable", "Secure root context is not active.")
+        relative_path = _relative_path(relative_path)
+        if max_bytes < 0:
+            raise ValueError("max_bytes must be non-negative")
+        if os.name == "posix":
+            descriptor = self._open_posix(relative_path, expected)
+        elif os.name == "nt":
+            descriptor = self._open_windows(relative_path, expected)
+        else:
+            raise SecurePathError("secure_open_unavailable", "Secure no-follow reads are unavailable.")
+
+        try:
+            opened = os.fstat(descriptor)
+            _validate_opened_file(opened, relative_path, expected)
+            if opened.st_size > max_bytes:
+                raise SecurePathError(
+                    "file_size_limit",
+                    f"Selected file exceeds the {max_bytes}-byte limit: {relative_path.as_posix()}",
+                    relative_path=relative_path.as_posix(),
+                    metadata={"actual_bytes": opened.st_size, "limit_bytes": max_bytes},
+                )
+            chunks: list[bytes] = []
+            total = 0
+            while True:
+                chunk = os.read(descriptor, min(65_536, max_bytes + 1 - total))
+                if not chunk:
+                    break
+                chunks.append(chunk)
+                total += len(chunk)
+                if total > max_bytes:
+                    raise SecurePathError(
+                        "file_size_limit",
+                        f"Selected file exceeds the {max_bytes}-byte limit: {relative_path.as_posix()}",
+                        relative_path=relative_path.as_posix(),
+                        metadata={"actual_bytes": total, "limit_bytes": max_bytes},
+                    )
+            after = os.fstat(descriptor)
+            _validate_opened_file(after, relative_path, opened)
+            return b"".join(chunks), opened
+        finally:
+            os.close(descriptor)
+
+    def _open_posix(self, relative_path: Path, expected: os.stat_result | None) -> int:
+        if self._root_fd is None:
+            raise SecurePathError("secure_open_unavailable", "Secure root descriptor is unavailable.")
+        directory_fd = os.dup(self._root_fd)
+        directory_flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
+        file_flags = (
+            os.O_RDONLY
+            | os.O_NOFOLLOW
+            | getattr(os, "O_CLOEXEC", 0)
+            | getattr(os, "O_BINARY", 0)
+            | getattr(os, "O_NONBLOCK", 0)
+            | getattr(os, "O_NOCTTY", 0)
+        )
+        try:
+            for component in relative_path.parts[:-1]:
+                try:
+                    child_fd = os.open(component, directory_flags, dir_fd=directory_fd)
+                except OSError as exc:
+                    raise SecurePathError(
+                        "unsafe_path",
+                        f"Cannot securely traverse path component {component!r}: {exc}",
+                        relative_path=relative_path.as_posix(),
+                    ) from exc
+                try:
+                    child_metadata = os.fstat(child_fd)
+                except BaseException:
+                    os.close(child_fd)
+                    raise
+                if not stat.S_ISDIR(child_metadata.st_mode) or stat_is_link_or_reparse(child_metadata):
+                    os.close(child_fd)
+                    raise SecurePathError(
+                        "unsafe_path",
+                        f"Path component is not a regular directory: {component}",
+                        relative_path=relative_path.as_posix(),
+                    )
+                os.close(directory_fd)
+                directory_fd = child_fd
+
+            try:
+                before = os.stat(relative_path.name, dir_fd=directory_fd, follow_symlinks=False)
+            except OSError as exc:
+                raise SecurePathError(
+                    "unsafe_path",
+                    f"Cannot inspect selected file securely: {relative_path.as_posix()}: {exc}",
+                    relative_path=relative_path.as_posix(),
+                ) from exc
+            _validate_opened_file(before, relative_path, expected)
+            try:
+                descriptor = os.open(relative_path.name, file_flags, dir_fd=directory_fd)
+            except OSError as exc:
+                message = "Selected path is a symlink or unsafe file" if exc.errno == errno.ELOOP else str(exc)
+                raise SecurePathError(
+                    "unsafe_path",
+                    f"Cannot securely open {relative_path.as_posix()}: {message}",
+                    relative_path=relative_path.as_posix(),
+                ) from exc
+            try:
+                _validate_opened_file(os.fstat(descriptor), relative_path, before)
+            except BaseException:
+                os.close(descriptor)
+                raise
+            return descriptor
+        finally:
+            os.close(directory_fd)
+
+    def _open_windows(self, relative_path: Path, expected: os.stat_result | None) -> int:
+        if not self._windows_root_handles:
+            raise SecurePathError("secure_open_unavailable", "Secure root handle is unavailable.")
+
+        import msvcrt
+
+        directory_handles: list[int] = []
+        parent_handle = self._windows_root_handles[-1]
+        descriptor = -1
+        native_file_handle = -1
+        try:
+            for component in relative_path.parts[:-1]:
+                native_directory_handle = _windows_open_relative_handle(
+                    parent_handle,
+                    component,
+                    access=_WINDOWS_DIRECTORY_READ_ACCESS,
+                    share=_WINDOWS_SHARE_READ_WRITE,
+                    disposition=_WINDOWS_FILE_OPEN,
+                    file_attributes=0,
+                    create_options=_WINDOWS_DIRECTORY_OPEN_OPTIONS,
+                )
+                try:
+                    _validate_windows_read_directory_handle(native_directory_handle, relative_path)
+                except BaseException:
+                    _windows_close_handle(native_directory_handle)
+                    raise
+                directory_handles.append(native_directory_handle)
+                parent_handle = native_directory_handle
+
+            native_file_handle = _windows_open_relative_handle(
+                parent_handle,
+                relative_path.name,
+                access=_WINDOWS_FILE_READ_ACCESS,
+                # Deny write/delete sharing for the selected file while the
+                # CRT descriptor is live. This closes same-size rewrite races
+                # that Windows creation-time metadata cannot detect.
+                share=_WINDOWS_SHARE_READ,
+                disposition=_WINDOWS_FILE_OPEN,
+                file_attributes=0,
+                create_options=_WINDOWS_FILE_OPEN_OPTIONS,
+            )
+            _validate_windows_read_file_handle(native_file_handle, relative_path)
+            descriptor = msvcrt.open_osfhandle(
+                native_file_handle,
+                os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_NOINHERIT", 0),
+            )
+            native_file_handle = -1
+            opened = os.fstat(descriptor)
+            _validate_opened_file(opened, relative_path, expected)
+            return descriptor
+        except OSError as exc:
+            if descriptor >= 0:
+                os.close(descriptor)
+                descriptor = -1
+            raise SecurePathError(
+                "unsafe_path",
+                f"Cannot securely open selected file {relative_path.as_posix()}: {exc}",
+                relative_path=relative_path.as_posix(),
+            ) from exc
+        except BaseException:
+            if descriptor >= 0:
+                os.close(descriptor)
+            raise
+        finally:
+            if native_file_handle >= 0:
+                _windows_close_handle(native_file_handle)
+            while directory_handles:
+                _windows_close_handle(directory_handles.pop())
+
+
+def _windows_kernel32():
+    if os.name != "nt":
+        raise OSError("Windows handle operations are unavailable on this platform")
+    import ctypes
+
+    return ctypes.WinDLL("kernel32", use_last_error=True)
+
+
+def _windows_raise_last_error(message: str) -> OSError:
+    import ctypes
+
+    error = ctypes.get_last_error()
+    return OSError(error, message)
+
+
+def _windows_open_handle(
+    path: Path,
+    *,
+    access: int,
+    share: int,
+    disposition: int,
+    flags: int,
+) -> int:
+    import ctypes
+    from ctypes import wintypes
+
+    kernel32 = _windows_kernel32()
+    create_file = kernel32.CreateFileW
+    create_file.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.HANDLE,
+    ]
+    create_file.restype = wintypes.HANDLE
+    handle = create_file(os.fspath(path), access, share, None, disposition, flags, None)
+    invalid_handle = ctypes.c_void_p(-1).value
+    if handle == invalid_handle:
+        raise _windows_raise_last_error(f"Cannot open Windows filesystem handle: {path}")
+    return int(handle)
+
+
+def _validate_windows_path_component(name: str, *, label: str) -> None:
+    """Reject Win32 normalization aliases, device names, ADS, and invalid UTF-16."""
+    invalid_characters = '<>:"/\\|?*'
+    stem = name.split(".", 1)[0].rstrip(" .").casefold()
+    reserved = {
+        "con",
+        "prn",
+        "aux",
+        "nul",
+        *(f"com{index}" for index in range(1, 10)),
+        *(f"lpt{index}" for index in range(1, 10)),
+        *(f"com{index}" for index in "¹²³"),
+        *(f"lpt{index}" for index in "¹²³"),
+    }
+    try:
+        utf16_units = len(name.encode("utf-16-le")) // 2
+    except UnicodeEncodeError as exc:
+        raise SecurePathError("unsafe_path", f"{label} has an unsafe Windows file name.") from exc
+    if (
+        not name
+        or name in {".", ".."}
+        or utf16_units > 255
+        or any(ord(character) < 32 or character in invalid_characters for character in name)
+        or name.endswith((" ", "."))
+        or stem in reserved
+    ):
+        raise SecurePathError("unsafe_path", f"{label} has an unsafe Windows file name.")
+
+
+def _windows_open_relative_handle(
+    parent_handle: int,
+    name: str,
+    *,
+    access: int,
+    share: int,
+    disposition: int,
+    file_attributes: int,
+    create_options: int,
+    object_attributes_flags: int = _WINDOWS_OBJECT_ATTRIBUTES_FLAGS,
+) -> int:
+    """Open one path component relative to a held native directory handle."""
+    import ctypes
+    from ctypes import wintypes
+
+    _validate_windows_path_component(name, label="Anchored path component")
+
+    class _UnicodeString(ctypes.Structure):
+        _fields_ = [
+            ("Length", wintypes.USHORT),
+            ("MaximumLength", wintypes.USHORT),
+            ("Buffer", wintypes.LPWSTR),
+        ]
+
+    class _ObjectAttributes(ctypes.Structure):
+        _fields_ = [
+            ("Length", wintypes.ULONG),
+            ("RootDirectory", wintypes.HANDLE),
+            ("ObjectName", ctypes.POINTER(_UnicodeString)),
+            ("Attributes", wintypes.ULONG),
+            ("SecurityDescriptor", wintypes.LPVOID),
+            ("SecurityQualityOfService", wintypes.LPVOID),
+        ]
+
+    class _IoStatusValue(ctypes.Union):
+        _fields_ = [("Status", wintypes.LONG), ("Pointer", wintypes.LPVOID)]  # noqa: RUF012
+
+    class _IoStatusBlock(ctypes.Structure):
+        _fields_ = [("Value", _IoStatusValue), ("Information", ctypes.c_size_t)]
+
+    encoded_name = name.encode("utf-16-le")
+    name_buffer = ctypes.create_unicode_buffer(name)
+    unicode_name = _UnicodeString(
+        Length=len(encoded_name),
+        MaximumLength=len(encoded_name) + ctypes.sizeof(wintypes.WCHAR),
+        Buffer=ctypes.cast(name_buffer, wintypes.LPWSTR),
+    )
+    object_attributes = _ObjectAttributes(
+        Length=ctypes.sizeof(_ObjectAttributes),
+        RootDirectory=parent_handle,
+        ObjectName=ctypes.pointer(unicode_name),
+        Attributes=object_attributes_flags,
+        SecurityDescriptor=None,
+        SecurityQualityOfService=None,
+    )
+    io_status = _IoStatusBlock()
+    handle = wintypes.HANDLE()
+
+    ntdll = ctypes.WinDLL("ntdll")
+    nt_create_file = ntdll.NtCreateFile
+    nt_create_file.argtypes = [
+        ctypes.POINTER(wintypes.HANDLE),
+        wintypes.DWORD,
+        ctypes.POINTER(_ObjectAttributes),
+        ctypes.POINTER(_IoStatusBlock),
+        wintypes.LPVOID,
+        wintypes.ULONG,
+        wintypes.ULONG,
+        wintypes.ULONG,
+        wintypes.ULONG,
+        wintypes.LPVOID,
+        wintypes.ULONG,
+    ]
+    nt_create_file.restype = wintypes.LONG
+    status = int(
+        nt_create_file(
+            ctypes.byref(handle),
+            access,
+            ctypes.byref(object_attributes),
+            ctypes.byref(io_status),
+            None,
+            file_attributes,
+            share,
+            disposition,
+            create_options,
+            None,
+            0,
+        )
+    )
+    if status < 0:
+        rtl_status_to_error = ntdll.RtlNtStatusToDosError
+        rtl_status_to_error.argtypes = [wintypes.LONG]
+        rtl_status_to_error.restype = wintypes.ULONG
+        error = int(rtl_status_to_error(status))
+        raise OSError(error, f"Cannot open anchored Windows path component: {name}")
+    if not handle.value:
+        raise OSError("NtCreateFile succeeded without returning a file handle")
+    return int(handle.value)
+
+
+def _windows_close_handle(handle: int) -> None:
+    from ctypes import wintypes
+
+    kernel32 = _windows_kernel32()
+    close_handle = kernel32.CloseHandle
+    close_handle.argtypes = [wintypes.HANDLE]
+    close_handle.restype = wintypes.BOOL
+    if not close_handle(handle):
+        raise _windows_raise_last_error("Cannot close Windows filesystem handle")
+
+
+def _windows_handle_metadata(handle: int) -> _WindowsHandleMetadata:
+    import ctypes
+    from ctypes import wintypes
+
+    class _ByHandleFileInformation(ctypes.Structure):
+        _fields_ = [
+            ("dwFileAttributes", wintypes.DWORD),
+            ("ftCreationTime", wintypes.FILETIME),
+            ("ftLastAccessTime", wintypes.FILETIME),
+            ("ftLastWriteTime", wintypes.FILETIME),
+            ("dwVolumeSerialNumber", wintypes.DWORD),
+            ("nFileSizeHigh", wintypes.DWORD),
+            ("nFileSizeLow", wintypes.DWORD),
+            ("nNumberOfLinks", wintypes.DWORD),
+            ("nFileIndexHigh", wintypes.DWORD),
+            ("nFileIndexLow", wintypes.DWORD),
+        ]
+
+    kernel32 = _windows_kernel32()
+    get_information = kernel32.GetFileInformationByHandle
+    get_information.argtypes = [wintypes.HANDLE, ctypes.POINTER(_ByHandleFileInformation)]
+    get_information.restype = wintypes.BOOL
+    information = _ByHandleFileInformation()
+    if not get_information(handle, ctypes.byref(information)):
+        raise _windows_raise_last_error("Cannot inspect open Windows filesystem handle")
+    return _WindowsHandleMetadata(
+        attributes=int(information.dwFileAttributes),
+        volume_serial=int(information.dwVolumeSerialNumber),
+        file_id=(int(information.nFileIndexHigh) << 32) | int(information.nFileIndexLow),
+        size=(int(information.nFileSizeHigh) << 32) | int(information.nFileSizeLow),
+        link_count=int(information.nNumberOfLinks),
+        last_write_time=(int(information.ftLastWriteTime.dwHighDateTime) << 32)
+        | int(information.ftLastWriteTime.dwLowDateTime),
+    )
+
+
+def _validate_windows_read_directory_handle(handle: int, relative_path: Path) -> _WindowsHandleMetadata:
+    """Require one opened Windows traversal component to be a plain directory."""
+    metadata = _windows_handle_metadata(handle)
+    directory_attribute = 0x10
+    reparse_attribute = 0x400
+    if metadata.attributes & reparse_attribute or not metadata.attributes & directory_attribute:
+        raise SecurePathError(
+            "unsafe_path",
+            f"Path contains a non-directory or reparse component: {relative_path.as_posix()}",
+            relative_path=relative_path.as_posix(),
+        )
+    return metadata
+
+
+def _validate_windows_read_file_handle(handle: int, relative_path: Path) -> _WindowsHandleMetadata:
+    """Require one selected Windows handle to be regular, single-link, and no-follow."""
+    metadata = _windows_handle_metadata(handle)
+    directory_attribute = 0x10
+    reparse_attribute = 0x400
+    if metadata.attributes & (directory_attribute | reparse_attribute):
+        raise SecurePathError(
+            "unsafe_path",
+            f"Refusing selected directory or reparse point: {relative_path.as_posix()}",
+            relative_path=relative_path.as_posix(),
+        )
+    if metadata.link_count != 1:
+        _raise_unsafe_file(relative_path, hardlink=True)
+    return metadata
+
+
+def _windows_open_anchored_directory_chain(
+    path: Path,
+    *,
+    expected: os.stat_result,
+) -> list[int]:
+    """Pin an absolute directory from its volume anchor without following reparses."""
+    absolute = _absolute_no_resolve(path)
+    if not absolute.anchor:
+        raise SecurePathError("unsafe_root", "Windows root has no filesystem anchor.")
+
+    anchor = Path(absolute.anchor)
+    handles: list[int] = []
+    try:
+        anchor_handle = _windows_open_handle(
+            anchor,
+            access=_WINDOWS_DIRECTORY_READ_ACCESS,
+            share=_WINDOWS_SHARE_READ_WRITE,
+            disposition=3,
+            flags=0x02000000 | _WINDOWS_FILE_OPEN_REPARSE_POINT,
+        )
+        handles.append(anchor_handle)
+        _validate_windows_read_directory_handle(anchor_handle, anchor)
+
+        current_path = anchor
+        parent_handle = anchor_handle
+        for component in absolute.parts[1:]:
+            current_path /= component
+            child_handle = _windows_open_relative_handle(
+                parent_handle,
+                component,
+                access=_WINDOWS_DIRECTORY_READ_ACCESS,
+                share=_WINDOWS_SHARE_READ_WRITE,
+                disposition=_WINDOWS_FILE_OPEN,
+                file_attributes=0,
+                create_options=_WINDOWS_DIRECTORY_OPEN_OPTIONS,
+            )
+            handles.append(child_handle)
+            _validate_windows_read_directory_handle(child_handle, current_path)
+            parent_handle = child_handle
+
+        try:
+            declared = absolute.lstat()
+        except OSError as exc:
+            raise SecurePathError("unsafe_root", f"Cannot revalidate declared root: {exc}") from exc
+        if stat_is_link_or_reparse(declared) or not stat.S_ISDIR(declared.st_mode):
+            raise SecurePathError("unsafe_root", "Declared root became a reparse point or non-directory.")
+        if not os.path.samestat(expected, declared):
+            raise SecurePathError("unsafe_root", "Root changed identity while native handles were opened.")
+        return handles
+    except BaseException:
+        while handles:
+            _windows_close_handle(handles.pop())
+        raise

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,16 @@ from pathlib import Path
 
 import pytest
 
+
+@pytest.fixture(autouse=True)
+def _isolate_output_provenance_key(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Keep every test away from the developer's persistent provenance key."""
+    monkeypatch.setenv(
+        "SKILLEVALUATOR_OUTPUT_PROVENANCE_KEY_FILE",
+        str(tmp_path / ".skillevaluator-state" / "output-provenance.key"),
+    )
+
+
 # =============================================================================
 # SKILLS FIXTURES
 # =============================================================================

--- a/tests/reporting/test_reporters.py
+++ b/tests/reporting/test_reporters.py
@@ -702,6 +702,7 @@ class TestTier3HarborCanonicalPayload:
             ),
             encoding="utf-8",
         )
+        (run_dir / "run_config.json").write_text("{}", encoding="utf-8")
         (run_dir / "result.json").write_text(json.dumps({"run_id": run_id}), encoding="utf-8")
         (results_root / "latest").symlink_to(run_id)
 

--- a/tests/reporting/test_reporters.py
+++ b/tests/reporting/test_reporters.py
@@ -684,7 +684,9 @@ class TestTier3HarborCanonicalPayload:
     def test_failed_run_produces_false_agent_eval_result(self, tmp_path: Path) -> None:
         skill = tmp_path / "demo"
         skill.mkdir()
-        run_dir = tmp_path / "results" / "demo" / "latest"
+        results_root = tmp_path / "results" / "demo"
+        run_id = "20260709_120000"
+        run_dir = results_root / run_id
         summary = run_dir / "codex" / "with-skill" / "summary.json"
         summary.parent.mkdir(parents=True)
         summary.write_text(
@@ -700,6 +702,8 @@ class TestTier3HarborCanonicalPayload:
             ),
             encoding="utf-8",
         )
+        (run_dir / "result.json").write_text(json.dumps({"run_id": run_id}), encoding="utf-8")
+        (results_root / "latest").symlink_to(run_id)
 
         result = agent_eval_result_from_run(
             skill,

--- a/tests/reporting/test_unified_tier3_report.py
+++ b/tests/reporting/test_unified_tier3_report.py
@@ -53,6 +53,75 @@ def _write_summary(
     )
 
 
+def _write_authenticated_pre_status_summary(run_dir: Path, *, score: float = 0.8) -> None:
+    summary = run_dir / "opencode" / "with-skill" / "summary.json"
+    summary.parent.mkdir(parents=True)
+    (run_dir / "run_config.json").write_text(
+        json.dumps(
+            {
+                "harbor": {"n_attempts": {"value": 1, "source": "ACES default"}},
+                "task_source": "evals_json",
+                "agents": {
+                    "opencode": {
+                        "agent": "opencode",
+                        "model": "test-model",
+                        "source": "test default",
+                        "occurrence": "1",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    summary.write_text(
+        json.dumps(
+            {
+                "agent": "opencode",
+                "model": "test-model",
+                "model_source": "test default",
+                "scores": {"security": score},
+                "custom_scores": {},
+                "metric_set": "aces-default-v2",
+                "metrics": ["security"],
+                "dimensions": {"safety": {"score": score, "sources": {"security": 1.0}}},
+                "num_trials": 1,
+                "pass_at_k": {
+                    "k": 1,
+                    "pass_threshold": 0.5,
+                    "stop_on_pass": False,
+                    "passed_cases": 1,
+                    "failed_cases": 0,
+                    "total_cases": 1,
+                    "rate": 1.0,
+                    "attempts_used": 1,
+                    "max_attempts_possible": 1,
+                    "avg_attempts_used": 1.0,
+                    "extra_cases": [],
+                    "cases": {
+                        "case": {
+                            "passed": True,
+                            "first_pass_attempt": 1,
+                            "attempts_used": 1,
+                            "attempts_skipped": 0,
+                            "attempts_missing": 0,
+                            "best_score": score,
+                            "attempts": [
+                                {
+                                    "attempt": 1,
+                                    "trial": "case__attempt1",
+                                    "score": score,
+                                    "passed": True,
+                                }
+                            ],
+                        }
+                    },
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
 def _render_agent_payload(payload: dict) -> str:
     result = ValidationResult(validator_name="AGENT_EVAL", validator_description="Live evaluation")
     result.metadata["agent_eval"] = payload
@@ -123,6 +192,21 @@ def test_standalone_tier3_uses_generic_tier3_only_report(tmp_path: Path) -> None
     assert 'data-tier3-tab="trials"' in html
     assert "Diagnostics" in html
     assert "SkillEvaluator" in html
+
+
+def test_authenticated_pre_status_rerender_preserves_historical_scores(tmp_path: Path) -> None:
+    skill = tmp_path / "demo"
+    skill.mkdir()
+    run_dir = tmp_path / "results" / "20260709_120008"
+    _write_authenticated_pre_status_summary(run_dir)
+
+    tier3 = agent_eval_result_from_directory(skill, run_dir, use_llm_judge=False)
+
+    assert tier3 is not None
+    payload = tier3.metadata["agent_eval"]
+    assert payload["execution_status"] == "succeeded"
+    assert payload["overall_score"] is not None
+    assert payload["agents"]["opencode"]["evaluators"]["security"]["with_skill"] == 0.8
 
 
 def test_canonical_report_prefers_agentskills_dataset_fields() -> None:
@@ -866,6 +950,7 @@ def test_view_regenerates_missing_report_with_canonical_renderer(monkeypatch, tm
     results_root = tmp_path / "results"
     run_dir = results_root / skill.name / "20260709_120002"
     run_dir.mkdir(parents=True)
+    (run_dir / "run_config.json").write_text("{}", encoding="utf-8")
     (run_dir / "result.json").write_text(
         json.dumps({"run_id": run_dir.name}),
         encoding="utf-8",

--- a/tests/test_evaluation_service.py
+++ b/tests/test_evaluation_service.py
@@ -664,7 +664,8 @@ def test_report_discovery_handles_timestamped_results(tmp_path: Path) -> None:
     run_dir = results_root / "myskill" / "2026-06-18_120000"
     run_dir.mkdir(parents=True)
     (run_dir / "report.html").write_text("<html></html>", encoding="utf-8")
-    (results_root / "myskill" / "latest").symlink_to(run_dir)
+    (run_dir / "result.json").write_text(json.dumps({"run_id": run_dir.name}), encoding="utf-8")
+    (results_root / "myskill" / "latest").symlink_to(run_dir.name)
 
     service = EvaluationService()
     latest = service.discover_latest_results(skill, results_dir=results_root)

--- a/tests/test_evaluation_service.py
+++ b/tests/test_evaluation_service.py
@@ -664,6 +664,7 @@ def test_report_discovery_handles_timestamped_results(tmp_path: Path) -> None:
     run_dir = results_root / "myskill" / "2026-06-18_120000"
     run_dir.mkdir(parents=True)
     (run_dir / "report.html").write_text("<html></html>", encoding="utf-8")
+    (run_dir / "run_config.json").write_text("{}", encoding="utf-8")
     (run_dir / "result.json").write_text(json.dumps({"run_id": run_dir.name}), encoding="utf-8")
     (results_root / "myskill" / "latest").symlink_to(run_dir.name)
 

--- a/tests/test_harbor_adapter_safety.py
+++ b/tests/test_harbor_adapter_safety.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import importlib
 import json
 import os
 import subprocess
@@ -145,6 +146,79 @@ def test_copy_repo_excludes_sensitive_files_without_git(tmp_path: Path) -> None:
     skill = _write_repo_context_fixture(repo)
 
     _assert_sensitive_repo_files_are_excluded(repo, skill, tmp_path / "plain-task" / "environment")
+
+
+@pytest.mark.parametrize("tracked", [False, True], ids=["plain", "git"])
+def test_copy_repo_prunes_excluded_output_before_any_file_inspection(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tracked: bool,
+) -> None:
+    repo = tmp_path / "repo"
+    skill = repo / "skill"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("# Test skill\n", encoding="utf-8")
+    (repo / "README.md").write_text("safe\n", encoding="utf-8")
+    excluded = repo / "custom-results"
+    excluded.mkdir()
+    (excluded / "secret.json").write_text('{"ground_truth": "private"}', encoding="utf-8")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "canary.txt").write_text("host canary", encoding="utf-8")
+    _symlink_or_skip(excluded / "latest", outside, target_is_directory=True)
+    _symlink_or_skip(excluded / "dangling", tmp_path / "missing")
+
+    if tracked:
+        subprocess.run(["git", "init", "-q", str(repo)], check=True)
+        subprocess.run(["git", "-C", str(repo), "add", "-f", "--", "."], check=True)
+
+    if hasattr(os, "mkfifo"):
+        os.mkfifo(excluded / "blocked.fifo")
+    unreadable = excluded / "unreadable"
+    unreadable.mkdir()
+    (unreadable / "private.txt").write_text("private", encoding="utf-8")
+    unreadable.chmod(0)
+
+    original_is_file = Path.is_file
+
+    def guarded_is_file(path: Path) -> bool:
+        try:
+            path.absolute().relative_to(excluded.absolute())
+        except ValueError:
+            return original_is_file(path)
+        raise AssertionError(f"excluded output was inspected: {path}")
+
+    monkeypatch.setattr(Path, "is_file", guarded_is_file)
+    env_dir = tmp_path / "task" / "environment"
+    env_dir.mkdir(parents=True)
+    try:
+        metadata = _stage_repo_context(
+            env_dir,
+            source_skill_path=skill,
+            mode="full",
+            excluded_roots=(excluded,),
+        )
+    finally:
+        unreadable.chmod(0o700)
+
+    assert (env_dir / "repo" / "README.md").read_text(encoding="utf-8") == "safe\n"
+    assert not (env_dir / "repo" / excluded.relative_to(repo)).exists()
+    assert all(not Path(item["source"]).is_relative_to(excluded) for item in metadata["files"])
+
+
+def test_copy_repo_still_rejects_nonexcluded_file_symlink(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    skill = repo / "skill"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("# Test skill\n", encoding="utf-8")
+    source = repo / "source.txt"
+    source.write_text("canary", encoding="utf-8")
+    _symlink_or_skip(repo / "linked-source.txt", source)
+    env_dir = tmp_path / "task" / "environment"
+    env_dir.mkdir(parents=True)
+
+    with pytest.raises(ValueError, match=r"symlink|reparse"):
+        _stage_repo_context(env_dir, source_skill_path=skill, mode="full")
 
 
 def _symlink_or_skip(link: Path, target: Path, *, target_is_directory: bool = False) -> None:
@@ -326,6 +400,53 @@ def test_custom_grader_rejects_non_regular_candidate(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="non-symlinked regular file contained under evals/"):
         _copy_custom_grader(tmp_path / "task", skill, "custom_only")
+
+
+def test_custom_grader_rejects_hardlinked_candidate(tmp_path: Path) -> None:
+    skill = tmp_path / "skill"
+    grader = skill / "evals" / "grader.py"
+    grader.parent.mkdir(parents=True)
+    grader.write_text("safe grader", encoding="utf-8")
+    outside_alias = tmp_path / "grader-alias.py"
+    try:
+        outside_alias.hardlink_to(grader)
+    except OSError as exc:  # pragma: no cover - filesystem policy
+        pytest.skip(f"hardlinks unavailable on this host: {exc}")
+    task_dir = tmp_path / "task"
+
+    with pytest.raises(ValueError, match=r"hard.?link|multiple links"):
+        _copy_custom_grader(task_dir, skill, "custom_only")
+
+    assert grader.read_text(encoding="utf-8") == "safe grader"
+    assert not (task_dir / "tests" / "grader.py").exists()
+
+
+def test_custom_grader_rejects_source_replacement_after_validation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    secure_copy = importlib.import_module("skillevaluator.tier3.harbor.secure_copy")
+    skill = tmp_path / "skill"
+    grader = skill / "evals" / "grader.py"
+    grader.parent.mkdir(parents=True)
+    grader.write_text("validated grader", encoding="utf-8")
+    task_dir = tmp_path / "task"
+    original = secure_copy._build_file_manifest
+
+    def validate_then_replace(source: Path, allowed_root: Path):
+        manifest = original(source, allowed_root)
+        if Path(source) == grader.resolve():
+            grader.unlink()
+            grader.write_text("replacement grader", encoding="utf-8")
+        return manifest
+
+    monkeypatch.setattr(secure_copy, "_build_file_manifest", validate_then_replace)
+
+    with pytest.raises(ValueError, match="source changed after validation"):
+        _copy_custom_grader(task_dir, skill, "custom_only")
+
+    assert grader.read_text(encoding="utf-8") == "replacement grader"
+    assert not (task_dir / "tests" / "grader.py").exists()
 
 
 @pytest.mark.parametrize("candidate", _GRADER_CANDIDATES, ids=str)

--- a/tests/test_harbor_adapter_safety.py
+++ b/tests/test_harbor_adapter_safety.py
@@ -227,10 +227,10 @@ def test_generated_task_rebases_custom_dockerfile_content(tmp_path: Path) -> Non
     )[0]
 
     dockerfile = (task / "environment" / "Dockerfile").read_text(encoding="utf-8")
-    assert dockerfile.startswith(
-        "FROM registry.example/eval-base:verified\n# SkillEvaluator: original base was FROM python:3.11-slim\n"
+    assert dockerfile.startswith("FROM registry.example/eval-base:verified\n")
+    assert dockerfile.index("RUN echo generated-custom-layer\n") < dockerfile.index(
+        "# SkillEvaluator: original base was FROM python:3.11-slim\n"
     )
-    assert "RUN echo generated-custom-layer\n" in dockerfile
 
 
 def test_native_task_rebases_custom_dockerfile_content(tmp_path: Path) -> None:
@@ -254,24 +254,22 @@ def test_native_task_rebases_custom_dockerfile_content(tmp_path: Path) -> None:
     )[0]
 
     dockerfile = (task / "environment" / "Dockerfile").read_text(encoding="utf-8")
-    assert dockerfile.startswith(
-        "FROM registry.example/eval-base:verified\n# SkillEvaluator: original base was FROM ubuntu:24.04\n"
+    assert dockerfile.startswith("FROM registry.example/eval-base:verified\n")
+    assert dockerfile.index("RUN echo native-custom-layer\n") < dockerfile.index(
+        "# SkillEvaluator: original base was FROM ubuntu:24.04\n"
     )
-    assert "RUN echo native-custom-layer\n" in dockerfile
 
 
-def test_rebase_custom_dockerfile_content_without_from_is_unchanged() -> None:
+def test_rebase_custom_dockerfile_content_without_from_fails_closed() -> None:
     content = "# comment only\nRUN echo unchanged\n"
 
-    assert (
+    with pytest.raises(ValueError, match="exactly one FROM instruction"):
         _rebase_custom_dockerfile_content(
             content,
             "registry.example/eval-base:verified",
             agent_config_lines=[],
             include_input=False,
         )
-        is None
-    )
 
 
 @pytest.mark.parametrize("candidate", _GRADER_CANDIDATES, ids=str)

--- a/tests/test_harbor_adapter_safety.py
+++ b/tests/test_harbor_adapter_safety.py
@@ -356,7 +356,7 @@ def test_custom_grader_candidates_reject_external_symlinks(tmp_path: Path, candi
     _symlink_or_skip(grader, outside)
     task_dir = tmp_path / "task"
 
-    with pytest.raises(ValueError, match="non-symlinked regular file contained under evals/"):
+    with pytest.raises(ValueError, match=r"non-symlinked regular file contained under evals/|symlink|reparse"):
         _copy_custom_grader(task_dir, skill, "custom_only")
 
     assert not (task_dir / "tests" / candidate.name).exists()
@@ -476,7 +476,7 @@ def test_task_modes_reject_custom_grader_symlink_before_copy(tmp_path: Path, tas
     _symlink_or_skip(skill / "evals" / "grader.py", outside)
     output_dir = tmp_path / "tasks"
 
-    with pytest.raises(ValueError, match="non-symlinked regular file contained under evals/"):
+    with pytest.raises(ValueError, match=r"non-symlinked regular file contained under evals/|symlink|reparse"):
         if task_source == "generated":
             generate_harbor_tasks(skill, output_dir, with_skill=False, grading_mode="custom_only")
         else:

--- a/tests/test_harbor_case_id_safety.py
+++ b/tests/test_harbor_case_id_safety.py
@@ -64,7 +64,6 @@ def _write_skill(tmp_path: Path, case_ids: list[object]) -> Path:
         pytest.param('case"next', id="quote"),
         pytest.param(".hidden", id="leading-dot"),
         pytest.param("case.", id="trailing-dot"),
-        pytest.param("case..part", id="consecutive-dots"),
         pytest.param("x" * 129, id="overlong"),
         pytest.param(None, id="null"),
         pytest.param(True, id="boolean"),
@@ -125,6 +124,16 @@ def test_numeric_agentskills_id_is_canonicalized_for_harbor(tmp_path: Path) -> N
     assert task_config["metadata"]["entry_id"] == "1"
     entry = json.loads((task_paths[0] / "tests" / "entry.json").read_text(encoding="utf-8"))
     assert entry["id"] == "1"
+
+
+def test_consecutive_dots_inside_case_id_are_safe(tmp_path: Path) -> None:
+    skill_path = _write_skill(tmp_path, ["case..part"])
+    output_dir = tmp_path / "generated"
+
+    task_paths = generate_harbor_tasks(skill_path, output_dir)
+
+    assert task_paths == [output_dir / "case..part"]
+    assert (task_paths[0] / "task.toml").is_file()
 
 
 def test_validate_evals_reports_unsafe_case_ids(tmp_path: Path) -> None:
@@ -314,7 +323,7 @@ def test_all_dynamic_task_toml_strings_and_keys_are_quoted_for_real_harbor(tmp_p
         output_dir,
         runtime_env={"SAFE_ENV": hostile},
         pre_agent_setup=[hostile],
-        agent_workdir=hostile,
+        agent_workdir="/workspace/safe",
     )
     _write_task_toml(
         task_paths[0],

--- a/tests/test_harbor_html_report_failures.py
+++ b/tests/test_harbor_html_report_failures.py
@@ -523,7 +523,8 @@ def test_html_generation_failure_is_persisted_identically_to_returned_result(
 ) -> None:
     """A report warning is part of the final result contract on disk and in memory."""
     skill_path = tmp_path / "demo"
-    skill_path.mkdir()
+    (skill_path / "evals").mkdir(parents=True)
+    (skill_path / "evals" / "evals.json").write_text("[]\n", encoding="utf-8")
     cli_results_dir = tmp_path / "results"
     output_dir = external_results_root(cli_results_dir, skill_path)
     provider = ProviderConfig(

--- a/tests/test_harbor_input_staging.py
+++ b/tests/test_harbor_input_staging.py
@@ -18,8 +18,10 @@ from pathlib import Path
 
 import pytest
 
+import skillevaluator.tier3.harbor.adapter as adapter_module
 from skillevaluator.tier3.harbor.adapter import (
     _entry_file_refs,
+    _load_mcp_servers,
     _resolve_entry_file_ref,
     _stage_task_inputs,
     generate_harbor_tasks,
@@ -281,6 +283,68 @@ def test_generated_tasks_apply_per_entry_input_isolation(tmp_path: Path):
         assert "COPY input/ /workspace/input/" not in dockerfile
 
 
+def test_generation_uses_one_private_evals_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    skill, evals, _ = _make_skill(tmp_path)
+    (skill / "SKILL.md").write_text("# Snapshot test\n", encoding="utf-8")
+    (evals / "evals.json").write_text(
+        json.dumps([{"id": "case", "question": "dataset-A"}]),
+        encoding="utf-8",
+    )
+    (evals / "files" / "global.txt").write_text("fixture-A", encoding="utf-8")
+    moved = tmp_path / "moved-evals"
+    real_load = adapter_module._load_evals
+    swapped = False
+
+    def swap_original_evals_after_dataset_read(path: Path) -> list[dict[str, object]]:
+        nonlocal swapped
+        entries = real_load(path)
+        if not swapped:
+            swapped = True
+            evals.rename(moved)
+            replacement_files = evals / "files"
+            replacement_files.mkdir(parents=True)
+            (evals / "evals.json").write_text(
+                json.dumps([{"id": "case", "question": "dataset-B"}]),
+                encoding="utf-8",
+            )
+            (replacement_files / "global.txt").write_text("fixture-B", encoding="utf-8")
+        return entries
+
+    monkeypatch.setattr(adapter_module, "_load_evals", swap_original_evals_after_dataset_read)
+
+    task = generate_harbor_tasks(skill, tmp_path / "generated", with_skill=False)[0]
+
+    assert (task / "instruction.md").read_text(encoding="utf-8") == "dataset-A\n"
+    assert (task / "environment" / "input" / "global.txt").read_text(encoding="utf-8") == "fixture-A"
+
+
+@pytest.mark.parametrize("results_name", ("results", "Results"))
+def test_private_evals_snapshot_ignores_results_through_platform_root_aliases(
+    tmp_path: Path,
+    results_name: str,
+) -> None:
+    skill, evals, _ = _make_skill(tmp_path)
+    (skill / "SKILL.md").write_text("# Snapshot test\n", encoding="utf-8")
+    (evals / "evals.json").write_text(
+        json.dumps([{"id": "case", "question": "evaluate"}]),
+        encoding="utf-8",
+    )
+    results_dir = evals / results_name
+    run_dir = results_dir / "run-1"
+    run_dir.mkdir(parents=True)
+    try:
+        (results_dir / "current").symlink_to(run_dir.name, target_is_directory=True)
+    except OSError as exc:  # pragma: no cover - host policy, primarily native Windows
+        pytest.skip(f"symlinks unavailable on this host: {exc}")
+
+    task = generate_harbor_tasks(skill, tmp_path / "generated", with_skill=False)[0]
+
+    assert task.name == "case"
+
+
 @pytest.mark.parametrize("base_image", ["", "example.invalid/eval-base:latest"])
 def test_generated_task_copies_explicit_ref_without_shared_files_directory(tmp_path: Path, base_image: str):
     skill, evals, _ = _make_skill(tmp_path)
@@ -316,3 +380,260 @@ class TestResolveEntryFileRef:
         skill, evals, _ = _make_skill(tmp_path)
         with pytest.raises(ValueError, match="unsupported URI scheme"):
             _resolve_entry_file_ref("https://example.com/x", skill_path=skill, evals_dir=evals, input_files_dir=None)
+
+    @pytest.mark.parametrize(
+        "relative_path,is_directory",
+        [
+            ("evals.json", False),
+            ("EVALS.JSON", False),
+            ("dataset.yaml", False),
+            ("config.yml", False),
+            ("grader.py", False),
+            ("grader.sh", False),
+            ("EVAL.md", False),
+            ("benchmark_" + "conversion_report.md", False),
+            (".skillevaluator-generated-output", False),
+            ("tests", True),
+            ("harbor", True),
+            ("environment", True),
+            ("results", True),
+        ],
+    )
+    def test_evaluator_only_assets_cannot_be_declared_as_task_input(
+        self,
+        tmp_path: Path,
+        relative_path: str,
+        is_directory: bool,
+    ) -> None:
+        skill, evals, env_dir = _make_skill(tmp_path)
+        source = evals / relative_path
+        if is_directory:
+            source.mkdir()
+            (source / "secret.txt").write_text("evaluator-only", encoding="utf-8")
+        else:
+            source.write_text("evaluator-only", encoding="utf-8")
+
+        with pytest.raises(ValueError, match="evaluator-only"):
+            _stage_task_inputs(
+                env_dir,
+                input_files_dir=evals / "files",
+                entry={"id": "case", "files": [f"evals/{relative_path}"]},
+                source_skill_path=skill,
+                evals_dir=evals,
+            )
+
+        assert not (env_dir / "input").exists()
+
+
+class TestLoadMcpServersSafety:
+    def test_linked_mcp_configuration_is_rejected(self, tmp_path: Path) -> None:
+        skill = tmp_path / "skill"
+        environment = skill / "evals" / "environment"
+        environment.mkdir(parents=True)
+        outside = tmp_path / "outside-mcp_servers.toml"
+        outside.write_text('[[mcp_servers]]\nname = "outside"\ncommand = "/bin/sh"\n', encoding="utf-8")
+        link = environment / "mcp_servers.toml"
+        try:
+            link.symlink_to(outside)
+        except OSError as exc:  # pragma: no cover - host policy, primarily native Windows
+            pytest.skip(f"symlinks unavailable on this host: {exc}")
+
+        with pytest.raises(ValueError, match="regular non-linked file"):
+            _load_mcp_servers(skill)
+
+    def test_hardlinked_mcp_configuration_is_rejected(self, tmp_path: Path) -> None:
+        skill = tmp_path / "skill"
+        environment = skill / "evals" / "environment"
+        environment.mkdir(parents=True)
+        outside = tmp_path / "outside-mcp.toml"
+        outside.write_text('[[mcp_servers]]\nname = "outside"\ncommand = "/bin/sh"\n', encoding="utf-8")
+        try:
+            os.link(outside, environment / "mcp_servers.toml")
+        except OSError as exc:  # pragma: no cover - filesystem policy
+            pytest.skip(f"hardlinks unavailable on this host: {exc}")
+
+        with pytest.raises(ValueError, match="regular non-linked file"):
+            _load_mcp_servers(skill)
+
+    def test_linked_mcp_parent_directory_is_rejected(self, tmp_path: Path) -> None:
+        skill = tmp_path / "skill"
+        evals = skill / "evals"
+        evals.mkdir(parents=True)
+        outside = tmp_path / "outside-environment"
+        outside.mkdir()
+        (outside / "mcp_servers.toml").write_text(
+            '[[mcp_servers]]\nname = "outside"\ncommand = "/bin/sh"\n',
+            encoding="utf-8",
+        )
+        try:
+            (evals / "environment").symlink_to(outside, target_is_directory=True)
+        except OSError as exc:  # pragma: no cover - host policy, primarily native Windows
+            pytest.skip(f"symlinks unavailable on this host: {exc}")
+
+        with pytest.raises(ValueError, match=r"symlink|reparse"):
+            _load_mcp_servers(skill)
+
+    def test_linked_mcp_parent_is_rejected_even_when_config_is_absent(self, tmp_path: Path) -> None:
+        skill = tmp_path / "skill"
+        evals = skill / "evals"
+        evals.mkdir(parents=True)
+        outside = tmp_path / "outside-environment"
+        outside.mkdir()
+        try:
+            (evals / "environment").symlink_to(outside, target_is_directory=True)
+        except OSError as exc:  # pragma: no cover - host policy, primarily native Windows
+            pytest.skip(f"symlinks unavailable on this host: {exc}")
+
+        with pytest.raises(ValueError, match=r"symlink|reparse"):
+            _load_mcp_servers(skill)
+
+    def test_mcp_parent_change_is_rejected_before_missing_config_return(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        skill = tmp_path / "skill"
+        environment = skill / "evals" / "environment"
+        environment.mkdir(parents=True)
+        config = environment / "mcp_servers.toml"
+        config.write_text('[[mcp_servers]]\nname = "original"\ncommand = "/bin/sh"\n', encoding="utf-8")
+        moved = tmp_path / "moved-environment"
+        real_lexists = adapter_module.os.path.lexists
+        swapped = False
+
+        def swap_before_missing_check(path: os.PathLike[str] | str) -> bool:
+            nonlocal swapped
+            if not swapped and Path(path) == config:
+                swapped = True
+                environment.rename(moved)
+                environment.mkdir()
+                return False
+            return real_lexists(path)
+
+        monkeypatch.setattr(adapter_module.os.path, "lexists", swap_before_missing_check)
+
+        with pytest.raises(ValueError, match="changed"):
+            _load_mcp_servers(skill)
+
+    def test_mcp_parent_replaced_before_open_is_rejected(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        skill = tmp_path / "skill"
+        environment = skill / "evals" / "environment"
+        environment.mkdir(parents=True)
+        config = environment / "mcp_servers.toml"
+        config.write_text('[[mcp_servers]]\nname = "original"\ncommand = "/bin/sh"\n', encoding="utf-8")
+        moved = tmp_path / "moved-environment"
+        original_read_bytes = adapter_module.SecureRoot.read_bytes
+        swapped = False
+
+        def swap_parent(
+            secure_root: adapter_module.SecureRoot,
+            relative_path: Path,
+            max_bytes: int,
+            *,
+            expected: os.stat_result | None = None,
+        ) -> tuple[bytes, os.stat_result]:
+            nonlocal swapped
+            if not swapped and relative_path == Path("environment/mcp_servers.toml"):
+                swapped = True
+                environment.rename(moved)
+                environment.symlink_to(moved, target_is_directory=True)
+            return original_read_bytes(secure_root, relative_path, max_bytes, expected=expected)
+
+        monkeypatch.setattr(adapter_module.SecureRoot, "read_bytes", swap_parent)
+
+        with pytest.raises(ValueError, match=r"changed|symlink|reparse"):
+            _load_mcp_servers(skill)
+
+    def test_same_inode_mcp_rewrite_with_restored_mtime_is_rejected(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        skill = tmp_path / "skill"
+        environment = skill / "evals" / "environment"
+        environment.mkdir(parents=True)
+        config = environment / "mcp_servers.toml"
+        original_payload = '[[mcp_servers]]\nname = "alpha"\ncommand = "/bin/sh"\n'
+        replacement_payload = '[[mcp_servers]]\nname = "bravo"\ncommand = "/bin/sh"\n'
+        assert len(original_payload) == len(replacement_payload)
+        config.write_text(original_payload, encoding="utf-8")
+        original_metadata = config.stat()
+        original_read = adapter_module.os.read
+        mutated = False
+
+        def rewrite_named_source(descriptor: int, size: int) -> bytes:
+            nonlocal mutated
+            payload = original_read(descriptor, size)
+            if not mutated:
+                mutated = True
+                config.write_text(replacement_payload, encoding="utf-8")
+                os.utime(
+                    config,
+                    ns=(original_metadata.st_atime_ns, original_metadata.st_mtime_ns),
+                )
+                mutated_metadata = config.stat()
+                assert mutated_metadata.st_ino == original_metadata.st_ino
+                assert mutated_metadata.st_size == original_metadata.st_size
+                assert mutated_metadata.st_mtime_ns == original_metadata.st_mtime_ns
+            return payload
+
+        monkeypatch.setattr(adapter_module.os, "read", rewrite_named_source)
+
+        with pytest.raises(ValueError, match="changed while it was read"):
+            _load_mcp_servers(skill)
+
+    def test_mcp_configuration_replaced_during_read_is_rejected(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        skill = tmp_path / "skill"
+        environment = skill / "evals" / "environment"
+        environment.mkdir(parents=True)
+        config = environment / "mcp_servers.toml"
+        config.write_text('[[mcp_servers]]\nname = "original"\ncommand = "/bin/sh"\n', encoding="utf-8")
+        replacement = tmp_path / "replacement.toml"
+        replacement.write_text('[[mcp_servers]]\nname = "replaced"\ncommand = "/bin/sh"\n', encoding="utf-8")
+        original_read = adapter_module.os.read
+        swapped = False
+
+        def swap_named_source(descriptor: int, size: int) -> bytes:
+            nonlocal swapped
+            payload = original_read(descriptor, size)
+            if not swapped:
+                swapped = True
+                config.rename(environment / "original-opened.toml")
+                replacement.rename(config)
+            return payload
+
+        monkeypatch.setattr(adapter_module.os, "read", swap_named_source)
+
+        with pytest.raises(ValueError, match="changed while it was read"):
+            _load_mcp_servers(skill)
+
+    def test_task_generation_rejects_linked_mcp_before_output_mutation(self, tmp_path: Path) -> None:
+        skill = tmp_path / "skill"
+        evals = skill / "evals"
+        environment = evals / "environment"
+        environment.mkdir(parents=True)
+        (skill / "SKILL.md").write_text("# Test skill\n", encoding="utf-8")
+        (evals / "evals.json").write_text(
+            json.dumps([{"id": "case", "question": "Run the case"}]),
+            encoding="utf-8",
+        )
+        outside = tmp_path / "outside-mcp.toml"
+        outside.write_text('[[mcp_servers]]\nname = "outside"\ncommand = "/bin/sh"\n', encoding="utf-8")
+        try:
+            (environment / "mcp_servers.toml").symlink_to(outside)
+        except OSError as exc:  # pragma: no cover - host policy, primarily native Windows
+            pytest.skip(f"symlinks unavailable on this host: {exc}")
+        output = tmp_path / "generated"
+
+        with pytest.raises(ValueError, match=r"regular non-linked|symlink|reparse"):
+            generate_harbor_tasks(skill, output, with_skill=False)
+
+        assert not output.exists()

--- a/tests/test_harbor_input_staging.py
+++ b/tests/test_harbor_input_staging.py
@@ -178,6 +178,76 @@ class TestStageTaskInputs:
         )
         assert staged is False
 
+    def test_declared_file_symlink_to_undeclared_fixture_is_rejected(self, tmp_path: Path):
+        skill, evals, env_dir = _make_skill(tmp_path)
+        alias = evals / "files" / "alias.txt"
+        try:
+            alias.symlink_to("unrelated.txt")
+        except OSError as exc:  # pragma: no cover - host policy, primarily native Windows
+            pytest.skip(f"symlinks unavailable on this host: {exc}")
+
+        with pytest.raises(ValueError, match="symlink"):
+            _stage_task_inputs(
+                env_dir,
+                input_files_dir=evals / "files",
+                entry={"id": "t1", "files": ["files/alias.txt"]},
+                source_skill_path=skill,
+                evals_dir=evals,
+            )
+
+    def test_declared_directory_with_nested_symlink_is_rejected(self, tmp_path: Path):
+        skill, evals, env_dir = _make_skill(tmp_path)
+        declared = evals / "data" / "declared"
+        declared.mkdir()
+        alias = declared / "alias.txt"
+        try:
+            alias.symlink_to("../../files/unrelated.txt")
+        except OSError as exc:  # pragma: no cover - host policy, primarily native Windows
+            pytest.skip(f"symlinks unavailable on this host: {exc}")
+
+        with pytest.raises(ValueError, match="symlink"):
+            _stage_task_inputs(
+                env_dir,
+                input_files_dir=evals / "files",
+                entry={"id": "t1", "files": ["data/declared"]},
+                source_skill_path=skill,
+                evals_dir=evals,
+            )
+
+    def test_legacy_shared_directory_with_nested_symlink_is_rejected(self, tmp_path: Path):
+        skill, evals, env_dir = _make_skill(tmp_path)
+        alias = evals / "files" / "alias.txt"
+        try:
+            alias.symlink_to("unrelated.txt")
+        except OSError as exc:  # pragma: no cover - host policy, primarily native Windows
+            pytest.skip(f"symlinks unavailable on this host: {exc}")
+
+        with pytest.raises(ValueError, match="symlink"):
+            _stage_task_inputs(
+                env_dir,
+                input_files_dir=evals / "files",
+                entry={"id": "t1"},
+                source_skill_path=skill,
+                evals_dir=evals,
+            )
+
+    def test_declared_hardlink_is_rejected(self, tmp_path: Path):
+        skill, evals, env_dir = _make_skill(tmp_path)
+        alias = evals / "data" / "alias.txt"
+        try:
+            os.link(evals / "files" / "unrelated.txt", alias)
+        except OSError as exc:  # pragma: no cover - filesystem policy
+            pytest.skip(f"hardlinks unavailable on this host: {exc}")
+
+        with pytest.raises(ValueError, match=r"hardlink|hard link"):
+            _stage_task_inputs(
+                env_dir,
+                input_files_dir=evals / "files",
+                entry={"id": "t1", "files": ["data/alias.txt"]},
+                source_skill_path=skill,
+                evals_dir=evals,
+            )
+
 
 def test_generated_tasks_apply_per_entry_input_isolation(tmp_path: Path):
     skill, evals, _ = _make_skill(tmp_path)

--- a/tests/test_harbor_input_staging.py
+++ b/tests/test_harbor_input_staging.py
@@ -3,14 +3,17 @@
 
 """Regression tests for per-entry eval input staging.
 
-Ports SkillEvaluator 0.7.22 ``0d17f5e`` ("upload staged eval inputs to standard sandboxes")
-into the in-process Tier 3 engine (``tier3/harbor/adapter.py``). The adapter now
-stages both the shared ``evals/files/`` directory and each entry's ``files`` refs
-into the task ``input/`` dir, with traversal protection.
+Ports Skill Evaluator 0.7.22 ``0d17f5e`` ("upload staged eval inputs to standard sandboxes")
+into the in-process Tier 3 engine (``tier3/harbor/adapter.py``). Entries that
+declare ``files`` stage only those refs; entries that omit ``files`` retain the
+legacy shared ``evals/files/`` behavior. All refs retain traversal protection.
 """
 
 from __future__ import annotations
 
+import json
+import os
+import shutil
 from pathlib import Path
 
 import pytest
@@ -19,15 +22,19 @@ from skillevaluator.tier3.harbor.adapter import (
     _entry_file_refs,
     _resolve_entry_file_ref,
     _stage_task_inputs,
+    generate_harbor_tasks,
 )
 
 
 def _make_skill(tmp_path: Path) -> tuple[Path, Path, Path]:
     skill = tmp_path / "myskill"
+    (skill / "SKILL.md").parent.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("# Test skill\n")
     evals = skill / "evals"
     files = evals / "files"
     files.mkdir(parents=True)
     (files / "global.txt").write_text("global")
+    (files / "unrelated.txt").write_text("unrelated")
     data = evals / "data"
     data.mkdir()
     (data / "case1.txt").write_text("case1")
@@ -43,6 +50,9 @@ class TestEntryFileRefs:
     def test_string_is_wrapped(self):
         assert _entry_file_refs({"files": "data/case1.txt"}) == ["data/case1.txt"]
 
+    def test_explicit_null_returns_empty(self):
+        assert _entry_file_refs({"files": None}) == []
+
     def test_list_is_passed_through(self):
         assert _entry_file_refs({"files": ["a/b.txt", " c/d.txt "]}) == ["a/b.txt", "c/d.txt"]
 
@@ -52,15 +62,110 @@ class TestEntryFileRefs:
 
 
 class TestStageTaskInputs:
-    def test_stages_global_files_and_entry_refs(self, tmp_path: Path):
+    def test_explicit_files_stage_only_declared_refs(self, tmp_path: Path):
         skill, evals, env_dir = _make_skill(tmp_path)
         entry = {"id": "t1", "files": ["data/case1.txt"]}
         staged = _stage_task_inputs(
             env_dir, input_files_dir=evals / "files", entry=entry, source_skill_path=skill, evals_dir=evals
         )
         assert staged is True
-        names = sorted(p.name for p in (env_dir / "input").rglob("*") if p.is_file())
-        assert names == ["case1.txt", "global.txt"]
+        paths = sorted(
+            p.relative_to(env_dir / "input").as_posix() for p in (env_dir / "input").rglob("*") if p.is_file()
+        )
+        assert paths == ["data/case1.txt"]
+
+    def test_explicit_file_under_shared_directory_stages_only_that_file(self, tmp_path: Path):
+        skill, evals, env_dir = _make_skill(tmp_path)
+        staged = _stage_task_inputs(
+            env_dir,
+            input_files_dir=evals / "files",
+            entry={"id": "t1", "files": "files/global.txt"},
+            source_skill_path=skill,
+            evals_dir=evals,
+        )
+        assert staged is True
+        paths = sorted(
+            p.relative_to(env_dir / "input").as_posix() for p in (env_dir / "input").rglob("*") if p.is_file()
+        )
+        assert paths == ["global.txt"]
+
+    def test_omitted_files_stages_entire_shared_directory(self, tmp_path: Path):
+        skill, evals, env_dir = _make_skill(tmp_path)
+        staged = _stage_task_inputs(
+            env_dir,
+            input_files_dir=evals / "files",
+            entry={"id": "t1"},
+            source_skill_path=skill,
+            evals_dir=evals,
+        )
+        assert staged is True
+        paths = sorted(
+            p.relative_to(env_dir / "input").as_posix() for p in (env_dir / "input").rglob("*") if p.is_file()
+        )
+        assert paths == ["global.txt", "unrelated.txt"]
+
+    @pytest.mark.parametrize("files", [[], None, "", "   "])
+    def test_explicit_empty_files_stages_nothing_and_cleans_stale_input(self, tmp_path: Path, files: object):
+        skill, evals, env_dir = _make_skill(tmp_path)
+        input_dir = env_dir / "input"
+        input_dir.mkdir()
+        (input_dir / "stale.txt").write_text("stale")
+
+        staged = _stage_task_inputs(
+            env_dir,
+            input_files_dir=evals / "files",
+            entry={"id": "t1", "files": files},
+            source_skill_path=skill,
+            evals_dir=evals,
+        )
+
+        assert staged is False
+        assert not input_dir.exists()
+
+    @pytest.mark.parametrize("stale_kind", ["file", "symlink", "fifo"])
+    def test_explicit_empty_files_safely_cleans_non_directory_input(self, tmp_path: Path, stale_kind: str):
+        skill, evals, env_dir = _make_skill(tmp_path)
+        input_path = env_dir / "input"
+        symlink_target = tmp_path / "outside.txt"
+        symlink_target.write_text("keep")
+        if stale_kind == "file":
+            input_path.write_text("stale")
+        elif stale_kind == "symlink":
+            input_path.symlink_to(symlink_target)
+        else:
+            if not hasattr(os, "mkfifo"):
+                pytest.skip("FIFOs are unavailable on this platform")
+            os.mkfifo(input_path)
+
+        staged = _stage_task_inputs(
+            env_dir,
+            input_files_dir=evals / "files",
+            entry={"id": "t1", "files": []},
+            source_skill_path=skill,
+            evals_dir=evals,
+        )
+
+        assert staged is False
+        assert not os.path.lexists(input_path)
+        assert symlink_target.read_text() == "keep"
+
+    def test_explicit_refs_replace_stale_input(self, tmp_path: Path):
+        skill, evals, env_dir = _make_skill(tmp_path)
+        input_dir = env_dir / "input"
+        input_dir.mkdir()
+        (input_dir / "stale.txt").write_text("stale")
+
+        staged = _stage_task_inputs(
+            env_dir,
+            input_files_dir=evals / "files",
+            entry={"id": "t1", "files": ["data/case1.txt"]},
+            source_skill_path=skill,
+            evals_dir=evals,
+        )
+
+        assert staged is True
+        paths = sorted(p.relative_to(input_dir).as_posix() for p in input_dir.rglob("*") if p.is_file())
+        assert paths == ["data/case1.txt"]
 
     def test_no_inputs_returns_false(self, tmp_path: Path):
         skill = tmp_path / "myskill"
@@ -72,6 +177,55 @@ class TestStageTaskInputs:
             env_dir, input_files_dir=None, entry={"id": "t"}, source_skill_path=skill, evals_dir=evals
         )
         assert staged is False
+
+
+def test_generated_tasks_apply_per_entry_input_isolation(tmp_path: Path):
+    skill, evals, _ = _make_skill(tmp_path)
+    entries = [
+        {"id": "legacy", "question": "legacy"},
+        {"id": "selected", "question": "selected", "files": ["data/case1.txt"]},
+        {"id": "empty", "question": "empty", "files": []},
+        {"id": "null", "question": "null", "files": None},
+    ]
+    (evals / "evals.json").write_text(json.dumps(entries))
+
+    task_dirs = generate_harbor_tasks(skill, tmp_path / "generated")
+    tasks = {task.name: task for task in task_dirs}
+
+    def staged_paths(case_id: str) -> list[str]:
+        input_dir = tasks[case_id] / "environment" / "input"
+        if not input_dir.exists():
+            return []
+        return sorted(path.relative_to(input_dir).as_posix() for path in input_dir.rglob("*") if path.is_file())
+
+    assert staged_paths("legacy") == ["global.txt", "unrelated.txt"]
+    assert staged_paths("selected") == ["data/case1.txt"]
+    assert staged_paths("empty") == []
+    assert staged_paths("null") == []
+
+    for case_id in ("legacy", "selected"):
+        dockerfile = (tasks[case_id] / "environment" / "Dockerfile").read_text()
+        assert "COPY input/ /workspace/input/" in dockerfile
+    for case_id in ("empty", "null"):
+        dockerfile = (tasks[case_id] / "environment" / "Dockerfile").read_text()
+        assert "COPY input/ /workspace/input/" not in dockerfile
+
+
+@pytest.mark.parametrize("base_image", ["", "example.invalid/eval-base:latest"])
+def test_generated_task_copies_explicit_ref_without_shared_files_directory(tmp_path: Path, base_image: str):
+    skill, evals, _ = _make_skill(tmp_path)
+    shutil.rmtree(evals / "files")
+    entries = [{"id": "selected", "question": "selected", "files": "data/case1.txt"}]
+    (evals / "evals.json").write_text(json.dumps(entries))
+
+    task = generate_harbor_tasks(skill, tmp_path / "generated", base_image=base_image)[0]
+
+    input_dir = task / "environment" / "input"
+    assert [path.relative_to(input_dir).as_posix() for path in input_dir.rglob("*") if path.is_file()] == [
+        "data/case1.txt"
+    ]
+    dockerfile = (task / "environment" / "Dockerfile").read_text()
+    assert "COPY input/ /workspace/input/" in dockerfile
 
 
 class TestResolveEntryFileRef:

--- a/tests/test_harbor_local_mode.py
+++ b/tests/test_harbor_local_mode.py
@@ -2627,6 +2627,7 @@ def test_strict_exec_filters_broad_prefixes_and_publishes_selected_npm_runtime(
         @staticmethod
         def wrap(argv: list[str], **kwargs: object) -> list[str]:
             captured["extra_ro"] = kwargs["extra_ro"]
+            captured["deny_reads"] = kwargs["deny_reads"]
             captured["wrapped"] = real_sandbox.wrap(argv, **kwargs)  # type: ignore[arg-type]
             return argv
 
@@ -2640,6 +2641,7 @@ def test_strict_exec_filters_broad_prefixes_and_publishes_selected_npm_runtime(
     extra_ro = captured["extra_ro"]
     assert isinstance(wrapped, list)
     assert isinstance(extra_ro, list)
+    assert captured["deny_reads"] == (Path(os.environ["SKILLEVALUATOR_OUTPUT_PROVENANCE_KEY_FILE"]),)
     ro_binds = {tuple(wrapped[index + 1 : index + 3]) for index, value in enumerate(wrapped) if value == "--ro-bind"}
     symlinks = {tuple(wrapped[index + 1 : index + 3]) for index, value in enumerate(wrapped) if value == "--symlink"}
     broad_roots = {"/", "/usr", "/usr/local", "/opt", "/tmp", "/private/tmp", "/var/tmp", str(Path.home())}

--- a/tests/test_harbor_local_sandbox.py
+++ b/tests/test_harbor_local_sandbox.py
@@ -1505,3 +1505,87 @@ else:
         finally:
             runtime_write_probe.unlink(missing_ok=True)
             shutil.rmtree(probe_dir, ignore_errors=True)
+
+
+def test_bwrap_masks_explicit_denied_key_inside_broad_read_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    broad = tmp_path / "broad"
+    key = broad / "state" / "output-provenance.key"
+    key.parent.mkdir(parents=True)
+    key.write_text("secret", encoding="utf-8")
+    run_root = tmp_path / "run"
+    home = run_root / "home"
+    sandbox_tmp = run_root / "tmp"
+    home.mkdir(parents=True)
+    sandbox_tmp.mkdir()
+    monkeypatch.setattr(local_sandbox, "_SYSTEM_RO_PATHS", (str(broad),))
+
+    argv = local_sandbox._bwrap_argv(
+        ["/usr/bin/true"],
+        workdir=run_root,
+        write_roots=[run_root],
+        home=home,
+        tmp=sandbox_tmp,
+        allow_net=False,
+        extra_ro=[],
+        deny_reads=[key],
+    )
+
+    ro_binds = [argv[index : index + 3] for index, value in enumerate(argv) if value == "--ro-bind"]
+    assert ["--ro-bind", "/dev/null", str(key.resolve())] in ro_binds
+
+
+def test_seatbelt_profile_explicitly_denies_provenance_key(tmp_path: Path) -> None:
+    key = tmp_path / "private" / "output-provenance.key"
+    key.parent.mkdir()
+    key.write_text("secret", encoding="utf-8")
+    run_root = tmp_path / "run"
+    home = run_root / "home"
+    sandbox_tmp = run_root / "tmp"
+    home.mkdir(parents=True)
+    sandbox_tmp.mkdir()
+
+    argv = local_sandbox._seatbelt_argv(
+        ["/usr/bin/true"],
+        write_roots=[run_root],
+        tmp=sandbox_tmp,
+        home=home,
+        extra_ro=[key.parent],
+        allow_net=False,
+        deny_reads=[key],
+    )
+
+    profile = argv[2]
+    assert f'(deny file-read* (literal "{local_sandbox._sbpl_quote(key.absolute())}"))' in profile
+    assert f'(deny file-read* (literal "{local_sandbox._sbpl_quote(key.resolve())}"))' in profile
+
+
+@pytest.mark.skipif(
+    platform.system() != "Darwin" or not Path("/usr/bin/sandbox-exec").exists(),
+    reason="requires macOS sandbox-exec",
+)
+def test_actual_seatbelt_blocks_provenance_key_read(tmp_path: Path) -> None:
+    key = tmp_path / "private" / "output-provenance.key"
+    key.parent.mkdir()
+    key.write_text("secret", encoding="utf-8")
+    run_root = tmp_path / "run"
+    home = run_root / "home"
+    sandbox_tmp = run_root / "tmp"
+    home.mkdir(parents=True)
+    sandbox_tmp.mkdir()
+    argv = local_sandbox._seatbelt_argv(
+        ["/bin/cat", str(key)],
+        write_roots=[run_root],
+        tmp=sandbox_tmp,
+        home=home,
+        extra_ro=[key.parent],
+        allow_net=False,
+        deny_reads=[key],
+    )
+
+    result = subprocess.run(argv, capture_output=True, text=True, check=False)
+
+    assert result.returncode != 0
+    assert "secret" not in result.stdout

--- a/tests/test_harbor_output_provenance.py
+++ b/tests/test_harbor_output_provenance.py
@@ -11,6 +11,7 @@ import shutil
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -57,6 +58,170 @@ def _in_skill_output(skill: Path, name: str) -> tuple[Path, Path]:
     return declared_root, declared_root / "dataset"
 
 
+def _simulate_windows_crt_fstat_identity(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Return valid descriptor metadata with a Windows-incompatible identity."""
+    original_fstat = output_provenance.os.fstat
+
+    def incompatible_fstat(descriptor: int) -> object:
+        opened = original_fstat(descriptor)
+        return SimpleNamespace(
+            st_dev=opened.st_dev + 10_000,
+            st_ino=opened.st_ino + 10_000,
+            st_mode=opened.st_mode,
+            st_nlink=opened.st_nlink,
+            st_size=opened.st_size,
+            st_uid=opened.st_uid,
+            st_mtime_ns=opened.st_mtime_ns,
+            st_ctime_ns=opened.st_ctime_ns,
+        )
+
+    monkeypatch.setattr(output_provenance, "_PATH_DESCRIPTOR_IDENTITIES_COMPARABLE", False, raising=False)
+    monkeypatch.setattr(output_provenance.os, "fstat", incompatible_fstat)
+
+
+def test_atomic_output_accepts_windows_crt_descriptor_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "result.json"
+    destination.write_bytes(b"old")
+    _simulate_windows_crt_fstat_identity(monkeypatch)
+
+    output_provenance.write_output_file_atomically(destination, b"complete")
+
+    assert destination.read_bytes() == b"complete"
+    assert not list(tmp_path.glob(".result.json.*.tmp"))
+
+
+def test_marker_failure_cleanup_accepts_windows_crt_descriptor_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "generated"
+    root.mkdir()
+    original_fdopen = output_provenance.os.fdopen
+
+    class _FailingWriter:
+        def __init__(self, handle: object) -> None:
+            self._handle = handle
+
+        def __enter__(self) -> _FailingWriter:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            self._handle.close()  # type: ignore[attr-defined]
+
+        def write(self, payload: bytes) -> int:
+            self._handle.write(payload[:1])  # type: ignore[attr-defined]
+            self._handle.flush()  # type: ignore[attr-defined]
+            raise OSError("injected marker write failure")
+
+        def flush(self) -> None:
+            self._handle.flush()  # type: ignore[attr-defined]
+
+        def fileno(self) -> int:
+            return self._handle.fileno()  # type: ignore[attr-defined,no-any-return]
+
+    monkeypatch.setattr(output_provenance, "_load_or_create_key", lambda: b"k" * 32)
+    monkeypatch.setattr(
+        output_provenance.os,
+        "fdopen",
+        lambda descriptor, *args, **kwargs: _FailingWriter(original_fdopen(descriptor, *args, **kwargs)),
+    )
+    _simulate_windows_crt_fstat_identity(monkeypatch)
+
+    with pytest.raises(OSError, match="injected marker write failure"):
+        output_provenance.write_generated_output_marker(root)
+
+    assert list(root.iterdir()) == []
+
+
+@pytest.mark.parametrize("failure_point", ["fstat", "lstat"])
+def test_marker_metadata_failure_closes_descriptor_without_unproven_name_cleanup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure_point: str,
+) -> None:
+    root = tmp_path / "generated"
+    root.mkdir()
+    marker = root / GENERATED_OUTPUT_MARKER
+    original_close = output_provenance.os.close
+    original_fstat = output_provenance.os.fstat
+    original_lstat = output_provenance.Path.lstat
+    original_unlink_if_same_file = output_provenance._unlink_if_same_file
+    closed_descriptors: list[int] = []
+    cleanup_attempts: list[Path] = []
+    failure_injected = False
+
+    def tracked_close(descriptor: int) -> None:
+        closed_descriptors.append(descriptor)
+        original_close(descriptor)
+
+    def injected_fstat(descriptor: int) -> os.stat_result:
+        nonlocal failure_injected
+        if failure_point == "fstat" and not failure_injected:
+            failure_injected = True
+            raise OSError("injected marker fstat failure")
+        return original_fstat(descriptor)
+
+    def injected_lstat(path: Path) -> os.stat_result:
+        nonlocal failure_injected
+        if failure_point == "lstat" and path == marker and not failure_injected:
+            failure_injected = True
+            raise OSError("injected marker lstat failure")
+        return original_lstat(path)
+
+    def track_cleanup(path: Path, expected: os.stat_result) -> bool:
+        cleanup_attempts.append(path)
+        return original_unlink_if_same_file(path, expected)
+
+    monkeypatch.setattr(output_provenance, "_load_or_create_key", lambda: b"k" * 32)
+    monkeypatch.setattr(output_provenance.os, "close", tracked_close)
+    monkeypatch.setattr(output_provenance.os, "fstat", injected_fstat)
+    monkeypatch.setattr(output_provenance.Path, "lstat", injected_lstat)
+    monkeypatch.setattr(output_provenance, "_unlink_if_same_file", track_cleanup)
+
+    with pytest.raises(OSError, match=rf"injected marker {failure_point} failure"):
+        output_provenance.write_generated_output_marker(root)
+
+    assert failure_injected
+    assert closed_descriptors
+    assert cleanup_attempts == []
+    assert marker.is_file()
+
+
+@pytest.mark.skipif(os.name != "posix", reason="requires POSIX rename-while-open behavior")
+def test_marker_lstat_failure_never_unlinks_a_substituted_name(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "generated"
+    root.mkdir()
+    marker = root / GENERATED_OUTPUT_MARKER
+    original_partial = root / ".original-partial-marker"
+    original_lstat = output_provenance.Path.lstat
+    substituted = False
+
+    def substitute_then_fail(path: Path) -> os.stat_result:
+        nonlocal substituted
+        if path == marker and not substituted:
+            substituted = True
+            marker.rename(original_partial)
+            marker.write_text("preserve replacement\n", encoding="utf-8")
+            raise OSError("injected marker lstat failure after substitution")
+        return original_lstat(path)
+
+    monkeypatch.setattr(output_provenance, "_load_or_create_key", lambda: b"k" * 32)
+    monkeypatch.setattr(output_provenance.Path, "lstat", substitute_then_fail)
+
+    with pytest.raises(OSError, match="injected marker lstat failure after substitution"):
+        output_provenance.write_generated_output_marker(root)
+
+    assert substituted
+    assert marker.read_text(encoding="utf-8") == "preserve replacement\n"
+    assert original_partial.is_file()
+
+
 def test_concurrent_first_key_creation_publishes_one_complete_key(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -99,6 +264,113 @@ def test_interrupted_hardlink_publish_is_recovered(tmp_path: Path) -> None:
     assert payload.startswith(b"SkillEvaluator generated output v2\n")
     assert not temporary.exists()
     assert key_path.stat().st_nlink == 1
+
+
+@pytest.mark.parametrize("failure_point", ["write", "fsync"])
+def test_marker_publication_failure_removes_only_its_partial_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure_point: str,
+) -> None:
+    """A failed marker claim must not leave a plausible owned reservation."""
+    root = tmp_path / "generated"
+    root.mkdir()
+    output_provenance.generated_output_marker_payload(tmp_path / "seed")
+    original_fdopen = output_provenance.os.fdopen
+    original_fsync = output_provenance.os.fsync
+
+    class _PartialWriter:
+        def __init__(self, handle: object) -> None:
+            self._handle = handle
+
+        def __enter__(self) -> _PartialWriter:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            self._handle.close()  # type: ignore[attr-defined]
+
+        def write(self, payload: bytes) -> int:
+            self._handle.write(payload[: len(payload) // 2])  # type: ignore[attr-defined]
+            self._handle.flush()  # type: ignore[attr-defined]
+            raise OSError("injected marker write failure")
+
+        def flush(self) -> None:
+            self._handle.flush()  # type: ignore[attr-defined]
+
+        def fileno(self) -> int:
+            return self._handle.fileno()  # type: ignore[attr-defined,no-any-return]
+
+    if failure_point == "write":
+        monkeypatch.setattr(
+            output_provenance.os,
+            "fdopen",
+            lambda descriptor, *args, **kwargs: _PartialWriter(original_fdopen(descriptor, *args, **kwargs)),
+        )
+        expected_error = "injected marker write failure"
+    else:
+        monkeypatch.setattr(
+            output_provenance.os,
+            "fsync",
+            lambda _descriptor: (_ for _ in ()).throw(OSError("injected marker fsync failure")),
+        )
+        expected_error = "injected marker fsync failure"
+
+    with pytest.raises(OSError, match=expected_error):
+        output_provenance.write_generated_output_marker(root)
+
+    assert not (root / GENERATED_OUTPUT_MARKER).exists()
+    assert list(root.iterdir()) == []
+    monkeypatch.setattr(output_provenance.os, "fdopen", original_fdopen)
+    monkeypatch.setattr(output_provenance.os, "fsync", original_fsync)
+
+
+def test_owned_output_cleanup_refuses_a_path_substituted_after_authentication(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "reserved-run"
+    moved_root = tmp_path / "moved-reserved-run"
+    mark_generated_output_root(root)
+    original_identity = root.stat().st_dev, root.stat().st_ino
+    original_fingerprint = output_provenance._node_fingerprint
+    root_fingerprint_calls = 0
+
+    def substitute_after_identity_check(metadata: os.stat_result) -> tuple[int, int, int, int, int]:
+        nonlocal root_fingerprint_calls
+        fingerprint = original_fingerprint(metadata)
+        if (metadata.st_dev, metadata.st_ino) == original_identity:
+            root_fingerprint_calls += 1
+            if root_fingerprint_calls == 2:
+                root.rename(moved_root)
+                root.mkdir()
+                (root / "preserve.txt").write_text("replacement\n", encoding="utf-8")
+        return fingerprint
+
+    monkeypatch.setattr(output_provenance, "_node_fingerprint", substitute_after_identity_check)
+
+    removed = output_provenance.remove_generated_output_root_if_owned(root)
+
+    assert removed is False
+    assert (root / "preserve.txt").read_text(encoding="utf-8") == "replacement\n"
+    assert moved_root.is_dir()
+
+
+def test_fallback_owned_output_cleanup_never_recursively_deletes_contents(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "reserved-run"
+    mark_generated_output_root(root)
+    sentinel = root / "preserve.txt"
+    sentinel.write_text("preserve\n", encoding="utf-8")
+    identity = root.stat().st_dev, root.stat().st_ino
+    monkeypatch.setattr(output_provenance, "_DESCRIPTOR_BACKEND", False)
+
+    removed = output_provenance.remove_generated_output_root_if_owned(root, expected_identity=identity)
+
+    assert removed is False
+    assert sentinel.read_text(encoding="utf-8") == "preserve\n"
+    assert (root / GENERATED_OUTPUT_MARKER).is_file()
 
 
 def test_fixed_marker_cannot_authorize_authored_source_replacement(tmp_path: Path) -> None:

--- a/tests/test_harbor_output_provenance.py
+++ b/tests/test_harbor_output_provenance.py
@@ -424,32 +424,83 @@ def test_invalid_marker_blocks_in_skill_atomic_replacement(tmp_path: Path, nativ
     assert sentinel.read_text(encoding="utf-8") == "preserve\n"
 
 
+@pytest.mark.parametrize(
+    "force_fallback",
+    [
+        False,
+        pytest.param(
+            True,
+            marks=pytest.mark.skipif(os.name == "nt", reason="native Windows already exercises the fallback publisher"),
+        ),
+    ],
+)
 def test_partial_atomic_publication_preserves_signed_output_and_reruns(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    force_fallback: bool,
 ) -> None:
+    if force_fallback:
+        monkeypatch.setattr(secure_copy, "_DESCRIPTOR_BACKEND", False)
+        monkeypatch.setattr(secure_copy, "_ATOMIC_RENAME", None)
     skill = _write_skill(tmp_path)
     declared_root, output = _in_skill_output(skill, "partial-results")
     generate_harbor_tasks(skill, output, repo_context_exclude_paths=(declared_root,))
     old_dataset = (output / "dataset.toml").read_bytes()
-    original_rename = secure_copy._rename_no_replace
+    output_parent_metadata = output.parent.stat()
     rename_calls = 0
 
-    def _fail_second_rename(*args: object, **kwargs: object) -> None:
-        nonlocal rename_calls
-        rename_calls += 1
-        if rename_calls == 2:
-            raise OSError("injected generated-output publish failure after old destination moved")
-        original_rename(*args, **kwargs)
+    using_fallback = not secure_copy._DESCRIPTOR_BACKEND or secure_copy._ATOMIC_RENAME is None
+    if using_fallback:
+        original_path_rename = Path.rename
 
-    monkeypatch.setattr(secure_copy, "_rename_no_replace", _fail_second_rename)
+        def _fail_second_path_rename(source: Path, target: Path) -> Path:
+            nonlocal rename_calls
+            target_path = Path(target)
+            if output in (source, target_path):
+                rename_calls += 1
+                if rename_calls == 2:
+                    raise OSError("injected generated-output publish failure after old destination moved")
+            return original_path_rename(source, target_path)
+
+        monkeypatch.setattr(Path, "rename", _fail_second_path_rename)
+    else:
+        original_atomic_rename = secure_copy._rename_no_replace
+
+        def _fail_second_atomic_rename(
+            source_name: str,
+            destination_name: str,
+            *,
+            source_parent: int,
+            destination_parent: int,
+        ) -> None:
+            nonlocal rename_calls
+            in_output_parent = os.path.samestat(
+                os.fstat(source_parent),
+                output_parent_metadata,
+            ) and os.path.samestat(os.fstat(destination_parent), output_parent_metadata)
+            if in_output_parent and output.name in (source_name, destination_name):
+                rename_calls += 1
+                if rename_calls == 2:
+                    raise OSError("injected generated-output publish failure after old destination moved")
+            original_atomic_rename(
+                source_name,
+                destination_name,
+                source_parent=source_parent,
+                destination_parent=destination_parent,
+            )
+
+        monkeypatch.setattr(secure_copy, "_rename_no_replace", _fail_second_atomic_rename)
     with pytest.raises(OSError, match="generated-output publish"):
         generate_harbor_tasks(skill, output, repo_context_exclude_paths=(declared_root,))
 
+    assert rename_calls == 3
     assert (output / "dataset.toml").read_bytes() == old_dataset
     assert is_generated_output_root(output)
 
-    monkeypatch.setattr(secure_copy, "_rename_no_replace", original_rename)
+    if using_fallback:
+        monkeypatch.setattr(Path, "rename", original_path_rename)
+    else:
+        monkeypatch.setattr(secure_copy, "_rename_no_replace", original_atomic_rename)
     tasks = generate_harbor_tasks(skill, output, repo_context_exclude_paths=(declared_root,))
     assert tasks
     assert is_generated_output_root(output)

--- a/tests/test_harbor_output_provenance.py
+++ b/tests/test_harbor_output_provenance.py
@@ -1,0 +1,262 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression coverage for path-bound generated-output provenance."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from skillevaluator.tier3 import output_provenance
+from skillevaluator.tier3.harbor import secure_copy
+from skillevaluator.tier3.harbor.adapter import generate_harbor_tasks, stage_native_harbor_tasks
+from skillevaluator.tier3.output_provenance import (
+    GENERATED_OUTPUT_MARKER,
+    is_generated_output_root,
+    mark_generated_output_root,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_output_provenance_key(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv(
+        "SKILLEVALUATOR_OUTPUT_PROVENANCE_KEY_FILE",
+        str(tmp_path / ".skillevaluator-state" / "output-provenance.key"),
+    )
+
+
+def _write_skill(tmp_path: Path, *, native: bool = False) -> Path:
+    skill = tmp_path / "skill"
+    (skill / "evals").mkdir(parents=True)
+    (skill / "SKILL.md").write_text("# Test skill\n", encoding="utf-8")
+    (skill / "evals" / "evals.json").write_text(
+        json.dumps([{"id": "case-001", "question": "Complete the task.", "files": []}]),
+        encoding="utf-8",
+    )
+    if native:
+        task = skill / "evals" / "harbor" / "case-001"
+        task.mkdir(parents=True)
+        (task / "instruction.md").write_text("Complete the native task.\n", encoding="utf-8")
+        (task / "task.toml").write_text(
+            'schema_version = "1.3"\n\n[task]\nname = "nvidia/case-001"\n\n'
+            '[metadata]\nentry_id = "case-001"\n\n[environment]\n',
+            encoding="utf-8",
+        )
+    return skill
+
+
+def _in_skill_output(skill: Path, name: str) -> tuple[Path, Path]:
+    declared_root = skill / name
+    return declared_root, declared_root / "dataset"
+
+
+def test_concurrent_first_key_creation_publishes_one_complete_key(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "generated"
+    barrier = threading.Barrier(2)
+    original_link = output_provenance.os.link
+
+    def synchronized_link(source: Path, target: Path) -> None:
+        barrier.wait(timeout=5)
+        original_link(source, target)
+
+    monkeypatch.setattr(output_provenance.os, "link", synchronized_link)
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        payloads = list(
+            executor.map(
+                lambda _index: output_provenance.generated_output_marker_payload(destination),
+                range(2),
+            )
+        )
+
+    key_path = Path(os.environ["SKILLEVALUATOR_OUTPUT_PROVENANCE_KEY_FILE"])
+    assert payloads[0] == payloads[1]
+    if os.name == "nt":
+        assert 32 < key_path.stat().st_size <= 4096
+    else:
+        assert key_path.stat().st_size == 32
+    assert key_path.stat().st_nlink == 1
+    assert not list(key_path.parent.glob(".output-provenance.key.tmp-*"))
+
+
+def test_interrupted_hardlink_publish_is_recovered(tmp_path: Path) -> None:
+    key_path = Path(os.environ["SKILLEVALUATOR_OUTPUT_PROVENANCE_KEY_FILE"])
+    output_provenance.generated_output_marker_payload(tmp_path / "seed")
+    temporary = key_path.parent / ".output-provenance.key.tmp-interrupted"
+    os.link(key_path, temporary)
+
+    payload = output_provenance.generated_output_marker_payload(tmp_path / "generated")
+
+    assert payload.startswith(b"SkillEvaluator generated output v2\n")
+    assert not temporary.exists()
+    assert key_path.stat().st_nlink == 1
+
+
+def test_fixed_marker_cannot_authorize_authored_source_replacement(tmp_path: Path) -> None:
+    skill = _write_skill(tmp_path)
+    declared_root, output = _in_skill_output(skill, "fixed-marker-results")
+    authored_task = output / "case-001"
+    authored_task.mkdir(parents=True)
+    (output / GENERATED_OUTPUT_MARKER).write_bytes(b"SkillEvaluator generated output v1\n")
+    (authored_task / "SKILL.md").write_text("# Authored source\n", encoding="utf-8")
+    sentinel = authored_task / "keep.txt"
+    sentinel.write_text("preserve\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match=r"runtime skill source|marker"):
+        generate_harbor_tasks(skill, output, repo_context_exclude_paths=(declared_root,))
+
+    assert sentinel.read_text(encoding="utf-8") == "preserve\n"
+
+
+def test_generated_marker_is_bound_to_its_original_destination(tmp_path: Path) -> None:
+    skill = _write_skill(tmp_path)
+    original_root, original = _in_skill_output(skill, "original-results")
+    copied_root, copied = _in_skill_output(skill, "copied-results")
+    generate_harbor_tasks(skill, original, repo_context_exclude_paths=(original_root,))
+    copied.mkdir(parents=True)
+    shutil.copy2(original / GENERATED_OUTPUT_MARKER, copied / GENERATED_OUTPUT_MARKER)
+    authored_task = copied / "case-001"
+    authored_task.mkdir()
+    (authored_task / "SKILL.md").write_text("# Authored source\n", encoding="utf-8")
+    sentinel = authored_task / "keep.txt"
+    sentinel.write_text("preserve\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match=r"runtime skill source|marker"):
+        generate_harbor_tasks(skill, copied, repo_context_exclude_paths=(copied_root,))
+
+    assert sentinel.read_text(encoding="utf-8") == "preserve\n"
+
+
+@pytest.mark.parametrize("native", [False, True])
+def test_invalid_marker_blocks_in_skill_atomic_replacement(tmp_path: Path, native: bool) -> None:
+    skill = _write_skill(tmp_path, native=native)
+    declared_root, output = _in_skill_output(skill, "invalid-marker-results")
+    output.mkdir(parents=True)
+    (output / GENERATED_OUTPUT_MARKER).write_text("invalid\n", encoding="utf-8")
+    sentinel = output / "keep.txt"
+    sentinel.write_text("preserve\n", encoding="utf-8")
+    stager = stage_native_harbor_tasks if native else generate_harbor_tasks
+
+    with pytest.raises(ValueError, match="marker"):
+        stager(skill, output, repo_context_exclude_paths=(declared_root,))
+
+    assert sentinel.read_text(encoding="utf-8") == "preserve\n"
+
+
+def test_partial_atomic_publication_preserves_signed_output_and_reruns(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    skill = _write_skill(tmp_path)
+    declared_root, output = _in_skill_output(skill, "partial-results")
+    generate_harbor_tasks(skill, output, repo_context_exclude_paths=(declared_root,))
+    old_dataset = (output / "dataset.toml").read_bytes()
+    original_rename = secure_copy._rename_no_replace
+    rename_calls = 0
+
+    def _fail_second_rename(*args: object, **kwargs: object) -> None:
+        nonlocal rename_calls
+        rename_calls += 1
+        if rename_calls == 2:
+            raise OSError("injected generated-output publish failure after old destination moved")
+        original_rename(*args, **kwargs)
+
+    monkeypatch.setattr(secure_copy, "_rename_no_replace", _fail_second_rename)
+    with pytest.raises(OSError, match="generated-output publish"):
+        generate_harbor_tasks(skill, output, repo_context_exclude_paths=(declared_root,))
+
+    assert (output / "dataset.toml").read_bytes() == old_dataset
+    assert is_generated_output_root(output)
+
+    monkeypatch.setattr(secure_copy, "_rename_no_replace", original_rename)
+    tasks = generate_harbor_tasks(skill, output, repo_context_exclude_paths=(declared_root,))
+    assert tasks
+    assert is_generated_output_root(output)
+
+
+def test_external_output_retains_unmarked_overwrite_behavior(tmp_path: Path) -> None:
+    skill = _write_skill(tmp_path)
+    output = tmp_path / "external-output"
+    output.mkdir()
+    (output / GENERATED_OUTPUT_MARKER).write_text("invalid\n", encoding="utf-8")
+    sentinel = output / "keep.txt"
+    sentinel.write_text("replace\n", encoding="utf-8")
+
+    tasks = generate_harbor_tasks(skill, output)
+
+    assert tasks
+    assert not sentinel.exists()
+    assert not (output / GENERATED_OUTPUT_MARKER).exists()
+
+
+def test_unsigned_v2_marker_does_not_create_private_key(tmp_path: Path) -> None:
+    skill = _write_skill(tmp_path)
+    declared_root, output = _in_skill_output(skill, "unsigned-results")
+    output.mkdir(parents=True)
+    (output / GENERATED_OUTPUT_MARKER).write_bytes(b"SkillEvaluator generated output v2\n" + (b"A" * 43) + b"\n")
+    sentinel = output / "keep.txt"
+    sentinel.write_text("preserve\n", encoding="utf-8")
+    key_path = Path(os.environ["SKILLEVALUATOR_OUTPUT_PROVENANCE_KEY_FILE"])
+
+    with pytest.raises(ValueError, match="marker"):
+        generate_harbor_tasks(skill, output, repo_context_exclude_paths=(declared_root,))
+
+    assert sentinel.read_text(encoding="utf-8") == "preserve\n"
+    assert not key_path.exists()
+
+
+def test_key_override_inside_skill_is_rejected_before_mutation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    skill = _write_skill(tmp_path)
+    declared_root, output = _in_skill_output(skill, "key-location-results")
+    key_path = skill / "private-output-key"
+    monkeypatch.setenv("SKILLEVALUATOR_OUTPUT_PROVENANCE_KEY_FILE", str(key_path))
+
+    with pytest.raises(ValueError, match="outside evaluated and generated trees"):
+        generate_harbor_tasks(skill, output, repo_context_exclude_paths=(declared_root,))
+
+    assert not key_path.exists()
+    assert not output.exists()
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="requires POSIX FIFO support")
+def test_fifo_marker_and_key_are_rejected_without_blocking(tmp_path: Path) -> None:
+    skill = _write_skill(tmp_path)
+    declared_root, output = _in_skill_output(skill, "fifo-results")
+    output.mkdir(parents=True)
+    os.mkfifo(output / GENERATED_OUTPUT_MARKER)
+    sentinel = output / "keep.txt"
+    sentinel.write_text("preserve\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="marker"):
+        generate_harbor_tasks(skill, output, repo_context_exclude_paths=(declared_root,))
+    assert sentinel.read_text(encoding="utf-8") == "preserve\n"
+
+    key_path = Path(os.environ["SKILLEVALUATOR_OUTPUT_PROVENANCE_KEY_FILE"])
+    key_path.parent.mkdir(parents=True, mode=0o700)
+    os.mkfifo(key_path)
+    with pytest.raises(ValueError, match="single-link regular file"):
+        mark_generated_output_root(tmp_path / "key-fifo-output")
+
+
+def test_symlinked_private_marker_root_is_rejected(tmp_path: Path) -> None:
+    target = tmp_path / "marker-target"
+    target.mkdir()
+    linked_root = tmp_path / "marker-link"
+    linked_root.symlink_to(target, target_is_directory=True)
+
+    with pytest.raises(ValueError, match=r"symlink|reparse|junction"):
+        output_provenance.write_generated_output_marker(linked_root, destination=tmp_path / "destination")
+
+    assert list(target.iterdir()) == []

--- a/tests/test_harbor_runner_environment.py
+++ b/tests/test_harbor_runner_environment.py
@@ -388,7 +388,8 @@ def test_run_harbor_eval_stages_per_agent_credential_trees(
     tmp_path,
 ) -> None:
     skill = tmp_path / "demo"
-    skill.mkdir()
+    (skill / "evals").mkdir(parents=True)
+    (skill / "evals" / "evals.json").write_text("[]\n", encoding="utf-8")
     provider = _provider("nv_build")
     emitted: list[tuple[str, bool, dict[str, str]]] = []
     launched: dict[str, tuple[str, str, dict[str, str]]] = {}
@@ -459,7 +460,8 @@ def test_run_harbor_eval_rejects_provenance_key_inside_skill_before_creation(
     tmp_path,
 ) -> None:
     skill = tmp_path / "demo"
-    skill.mkdir()
+    (skill / "evals").mkdir(parents=True)
+    (skill / "evals" / "evals.json").write_text("[]\n", encoding="utf-8")
     key_path = skill / "private-output-provenance.key"
     monkeypatch.setenv("SKILLEVALUATOR_OUTPUT_PROVENANCE_KEY_FILE", str(key_path))
     monkeypatch.setattr(runner, "resolve_llm_provider", lambda: _provider("nv_build"))

--- a/tests/test_harbor_runner_environment.py
+++ b/tests/test_harbor_runner_environment.py
@@ -454,6 +454,37 @@ def test_run_harbor_eval_stages_per_agent_credential_trees(
     assert launched["claude-code"][2]["NVIDIA_API_KEY"] == "provider-key"
 
 
+def test_run_harbor_eval_rejects_provenance_key_inside_skill_before_creation(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    skill = tmp_path / "demo"
+    skill.mkdir()
+    key_path = skill / "private-output-provenance.key"
+    monkeypatch.setenv("SKILLEVALUATOR_OUTPUT_PROVENANCE_KEY_FILE", str(key_path))
+    monkeypatch.setattr(runner, "resolve_llm_provider", lambda: _provider("nv_build"))
+    monkeypatch.setattr(
+        runner,
+        "load_evals_config",
+        lambda _path: ({"harbor": {"task_source": "evals_json"}}, None),
+    )
+    monkeypatch.setattr(runner, "find_evals_file", lambda _path: skill / "evals" / "evals.json")
+    monkeypatch.setattr(runner, "_check_prerequisites", lambda **_kwargs: [])
+
+    result = runner.run_harbor_eval(
+        skill,
+        ["opencode"],
+        output_dir=tmp_path / "results",
+        env_mode="docker",
+        agent_runtime_preflight=False,
+    )
+
+    assert "error" in result
+    assert "provenance key must be outside" in result["error"][0]
+    assert not key_path.exists()
+    assert not (tmp_path / "results").exists()
+
+
 def test_harbor_subprocess_environment_excludes_arbitrary_host_secrets(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,
@@ -573,9 +604,18 @@ def test_runtime_env_rejects_host_process_control_names() -> None:
     unsafe_names = (
         "PATH",
         "PYTHONPATH",
+        "HOME",
+        "USERPROFILE",
+        "XDG_CONFIG_HOME",
+        "CLAUDE_CONFIG_DIR",
+        "CLAUDE_CODE_DISABLE_POLICY_SKILLS",
+        "CODEX_HOME",
+        "GEMINI_CLI_HOME",
+        "OPENCODE_CONFIG_DIR",
         "LD_PRELOAD",
         "DYLD_INSERT_LIBRARIES",
         "BASH_ENV",
+        "BASH_FUNC_hidden%%",
         "NODE_OPTIONS",
         "DOCKER_HOST",
         "COMPOSE_FILE",

--- a/tests/test_harbor_runner_status.py
+++ b/tests/test_harbor_runner_status.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import importlib
 import json
 import sys
 import threading
@@ -13,7 +14,7 @@ from pathlib import Path
 
 import pytest
 
-from skillevaluator.tier3.harbor import runner
+from skillevaluator.tier3.harbor import collector, runner
 
 
 @pytest.mark.parametrize("configured_concurrency", [1, 3, 4])
@@ -168,6 +169,224 @@ def test_stop_on_pass_preserves_nvidia_build_agent_import_path(
 _UNSAFE_LINK = r"symlink|reparse"
 
 
+@pytest.mark.parametrize("link_kind", ["directory", "dangling"])
+def test_merge_attempt_jobs_rejects_linked_whole_job_root(tmp_path: Path, link_kind: str) -> None:
+    target = tmp_path / "real-job"
+    if link_kind == "directory":
+        target.mkdir()
+    job_link = tmp_path / "attempt-001"
+    job_link.symlink_to(target, target_is_directory=True)
+    aggregate_dir = tmp_path / "aggregate"
+
+    with pytest.raises(ValueError, match=r"non-linked|symlink|reparse"):
+        runner._merge_attempt_jobs([job_link], aggregate_dir)
+
+    assert not aggregate_dir.exists()
+
+
+def test_merge_attempt_jobs_rejects_mocked_reparse_whole_job_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    job_dir = tmp_path / "attempt-001"
+    job_dir.mkdir()
+    detect_link = runner._job_path_is_link_or_reparse
+
+    def mocked_reparse(path: Path, metadata: object) -> bool:
+        return path == job_dir or detect_link(path, metadata)
+
+    monkeypatch.setattr(runner, "_job_path_is_link_or_reparse", mocked_reparse)
+
+    with pytest.raises(ValueError, match="non-linked"):
+        runner._merge_attempt_jobs([job_dir], tmp_path / "aggregate")
+
+
+def test_merge_attempt_jobs_rejects_non_directory_whole_job_root(tmp_path: Path) -> None:
+    job_file = tmp_path / "attempt-001"
+    job_file.write_text("not a job", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="non-linked directory"):
+        runner._merge_attempt_jobs([job_file], tmp_path / "aggregate")
+
+
+@pytest.mark.parametrize("artifact_kind", ["symlink", "hardlink"])
+def test_merge_attempt_jobs_rejects_forged_root_result(tmp_path: Path, artifact_kind: str) -> None:
+    job_dir = tmp_path / "attempt-001"
+    job_dir.mkdir()
+    forged = tmp_path / "forged-result.json"
+    forged.write_text('{"n_total_trials": 999, "stats": {}}', encoding="utf-8")
+    result = job_dir / "result.json"
+    try:
+        if artifact_kind == "symlink":
+            result.symlink_to(forged)
+        else:
+            result.hardlink_to(forged)
+    except OSError as exc:  # pragma: no cover - filesystem policy
+        pytest.skip(f"{artifact_kind} creation unavailable: {exc}")
+
+    with pytest.raises(ValueError, match=r"symlink|reparse|hard.?link|multiple links"):
+        runner._merge_attempt_jobs([job_dir], tmp_path / "aggregate")
+
+
+def test_merge_attempt_jobs_rejects_root_result_source_swap(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    secure_copy = importlib.import_module("skillevaluator.tier3.harbor.secure_copy")
+    job_dir = tmp_path / "attempt-001"
+    job_dir.mkdir()
+    result = job_dir / "result.json"
+    result.write_text('{"n_total_trials": 1, "stats": {}}', encoding="utf-8")
+    aggregate_dir = tmp_path / "aggregate"
+    aggregate_dir.mkdir()
+    marker = aggregate_dir / "keep.txt"
+    marker.write_text("old aggregate", encoding="utf-8")
+    original = secure_copy._build_tree_manifest
+
+    def validate_then_replace(source: Path, *args: object, **kwargs: object):
+        manifest = original(source, *args, **kwargs)
+        if Path(source).resolve() == job_dir.resolve():
+            result.unlink()
+            result.write_text('{"n_total_trials": 999, "stats": {}}', encoding="utf-8")
+        return manifest
+
+    monkeypatch.setattr(secure_copy, "_build_tree_manifest", validate_then_replace)
+
+    with pytest.raises(ValueError, match="source changed after validation"):
+        runner._merge_attempt_jobs([job_dir], aggregate_dir)
+
+    assert marker.read_text(encoding="utf-8") == "old aggregate"
+
+
+def test_merge_attempt_jobs_rejects_regular_root_directory_replacement(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    job_dir = tmp_path / "attempt-001"
+    job_dir.mkdir()
+    (job_dir / "result.json").write_text('{"n_total_trials": 1, "stats": {}}', encoding="utf-8")
+    aggregate_dir = tmp_path / "aggregate"
+    aggregate_dir.mkdir()
+    marker = aggregate_dir / "keep.txt"
+    marker.write_text("old aggregate", encoding="utf-8")
+    original_copy = runner.copytree_secure
+    replaced = False
+
+    def replace_root_then_copy(source: Path, destination: Path, **kwargs: object) -> None:
+        nonlocal replaced
+        if not replaced and Path(source) == job_dir:
+            replaced = True
+            job_dir.rename(tmp_path / "original-job")
+            job_dir.mkdir()
+            (job_dir / "result.json").write_text('{"n_total_trials": 999, "stats": {}}', encoding="utf-8")
+        original_copy(source, destination, **kwargs)
+
+    monkeypatch.setattr(runner, "copytree_secure", replace_root_then_copy)
+
+    with pytest.raises(ValueError, match="root changed during snapshot"):
+        runner._merge_attempt_jobs([job_dir], aggregate_dir)
+
+    assert marker.read_text(encoding="utf-8") == "old aggregate"
+
+
+def _write_multistep_attempt_job(
+    job_dir: Path,
+    *,
+    root_score: float,
+    step_scores: tuple[float, ...],
+    failed: bool = False,
+) -> Path:
+    trial = job_dir / "case-001_attempt001"
+    for index, score in enumerate(step_scores, start=1):
+        verifier = trial / "steps" / f"step-{index}" / "verifier"
+        verifier.mkdir(parents=True)
+        (verifier / "reward.json").write_text(json.dumps({"overall": score}), encoding="utf-8")
+    result: dict[str, object] = {
+        "trial_name": trial.name,
+        "task_name": "case-001",
+        "verifier_result": {"rewards": {"overall": root_score}},
+        "step_results": [
+            {"step_name": f"step-{index}", "verifier_result": {"rewards": {"overall": score}}}
+            for index, score in enumerate(step_scores, start=1)
+        ],
+    }
+    if failed:
+        result["exception_info"] = {
+            "exception_type": "TaskFailure",
+            "exception_message": "attempt crashed",
+        }
+    (trial / "result.json").write_text(json.dumps(result), encoding="utf-8")
+    _write_successful_job_result(job_dir, trial.name)
+    return trial
+
+
+def _write_successful_job_result(job_dir: Path, trial_name: str) -> None:
+    (job_dir / "result.json").write_text(
+        json.dumps(
+            {
+                "n_total_trials": 1,
+                "stats": {
+                    "n_trials": 1,
+                    "n_errors": 0,
+                    "evals": {
+                        "demo": {
+                            "n_trials": 1,
+                            "n_errors": 0,
+                            "reward_stats": {"overall": {"1.0": [trial_name]}},
+                        }
+                    },
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_job_passed_uses_authoritative_multistep_root_reward(tmp_path: Path) -> None:
+    job_dir = tmp_path / "job"
+    _write_multistep_attempt_job(job_dir, root_score=0.5, step_scores=(1.0, 0.0))
+
+    assert runner._job_passed(job_dir, 0.75) is False
+    rewards = collector._extract_rewards(job_dir)
+    assert len(rewards) == 1
+    assert collector._average_overall(rewards) == 0.5
+
+
+def test_job_passed_accepts_passing_authoritative_multistep_root_reward(tmp_path: Path) -> None:
+    job_dir = tmp_path / "job"
+    _write_multistep_attempt_job(job_dir, root_score=0.8, step_scores=(0.0, 0.0))
+
+    assert runner._job_passed(job_dir, 0.75) is True
+
+
+def test_job_passed_rejects_failed_trial_even_with_passing_rewards(tmp_path: Path) -> None:
+    job_dir = tmp_path / "job"
+    _write_multistep_attempt_job(job_dir, root_score=1.0, step_scores=(1.0,), failed=True)
+
+    assert runner._job_passed(job_dir, 0.75) is False
+
+
+def test_job_passed_rejects_failed_job_result_even_with_passing_reward(tmp_path: Path) -> None:
+    job_dir = tmp_path / "job"
+    _write_multistep_attempt_job(job_dir, root_score=1.0, step_scores=(1.0,))
+    job_result = json.loads((job_dir / "result.json").read_text(encoding="utf-8"))
+    job_result["stats"]["n_errors"] = 1
+    (job_dir / "result.json").write_text(json.dumps(job_result), encoding="utf-8")
+
+    assert runner._job_passed(job_dir, 0.75) is False
+
+
+def test_job_passed_preserves_legacy_single_step_reward(tmp_path: Path) -> None:
+    job_dir = tmp_path / "job"
+    trial_name = "case-001_attempt001"
+    verifier = job_dir / trial_name / "verifier"
+    verifier.mkdir(parents=True)
+    (verifier / "reward.json").write_text(json.dumps({"overall": 0.9}), encoding="utf-8")
+    _write_successful_job_result(job_dir, trial_name)
+
+    assert runner._job_passed(job_dir, 0.75) is True
+
+
 def test_merge_attempt_jobs_rejects_symlinked_trial_directory(tmp_path: Path) -> None:
     outside = tmp_path / "outside-trial"
     outside.mkdir()
@@ -253,6 +472,89 @@ def test_merge_attempt_jobs_preserves_regular_trial_artifacts(tmp_path: Path) ->
     assert (merged_trial / "artifacts" / "output.txt").read_text(encoding="utf-8") == "expected"
     merged_result = json.loads((aggregate_dir / "result.json").read_text(encoding="utf-8"))
     assert merged_result["stats"]["evals"]["demo"]["reward_stats"]["reward"]["1.0"] == [merged_trial.name]
+
+
+def test_merge_attempt_jobs_ignores_tmpdir_inside_attempt_job(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    job_dir = tmp_path / "attempt-001"
+    trial_dir = job_dir / "case-001__trial"
+    trial_dir.mkdir(parents=True)
+    (trial_dir / "artifact.txt").write_text("expected", encoding="utf-8")
+    monkeypatch.setattr(runner.tempfile, "tempdir", str(job_dir))
+    aggregate_dir = tmp_path / "aggregate"
+
+    runner._merge_attempt_jobs([job_dir], aggregate_dir)
+
+    assert (aggregate_dir / f"{job_dir.name}__{trial_dir.name}" / "artifact.txt").read_text() == "expected"
+    assert not list(tmp_path.glob(".aggregate-merge-*"))
+
+
+def test_merge_attempt_jobs_preserves_existing_aggregate_on_unsafe_source(tmp_path: Path) -> None:
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    safe_job = tmp_path / "attempt-001"
+    safe_trial = safe_job / "case-001__trial"
+    safe_trial.mkdir(parents=True)
+    (safe_trial / "safe.txt").write_text("staged first", encoding="utf-8")
+    unsafe_job = tmp_path / "attempt-002"
+    unsafe_trial = unsafe_job / "case-001__trial"
+    unsafe_trial.mkdir(parents=True)
+    (unsafe_trial / "unsafe").symlink_to(outside, target_is_directory=True)
+    aggregate_dir = tmp_path / "aggregate"
+    aggregate_dir.mkdir()
+    marker = aggregate_dir / "keep.txt"
+    marker.write_text("old aggregate", encoding="utf-8")
+
+    with pytest.raises(ValueError, match=_UNSAFE_LINK):
+        runner._merge_attempt_jobs([safe_job, unsafe_job], aggregate_dir)
+
+    assert marker.read_text(encoding="utf-8") == "old aggregate"
+    assert not (aggregate_dir / f"{safe_job.name}__{safe_trial.name}").exists()
+    assert not (aggregate_dir / f"{unsafe_job.name}__{unsafe_trial.name}").exists()
+    assert not list(tmp_path.glob(".aggregate-merge-*"))
+
+
+def test_merge_attempt_jobs_preserves_existing_aggregate_when_private_staging_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    job_dir = tmp_path / "attempt-001"
+    job_dir.mkdir()
+    aggregate_dir = tmp_path / "aggregate"
+    aggregate_dir.mkdir()
+    marker = aggregate_dir / "keep.txt"
+    marker.write_text("old aggregate", encoding="utf-8")
+
+    def fail_private_staging(*_args: object, **_kwargs: object) -> None:
+        raise OSError("injected temp failure")
+
+    monkeypatch.setattr(runner.tempfile, "TemporaryDirectory", fail_private_staging)
+
+    with pytest.raises(OSError, match="injected temp failure"):
+        runner._merge_attempt_jobs([job_dir], aggregate_dir)
+
+    assert marker.read_text(encoding="utf-8") == "old aggregate"
+
+
+@pytest.mark.parametrize("relationship", ["aggregate-in-job", "job-in-aggregate"])
+def test_merge_attempt_jobs_rejects_source_destination_overlap(tmp_path: Path, relationship: str) -> None:
+    if relationship == "aggregate-in-job":
+        job_dir = tmp_path / "attempt-001"
+        job_dir.mkdir()
+        aggregate_dir = job_dir / "aggregate"
+    else:
+        aggregate_dir = tmp_path / "aggregate"
+        job_dir = aggregate_dir / "attempt-001"
+        job_dir.mkdir(parents=True)
+    marker = job_dir / "keep.txt"
+    marker.write_text("source", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="must not overlap"):
+        runner._merge_attempt_jobs([job_dir], aggregate_dir)
+
+    assert marker.read_text(encoding="utf-8") == "source"
 
 
 def _run(

--- a/tests/test_harbor_runtime_preflight.py
+++ b/tests/test_harbor_runtime_preflight.py
@@ -675,7 +675,8 @@ def test_runtime_preflight_failure_stops_full_matrix(monkeypatch, tmp_path: Path
     from skillevaluator.tier3.harbor import runner
 
     skill = tmp_path / "demo"
-    skill.mkdir()
+    (skill / "evals").mkdir(parents=True)
+    (skill / "evals" / "evals.json").write_text("[]\n", encoding="utf-8")
     provider = ProviderConfig(
         provider="nv_build",
         model="meta/llama-3.1-8b-instruct",

--- a/tests/test_harbor_runtime_skill_isolation.py
+++ b/tests/test_harbor_runtime_skill_isolation.py
@@ -28,6 +28,7 @@ from skillevaluator.tier3.harbor.adapter import (
     validate_results_root_location,
 )
 from skillevaluator.tier3.output_provenance import mark_generated_output_root
+from skillevaluator.tier3.results_location import publish_latest_results
 
 
 def _write_runtime_skill(path: Path, package: str) -> Path:
@@ -1012,6 +1013,84 @@ def test_rotated_generated_output_is_excluded_from_runtime_skill_and_repo(
         path.read_text(encoding="utf-8", errors="ignore") for path in environment.rglob("*") if path.is_file()
     )
     assert "OLD-CASE-SECRET" not in readable
+
+
+@pytest.mark.parametrize("copy_repo", [False, True])
+def test_rotated_results_latest_alias_to_authenticated_run_is_excluded(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    copy_repo: bool,
+) -> None:
+    monkeypatch.setenv(
+        "SKILLEVALUATOR_OUTPUT_PROVENANCE_KEY_FILE",
+        str(tmp_path / ".skillevaluator-state" / "output-provenance.key"),
+    )
+    repo, target, _, _ = _write_projection_fixture(tmp_path)
+    old_results_root = target / "archived-results"
+    run_id = "20260805_120000_123_aaaaaaaaaaaa"
+    old_run = old_results_root / run_id
+    mark_generated_output_root(old_run)
+    (old_run / "run_config.json").write_text("{}\n", encoding="utf-8")
+    (old_run / "result.json").write_text(json.dumps({"run_id": run_id}), encoding="utf-8")
+    (old_run / "fixture-oracle.txt").write_text("HISTORICAL-RESULT-ORACLE\n", encoding="utf-8")
+    assert publish_latest_results(old_results_root, run_id)
+    (target / "evals" / "evals.json").write_text(
+        json.dumps([{"id": "case-001", "question": "Do not use historical results.", "files": []}]),
+        encoding="utf-8",
+    )
+
+    task = generate_harbor_tasks(target, tmp_path / f"current-latest-{copy_repo}", copy_repo=copy_repo)[0]
+
+    environment = task / "environment"
+    runtime_old_root = environment / "skills" / target.name / old_results_root.relative_to(target)
+    assert not (runtime_old_root / run_id).exists()
+    assert not (runtime_old_root / "latest").exists()
+    if copy_repo:
+        repo_old_root = environment / "repo" / target.relative_to(repo) / old_results_root.relative_to(target)
+        assert not (repo_old_root / run_id).exists()
+        assert not (repo_old_root / "latest").exists()
+    readable = "\n".join(
+        path.read_text(encoding="utf-8", errors="ignore") for path in environment.rglob("*") if path.is_file()
+    )
+    assert "HISTORICAL-RESULT-ORACLE" not in readable
+
+
+@pytest.mark.parametrize("lookalike", ["unmarked-latest", "outside-latest", "non-latest-alias"])
+def test_rotated_results_symlink_lookalikes_remain_rejected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    lookalike: str,
+) -> None:
+    monkeypatch.setenv(
+        "SKILLEVALUATOR_OUTPUT_PROVENANCE_KEY_FILE",
+        str(tmp_path / ".skillevaluator-state" / "output-provenance.key"),
+    )
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    old_results_root = target / "archived-results"
+    old_results_root.mkdir()
+    if lookalike == "non-latest-alias":
+        target_dir = old_results_root / "marked-run"
+        mark_generated_output_root(target_dir)
+        alias = old_results_root / "current"
+    elif lookalike == "unmarked-latest":
+        target_dir = old_results_root / "unmarked-run"
+        target_dir.mkdir()
+        alias = old_results_root / "latest"
+    else:
+        target_dir = tmp_path / "outside-run"
+        target_dir.mkdir()
+        alias = old_results_root / "latest"
+    (target_dir / "payload.txt").write_text("UNAUTHENTICATED-LOOKALIKE\n", encoding="utf-8")
+    try:
+        alias.symlink_to(target_dir.name if target_dir.parent == old_results_root else target_dir)
+    except OSError as exc:
+        pytest.skip(f"symlink creation unavailable: {exc}")
+
+    output = tmp_path / f"lookalike-{lookalike}"
+    with pytest.raises(ValueError, match="symlink"):
+        generate_harbor_tasks(target, output)
+
+    assert not output.exists()
 
 
 @pytest.mark.skipif(sys.platform != "darwin", reason="requires the macOS /var root alias")

--- a/tests/test_harbor_runtime_skill_isolation.py
+++ b/tests/test_harbor_runtime_skill_isolation.py
@@ -23,6 +23,7 @@ from skillevaluator.tier3.harbor.adapter import (
     _path_is_excluded,
     generate_harbor_tasks,
     prebuild_task_environments,
+    private_evaluator_skill_snapshot,
     stage_native_harbor_tasks,
     validate_results_root_location,
 )
@@ -213,6 +214,55 @@ def test_native_tasks_project_runtime_skills_without_root_evals(tmp_path: Path) 
     assert (task / "tests" / "grader.py").is_file()
 
 
+def test_native_task_staging_uses_one_private_evals_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    _write_minimal_native_task(target)
+    evals = target / "evals"
+    moved = tmp_path / "evals-A"
+    real_load = adapter_module._load_entries_by_id
+    swapped = False
+
+    def swap_original_evals_after_metadata_read(path: Path) -> dict[str, dict[str, object]]:
+        nonlocal swapped
+        entries = real_load(path)
+        if not swapped:
+            swapped = True
+            evals.rename(moved)
+            shutil.copytree(moved, evals)
+            (evals / "evals.json").write_text(
+                json.dumps(
+                    [
+                        {
+                            "id": "case-001",
+                            "question": "metadata-B",
+                            "files": ["evals/files/selected.txt"],
+                        }
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            (evals / "files" / "selected.txt").write_text("fixture-B\n", encoding="utf-8")
+            (evals / "harbor" / "case-001" / "instruction.md").write_text(
+                "native-B\n",
+                encoding="utf-8",
+            )
+        return entries
+
+    monkeypatch.setattr(adapter_module, "_load_entries_by_id", swap_original_evals_after_metadata_read)
+
+    task = stage_native_harbor_tasks(target, tmp_path / "native-snapshot", with_skill=False)[0]
+    entry = json.loads((task / "tests" / "entry.json").read_text(encoding="utf-8"))
+
+    assert swapped
+    assert (task / "instruction.md").read_text(encoding="utf-8") == "Run the native case.\n"
+    assert entry["question"] == "Use only the selected fixture."
+    assert (task / "environment" / "input" / "selected.txt").read_text(encoding="utf-8") == "SELECTED-FIXTURE\n"
+    assert (task / "tests" / "grader.py").is_file()
+
+
 def test_base_image_dependency_collection_ignores_only_root_evals(tmp_path: Path) -> None:
     _, target, references_dir, workspace = _write_projection_fixture(tmp_path)
 
@@ -365,7 +415,7 @@ def test_copy_repo_rejects_hardlink_alias(tmp_path: Path) -> None:
     except OSError as exc:  # pragma: no cover - filesystem policy
         pytest.skip(f"hardlinks unavailable on this host: {exc}")
 
-    with pytest.raises(ValueError, match=r"hardlink|hard link"):
+    with pytest.raises(ValueError, match=r"hard.?link"):
         generate_harbor_tasks(
             target,
             tmp_path / "generated-hardlink",
@@ -1416,7 +1466,8 @@ def test_readonly_custom_environment_snapshot_stays_outside_docker_context(
     original_copytree = adapter_module.copytree_secure
 
     def record_custom_snapshot(source: Path, destination: Path, *args: object, **kwargs: object) -> None:
-        if Path(source) == custom_environment:
+        source_path = Path(source)
+        if source_path.name == "environment" and source_path.parent.name == "evals":
             snapshot_destinations.append(Path(destination))
         original_copytree(source, destination, *args, **kwargs)
 
@@ -2672,3 +2723,350 @@ def test_eval_dataset_file_must_be_regular_and_unlinked(tmp_path: Path, kind: st
 
     with pytest.raises(ValueError, match="regular non-linked file"):
         generate_harbor_tasks(target, tmp_path / f"unsafe-dataset-{kind}")
+
+
+@pytest.mark.parametrize("kind", ["symlink", "hardlink", "fifo"])
+def test_selective_evaluator_snapshot_does_not_copy_unselected_unsafe_fixture(
+    tmp_path: Path,
+    kind: str,
+) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    files = target / "evals" / "files"
+    unselected = files / "unselected-unsafe"
+    outside = tmp_path / "outside-unselected.txt"
+    outside.write_text("must not be inspected or copied\n", encoding="utf-8")
+    try:
+        if kind == "symlink":
+            unselected.symlink_to(outside)
+        elif kind == "hardlink":
+            unselected.hardlink_to(outside)
+        elif hasattr(os, "mkfifo"):
+            os.mkfifo(unselected)
+        else:
+            pytest.skip("FIFO creation is unavailable")
+    except OSError as exc:
+        pytest.skip(f"{kind} creation is unavailable: {exc}")
+
+    # A sparse large sibling models the ENOSPC/performance regression without
+    # making the test consume the corresponding amount of disk.
+    (files / "unselected-large.bin").touch()
+    os.truncate(files / "unselected-large.bin", 256 * 1024 * 1024)
+
+    with private_evaluator_skill_snapshot(target, task_source="evals_json") as snapshot:
+        projected_files = snapshot / "evals" / "files"
+        assert (projected_files / "selected.txt").read_text(encoding="utf-8") == "SELECTED-FIXTURE\n"
+        assert not (projected_files / "hidden.txt").exists()
+        assert not os.path.lexists(projected_files / "unselected-unsafe")
+        assert not (projected_files / "unselected-large.bin").exists()
+
+
+@pytest.mark.parametrize("kind", ["symlink", "hardlink", "fifo"])
+def test_selective_evaluator_snapshot_fails_closed_for_referenced_unsafe_fixture(
+    tmp_path: Path,
+    kind: str,
+) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    files = target / "evals" / "files"
+    selected = files / "selected.txt"
+    selected.unlink()
+    outside = tmp_path / "outside-selected.txt"
+    outside.write_text("must never be copied\n", encoding="utf-8")
+    try:
+        if kind == "symlink":
+            selected.symlink_to(outside)
+        elif kind == "hardlink":
+            selected.hardlink_to(outside)
+        elif hasattr(os, "mkfifo"):
+            os.mkfifo(selected)
+        else:
+            pytest.skip("FIFO creation is unavailable")
+    except OSError as exc:
+        pytest.skip(f"{kind} creation is unavailable: {exc}")
+
+    with (
+        pytest.raises((FileNotFoundError, ValueError), match=r"outside evals|symlink|hard.?link|regular file"),
+        private_evaluator_skill_snapshot(target, task_source="evals_json"),
+    ):
+        pass
+
+
+def test_selective_evaluator_snapshot_preserves_legacy_implicit_files_corpus(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    (target / "evals" / "evals.json").write_text(
+        json.dumps([{"id": "case-001", "question": "Use the shared fixtures."}]),
+        encoding="utf-8",
+    )
+
+    with private_evaluator_skill_snapshot(target, task_source="evals_json") as snapshot:
+        projected_files = snapshot / "evals" / "files"
+        assert (projected_files / "selected.txt").is_file()
+        assert (projected_files / "hidden.txt").is_file()
+
+
+def test_native_snapshot_ignores_generated_only_entries_when_selecting_fixtures(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    _write_minimal_native_task(target)
+    evals = target / "evals"
+    (evals / "evals.json").write_text(
+        json.dumps(
+            [
+                {
+                    "id": "case-001",
+                    "question": "Use only the selected fixture.",
+                    "files": ["evals/files/selected.txt"],
+                },
+                {
+                    "id": "generated-only",
+                    "question": "This entry has legacy implicit shared files.",
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+    unsafe = evals / "files" / "unselected-unsafe"
+    outside = tmp_path / "outside-native-fixtures.txt"
+    outside.write_text("must not be inspected or copied\n", encoding="utf-8")
+    try:
+        unsafe.symlink_to(outside)
+    except OSError as exc:
+        pytest.skip(f"symlink creation is unavailable: {exc}")
+
+    with private_evaluator_skill_snapshot(target, task_source="native_harbor") as snapshot:
+        projected_files = snapshot / "evals" / "files"
+        assert (projected_files / "selected.txt").read_text(encoding="utf-8") == "SELECTED-FIXTURE\n"
+        assert not (projected_files / "hidden.txt").exists()
+        assert not os.path.lexists(projected_files / "unselected-unsafe")
+
+    task = stage_native_harbor_tasks(target, tmp_path / "native-selected-fixtures", with_skill=False)[0]
+    staged_input = task / "environment" / "input"
+    assert (staged_input / "selected.txt").read_text(encoding="utf-8") == "SELECTED-FIXTURE\n"
+    assert not (staged_input / "hidden.txt").exists()
+    assert not os.path.lexists(staged_input / "unselected-unsafe")
+
+
+def test_evidence_snapshot_binds_complete_files_corpus_for_explicit_entries(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+
+    with private_evaluator_skill_snapshot(
+        target,
+        task_source="evals_json",
+        bind_full_evidence_sources=True,
+    ) as snapshot:
+        projected_files = snapshot / "evals" / "files"
+        assert (projected_files / "selected.txt").is_file()
+        assert (projected_files / "hidden.txt").is_file()
+
+
+def test_selective_snapshot_ignores_shadowed_grader_but_evidence_binds_it(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    shadowed = target / "evals" / "tests" / "grader.py"
+    shadowed.parent.mkdir()
+    outside = tmp_path / "outside-shadowed-grader.py"
+    outside.write_text("raise RuntimeError('must not run')\n", encoding="utf-8")
+    try:
+        shadowed.symlink_to(outside)
+    except OSError as exc:
+        pytest.skip(f"symlink creation is unavailable: {exc}")
+
+    with private_evaluator_skill_snapshot(target, task_source="evals_json") as snapshot:
+        assert (snapshot / "evals" / "grader.py").is_file()
+        assert not os.path.lexists(snapshot / "evals" / "tests" / "grader.py")
+
+    with (
+        pytest.raises(ValueError, match="symlink"),
+        private_evaluator_skill_snapshot(
+            target,
+            task_source="evals_json",
+            bind_full_evidence_sources=True,
+        ),
+    ):
+        pass
+
+
+def test_evidence_snapshot_rejects_unselected_unsafe_file_it_must_bind(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    hidden = target / "evals" / "files" / "hidden.txt"
+    hidden.unlink()
+    outside = tmp_path / "evidence-hardlink.txt"
+    outside.write_text("bound evidence\n", encoding="utf-8")
+    try:
+        hidden.hardlink_to(outside)
+    except OSError as exc:
+        pytest.skip(f"hardlinks unavailable: {exc}")
+
+    with (
+        pytest.raises(ValueError, match=r"hard.?link"),
+        private_evaluator_skill_snapshot(
+            target,
+            task_source="evals_json",
+            bind_full_evidence_sources=True,
+        ),
+    ):
+        pass
+
+
+@pytest.mark.parametrize("kind", ["symlink", "hardlink", "fifo"])
+def test_selective_evaluator_snapshot_ignores_unsafe_unconsumed_evals_subtree(
+    tmp_path: Path,
+    kind: str,
+) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    archive = target / "evals" / "historical-archive"
+    archive.mkdir()
+    unsafe = archive / "unsafe"
+    outside = tmp_path / "outside-archive.txt"
+    outside.write_text("unconsumed\n", encoding="utf-8")
+    try:
+        if kind == "symlink":
+            unsafe.symlink_to(outside)
+        elif kind == "hardlink":
+            unsafe.hardlink_to(outside)
+        elif hasattr(os, "mkfifo"):
+            os.mkfifo(unsafe)
+        else:
+            pytest.skip("FIFO creation is unavailable")
+    except OSError as exc:
+        pytest.skip(f"{kind} creation is unavailable: {exc}")
+
+    with private_evaluator_skill_snapshot(target, task_source="evals_json") as snapshot:
+        assert not (snapshot / "evals" / "historical-archive").exists()
+
+
+def test_selective_evaluator_snapshot_rejects_fixture_selection_change_during_copy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    dataset = target / "evals" / "evals.json"
+    original_copytree = adapter_module.copytree_secure
+    mutated = False
+
+    def mutate_selection_then_copy(source: Path, destination: Path, *args: object, **kwargs: object) -> None:
+        nonlocal mutated
+        if Path(source) == target / "evals" and not mutated:
+            dataset.write_text(
+                json.dumps([{"id": "case-001", "question": "Now use every shared fixture."}]),
+                encoding="utf-8",
+            )
+            mutated = True
+        original_copytree(source, destination, *args, **kwargs)
+
+    monkeypatch.setattr(adapter_module, "copytree_secure", mutate_selection_then_copy)
+
+    with (
+        pytest.raises(ValueError, match="selection changed"),
+        private_evaluator_skill_snapshot(target, task_source="evals_json"),
+    ):
+        pass
+
+    assert mutated
+
+
+def test_in_repo_temp_evaluator_snapshot_is_excluded_from_copy_repo(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, target, _, _ = _write_projection_fixture(tmp_path)
+    in_repo_temp = repo / "in-repo-temp"
+    in_repo_temp.mkdir()
+    monkeypatch.setattr(tempfile, "tempdir", str(in_repo_temp))
+
+    task = generate_harbor_tasks(
+        target,
+        tmp_path / "in-repo-temp-output",
+        with_skill=True,
+        copy_repo=True,
+    )[0]
+
+    staged_repo = task / "environment" / "repo"
+    assert staged_repo.is_dir()
+    assert not list(staged_repo.rglob("evals.json"))
+    readable = "\n".join(
+        path.read_text(encoding="utf-8", errors="ignore") for path in staged_repo.rglob("*") if path.is_file()
+    )
+    assert "GROUND-TRUTH-SECRET" not in readable
+
+
+def test_temp_snapshot_inside_legacy_files_does_not_recurse_into_itself(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    (target / "evals" / "evals.json").write_text(
+        json.dumps([{"id": "case-001", "question": "Use every shared fixture."}]),
+        encoding="utf-8",
+    )
+    nested_temp = target / "evals" / "files" / "nested-temp-root"
+    nested_temp.mkdir()
+    monkeypatch.setattr(tempfile, "tempdir", str(nested_temp))
+
+    task = generate_harbor_tasks(target, tmp_path / "nested-temp-output", with_skill=False)[0]
+
+    staged_input = task / "environment" / "input"
+    assert (staged_input / "selected.txt").is_file()
+    assert (staged_input / "hidden.txt").is_file()
+    assert not list(staged_input.rglob("evals.json"))
+
+
+def test_native_projection_does_not_enumerate_symlinked_harbor_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    outside_skill = tmp_path / "outside-skill"
+    _write_minimal_native_task(outside_skill)
+    outside = outside_skill / "evals" / "harbor"
+    native_root = target / "evals" / "harbor"
+    try:
+        native_root.symlink_to(outside, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"directory symlink creation is unavailable: {exc}")
+
+    original_iterdir = Path.iterdir
+    enumerated_source = False
+
+    def record_iterdir(path: Path):
+        nonlocal enumerated_source
+        if path.absolute() == native_root.absolute():
+            enumerated_source = True
+        return original_iterdir(path)
+
+    monkeypatch.setattr(Path, "iterdir", record_iterdir)
+
+    with pytest.raises(ValueError, match="symlink"):
+        stage_native_harbor_tasks(target, tmp_path / "symlinked-native-root")
+
+    assert not enumerated_source
+
+
+def test_native_projection_does_not_read_task_directory_on_another_device(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    _write_minimal_native_task(target)
+    native_root = target / "evals" / "harbor"
+    task_dir = native_root / "case-001"
+    original_lstat = Path.lstat
+    original_read = adapter_module._read_regular_evals_file
+    read_task_config = False
+
+    def cross_device_lstat(path: Path):
+        metadata = original_lstat(path)
+        if path.absolute() != task_dir.absolute():
+            return metadata
+        fields = list(metadata)
+        fields[2] = metadata.st_dev + 1
+        return os.stat_result(fields)
+
+    def record_read(path: Path, **kwargs: object) -> bytes:
+        nonlocal read_task_config
+        if path.absolute() == (task_dir / "task.toml").absolute():
+            read_task_config = True
+        return original_read(path, **kwargs)
+
+    monkeypatch.setattr(Path, "lstat", cross_device_lstat)
+    monkeypatch.setattr(adapter_module, "_read_regular_evals_file", record_read)
+
+    assert adapter_module._native_projection_entry_ids(native_root) == ()
+    assert not read_task_config

--- a/tests/test_harbor_runtime_skill_isolation.py
+++ b/tests/test_harbor_runtime_skill_isolation.py
@@ -1,0 +1,2367 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression coverage for agent-visible Tier 3 skill projection."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from skillevaluator.tier3.harbor.adapter import (
+    _collect_all_skill_deps,
+    _dockerfile_resolved_build_context_sources,
+    _ensure_empty_custom_docker_input_compatibility,
+    _path_is_excluded,
+    generate_harbor_tasks,
+    prebuild_task_environments,
+    stage_native_harbor_tasks,
+    validate_results_root_location,
+)
+from skillevaluator.tier3.output_provenance import mark_generated_output_root
+
+
+def _write_runtime_skill(path: Path, package: str) -> Path:
+    path.mkdir(parents=True)
+    (path / "SKILL.md").write_text(f"# {path.name}\n", encoding="utf-8")
+    scripts = path / "scripts"
+    scripts.mkdir()
+    (scripts / "run.py").write_text("print('runtime')\n", encoding="utf-8")
+    (scripts / "requirements.txt").write_text(f"{package}-runtime==1\n", encoding="utf-8")
+    (scripts / "apt-packages.txt").write_text(f"{package}-runtime-tool\n", encoding="utf-8")
+
+    nested_evals = path / "references" / "evals"
+    nested_evals.mkdir(parents=True)
+    (nested_evals / "keep.md").write_text("legitimate runtime reference\n", encoding="utf-8")
+    (nested_evals / "requirements.txt").write_text(f"{package}-nested-runtime==1\n", encoding="utf-8")
+    (nested_evals / "apt-packages.txt").write_text(f"{package}-nested-runtime-tool\n", encoding="utf-8")
+
+    evals = path / "evals"
+    evals.mkdir()
+    (evals / "evals.json").write_text("[]\n", encoding="utf-8")
+    (evals / "requirements.txt").write_text(f"{package}-oracle==9\n", encoding="utf-8")
+    (evals / "apt-packages.txt").write_text(f"{package}-oracle-tool\n", encoding="utf-8")
+    return path
+
+
+def _write_nested_runtime_skill(wrapper: Path, package: str) -> Path:
+    nested = wrapper / "references" / "nested-skill"
+    nested.mkdir(parents=True)
+    (nested / "SKILL.md").write_text(f"# Nested {package}\n", encoding="utf-8")
+    scripts = nested / "scripts"
+    scripts.mkdir()
+    (scripts / "requirements.txt").write_text(f"{package}-nested-skill-runtime==1\n", encoding="utf-8")
+    (scripts / "apt-packages.txt").write_text(f"{package}-nested-skill-runtime-tool\n", encoding="utf-8")
+    evals = nested / "evals"
+    evals.mkdir()
+    (evals / "evals.json").write_text('[{"ground_truth": "NESTED-ORACLE"}]\n', encoding="utf-8")
+    (evals / "requirements.txt").write_text(f"{package}-nested-skill-oracle==9\n", encoding="utf-8")
+    (evals / "apt-packages.txt").write_text(f"{package}-nested-skill-oracle-tool\n", encoding="utf-8")
+    preserved = nested / "references" / "evals"
+    preserved.mkdir(parents=True)
+    (preserved / "keep.md").write_text("nested runtime reference\n", encoding="utf-8")
+    return nested
+
+
+def _write_minimal_native_task(target: Path) -> None:
+    native_task = target / "evals" / "harbor" / "case-001"
+    native_task.mkdir(parents=True)
+    (native_task / "instruction.md").write_text("Run the native case.\n", encoding="utf-8")
+    (native_task / "task.toml").write_text(
+        'schema_version = "1.3"\n\n[task]\nname = "nvidia/case-001"\n\n'
+        '[metadata]\nentry_id = "case-001"\n\n[environment]\n',
+        encoding="utf-8",
+    )
+
+
+def _write_projection_fixture(tmp_path: Path) -> tuple[Path, Path, Path, Path]:
+    repo = tmp_path / "repo"
+    target = _write_runtime_skill(repo / "target-skill", "target")
+    references_dir = repo / "reference-skills"
+    _write_runtime_skill(references_dir / "reference-skill", "reference")
+    workspace = _write_runtime_skill(repo / "workspace-skill", "workspace")
+
+    docs_evals = repo / "docs" / "evals"
+    docs_evals.mkdir(parents=True)
+    (docs_evals / "keep.txt").write_text("not a skill dataset\n", encoding="utf-8")
+
+    evals = target / "evals"
+    files = evals / "files"
+    files.mkdir()
+    (files / "selected.txt").write_text("SELECTED-FIXTURE\n", encoding="utf-8")
+    (files / "hidden.txt").write_text("UNDECLARED-ORACLE\n", encoding="utf-8")
+    (evals / "evals.json").write_text(
+        json.dumps(
+            [
+                {
+                    "id": "case-001",
+                    "question": "Use only the selected fixture.",
+                    "files": ["evals/files/selected.txt"],
+                    "ground_truth": "GROUND-TRUTH-SECRET",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (evals / "grader.py").write_text("def grade(*args, **kwargs):\n    return 1\n", encoding="utf-8")
+    sidecar = evals / "environment" / "sidecar"
+    sidecar.mkdir(parents=True)
+    (sidecar / "seed.txt").write_text("custom environment asset\n", encoding="utf-8")
+
+    return repo, target, references_dir, workspace
+
+
+def _assert_runtime_projection(task: Path, target: Path, workspace: Path) -> None:
+    env = task / "environment"
+    staged_skills = env / "skills"
+    for name in (target.name, "reference-skill", workspace.name):
+        staged = staged_skills / name
+        assert (staged / "SKILL.md").is_file()
+        assert (staged / "scripts" / "run.py").is_file()
+        assert not (staged / "evals").exists()
+        assert (staged / "references" / "evals" / "keep.md").is_file()
+
+    staged_repo = env / "repo"
+    assert not (staged_repo / target.name / "evals").exists()
+    assert not (staged_repo / "reference-skills" / "reference-skill" / "evals").exists()
+    assert not (staged_repo / workspace.name / "evals").exists()
+    assert (staged_repo / target.name / "references" / "evals" / "keep.md").is_file()
+    assert (staged_repo / "docs" / "evals" / "keep.txt").is_file()
+
+    readable_environment = "\n".join(
+        path.read_text(encoding="utf-8", errors="ignore") for path in env.rglob("*") if path.is_file()
+    )
+    assert "UNDECLARED-ORACLE" not in readable_environment
+    assert "GROUND-TRUTH-SECRET" not in readable_environment
+    assert (target / "evals" / "evals.json").is_file(), "source evaluation assets must remain intact"
+
+
+def test_generated_tasks_project_runtime_skills_without_root_evals(tmp_path: Path) -> None:
+    _, target, references_dir, workspace = _write_projection_fixture(tmp_path)
+
+    task = generate_harbor_tasks(
+        target,
+        tmp_path / "generated",
+        with_skill=True,
+        reference_skills_dir=references_dir,
+        workspace_skill_paths=[workspace],
+        copy_repo=True,
+    )[0]
+
+    _assert_runtime_projection(task, target, workspace)
+    assert (task / "environment" / "input" / "selected.txt").read_text(encoding="utf-8") == "SELECTED-FIXTURE\n"
+    assert not (task / "environment" / "input" / "hidden.txt").exists()
+    assert (task / "tests" / "grader.py").is_file()
+    assert "GROUND-TRUTH-SECRET" in (task / "tests" / "entry.json").read_text(encoding="utf-8")
+    assert (task / "environment" / "sidecar" / "seed.txt").is_file()
+    dockerfile = (task / "environment" / "Dockerfile").read_text(encoding="utf-8")
+    assert "target-runtime==1" in dockerfile
+    assert "target-oracle==9" not in dockerfile
+
+
+def test_native_tasks_project_runtime_skills_without_root_evals(tmp_path: Path) -> None:
+    _, target, references_dir, workspace = _write_projection_fixture(tmp_path)
+    native_task = target / "evals" / "harbor" / "case-001"
+    native_environment = native_task / "environment"
+    native_environment.mkdir(parents=True)
+    (native_environment / "native.txt").write_text("native environment asset\n", encoding="utf-8")
+    prebundled = native_environment / "skills" / "prebundled-skill"
+    (prebundled / "evals").mkdir(parents=True)
+    (prebundled / "skill.md").write_text("# Prebundled\n", encoding="utf-8")
+    (prebundled / "evals" / "secret.txt").write_text("PREBUNDLED-ORACLE\n", encoding="utf-8")
+    (prebundled / "references" / "evals").mkdir(parents=True)
+    (prebundled / "references" / "evals" / "keep.txt").write_text("keep\n", encoding="utf-8")
+    nested_prebundled = _write_nested_runtime_skill(prebundled, "prebundled")
+    (native_task / "instruction.md").write_text("Run the native case.\n", encoding="utf-8")
+    (native_task / "task.toml").write_text(
+        'schema_version = "1.3"\n\n[task]\nname = "nvidia/case-001"\n\n'
+        '[metadata]\nentry_id = "case-001"\n\n[environment]\n',
+        encoding="utf-8",
+    )
+
+    task = stage_native_harbor_tasks(
+        target,
+        tmp_path / "native",
+        with_skill=True,
+        reference_skills_dir=references_dir,
+        workspace_skill_paths=[workspace],
+        copy_repo=True,
+    )[0]
+
+    _assert_runtime_projection(task, target, workspace)
+    assert (task / "environment" / "input" / "selected.txt").read_text(encoding="utf-8") == "SELECTED-FIXTURE\n"
+    assert not (task / "environment" / "input" / "hidden.txt").exists()
+    assert (task / "instruction.md").read_text(encoding="utf-8") == "Run the native case.\n"
+    assert (task / "environment" / "native.txt").is_file()
+    assert not (task / "environment" / "skills" / "prebundled-skill" / "evals").exists()
+    assert (task / "environment" / "skills" / "prebundled-skill" / "references" / "evals" / "keep.txt").is_file()
+    staged_nested_prebundled = (
+        task / "environment" / "skills" / "prebundled-skill" / nested_prebundled.relative_to(prebundled)
+    )
+    assert (staged_nested_prebundled / "SKILL.md").is_file()
+    assert not (staged_nested_prebundled / "evals").exists()
+    assert (staged_nested_prebundled / "references" / "evals" / "keep.md").is_file()
+    assert (task / "tests" / "entry.json").is_file()
+    assert (task / "tests" / "grader.py").is_file()
+
+
+def test_base_image_dependency_collection_ignores_only_root_evals(tmp_path: Path) -> None:
+    _, target, references_dir, workspace = _write_projection_fixture(tmp_path)
+
+    pip_reqs, apt_packages = _collect_all_skill_deps(target, references_dir, [workspace])
+
+    assert pip_reqs == [
+        "reference-nested-runtime==1",
+        "reference-runtime==1",
+        "target-nested-runtime==1",
+        "target-runtime==1",
+        "workspace-nested-runtime==1",
+        "workspace-runtime==1",
+    ]
+    assert apt_packages == [
+        "reference-nested-runtime-tool",
+        "reference-runtime-tool",
+        "target-nested-runtime-tool",
+        "target-runtime-tool",
+        "workspace-nested-runtime-tool",
+        "workspace-runtime-tool",
+    ]
+
+
+def test_runtime_projection_excludes_nested_skill_evals_and_dependencies(tmp_path: Path) -> None:
+    _, target, references_dir, workspace = _write_projection_fixture(tmp_path)
+    wrappers = [target, references_dir / "reference-skill", workspace]
+    nested_skills = [
+        _write_nested_runtime_skill(wrapper, package)
+        for wrapper, package in zip(wrappers, ("target", "reference", "workspace"), strict=True)
+    ]
+
+    task = generate_harbor_tasks(
+        target,
+        tmp_path / "nested-skill-evals",
+        reference_skills_dir=references_dir,
+        workspace_skill_paths=[workspace],
+    )[0]
+
+    staged_wrappers = [
+        task / "environment" / "skills" / target.name,
+        task / "environment" / "skills" / "reference-skill",
+        task / "environment" / "skills" / workspace.name,
+    ]
+    for nested, wrapper, staged_wrapper in zip(nested_skills, wrappers, staged_wrappers, strict=True):
+        staged_nested = staged_wrapper / nested.relative_to(wrapper)
+        assert (staged_nested / "SKILL.md").is_file()
+        assert not (staged_nested / "evals").exists()
+        assert (staged_nested / "references" / "evals" / "keep.md").is_file()
+
+    pip_reqs, apt_packages = _collect_all_skill_deps(target, references_dir, [workspace])
+    for package in ("target", "reference", "workspace"):
+        assert f"{package}-nested-skill-runtime==1" in pip_reqs
+        assert f"{package}-nested-skill-runtime-tool" in apt_packages
+        assert f"{package}-nested-skill-oracle==9" not in pip_reqs
+        assert f"{package}-nested-skill-oracle-tool" not in apt_packages
+
+
+def test_base_image_dependency_collection_does_not_follow_alias_into_root_evals(tmp_path: Path) -> None:
+    _, target, references_dir, workspace = _write_projection_fixture(tmp_path)
+    alias_dir = target / "scripts" / "eval-alias"
+    alias_dir.mkdir()
+    try:
+        (alias_dir / "requirements.txt").symlink_to("../../evals/requirements.txt")
+        (alias_dir / "apt-packages.txt").symlink_to("../../evals/apt-packages.txt")
+    except OSError as exc:  # pragma: no cover - host policy, primarily native Windows
+        pytest.skip(f"symlinks unavailable on this host: {exc}")
+
+    pip_reqs, apt_packages = _collect_all_skill_deps(target, references_dir, [workspace])
+
+    assert "target-oracle==9" not in pip_reqs
+    assert "target-oracle-tool" not in apt_packages
+
+
+def test_base_image_dependency_collection_matches_ignored_runtime_projection(tmp_path: Path) -> None:
+    _, target, references_dir, workspace = _write_projection_fixture(tmp_path)
+    archived = target / "results"
+    archived.mkdir()
+    (archived / "requirements.txt").write_text("archived-oracle==9\n", encoding="utf-8")
+    (archived / "apt-packages.txt").write_text("archived-oracle-tool\n", encoding="utf-8")
+
+    pip_reqs, apt_packages = _collect_all_skill_deps(target, references_dir, [workspace])
+
+    assert "archived-oracle==9" not in pip_reqs
+    assert "archived-oracle-tool" not in apt_packages
+
+
+@pytest.mark.parametrize("link_kind", ["symlink", "hardlink"])
+def test_runtime_skill_projection_rejects_linked_host_file(tmp_path: Path, link_kind: str) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    outside = tmp_path / "host-secret.txt"
+    outside.write_text("HOST-SECRET\n", encoding="utf-8")
+    alias = target / "scripts" / "host-secret.txt"
+    try:
+        if link_kind == "symlink":
+            alias.symlink_to(outside)
+        else:
+            alias.hardlink_to(outside)
+    except OSError as exc:  # pragma: no cover - filesystem policy
+        pytest.skip(f"{link_kind}s unavailable on this host: {exc}")
+
+    with pytest.raises(ValueError, match=r"symlink|hard.?link"):
+        generate_harbor_tasks(target, tmp_path / f"runtime-{link_kind}")
+
+
+def test_copy_repo_does_not_follow_alias_into_skill_root_evals(tmp_path: Path) -> None:
+    repo, target, references_dir, workspace = _write_projection_fixture(tmp_path)
+    alias = repo / "oracle-alias.txt"
+    try:
+        alias.symlink_to(target / "evals" / "files" / "hidden.txt")
+    except OSError as exc:  # pragma: no cover - host policy, primarily native Windows
+        pytest.skip(f"symlinks unavailable on this host: {exc}")
+
+    task = generate_harbor_tasks(
+        target,
+        tmp_path / "generated-alias",
+        reference_skills_dir=references_dir,
+        workspace_skill_paths=[workspace],
+        copy_repo=True,
+    )[0]
+
+    assert not (task / "environment" / "repo" / alias.name).exists()
+
+
+def test_copy_repo_ignores_lexical_skill_evals_alias_to_repo_file(tmp_path: Path) -> None:
+    repo, target, references_dir, workspace = _write_projection_fixture(tmp_path)
+    secret = repo / ".env"
+    secret.write_text("TOKEN=repo-secret\n", encoding="utf-8")
+    alias = target / "evals" / "repo-secret-alias"
+    try:
+        alias.symlink_to(secret)
+    except OSError as exc:  # pragma: no cover - host policy, primarily native Windows
+        pytest.skip(f"symlinks unavailable on this host: {exc}")
+
+    task = generate_harbor_tasks(
+        target,
+        tmp_path / "generated-lexical-alias",
+        reference_skills_dir=references_dir,
+        workspace_skill_paths=[workspace],
+        copy_repo=True,
+    )[0]
+
+    assert not (task / "environment" / "repo" / target.name / "evals" / alias.name).exists()
+
+
+def test_copy_repo_rejects_hardlink_alias(tmp_path: Path) -> None:
+    repo, target, references_dir, workspace = _write_projection_fixture(tmp_path)
+    alias = repo / "oracle-hardlink.txt"
+    try:
+        alias.hardlink_to(target / "evals" / "files" / "hidden.txt")
+    except OSError as exc:  # pragma: no cover - filesystem policy
+        pytest.skip(f"hardlinks unavailable on this host: {exc}")
+
+    with pytest.raises(ValueError, match=r"hardlink|hard link"):
+        generate_harbor_tasks(
+            target,
+            tmp_path / "generated-hardlink",
+            reference_skills_dir=references_dir,
+            workspace_skill_paths=[workspace],
+            copy_repo=True,
+        )
+
+
+def test_linked_repo_ignores_lexical_skill_evals_alias(tmp_path: Path) -> None:
+    repo, target, references_dir, workspace = _write_projection_fixture(tmp_path)
+    secret = repo / "linked-secret.txt"
+    secret.write_text("LINKED-REPO-SECRET\n", encoding="utf-8")
+    alias = target / "evals" / "linked-secret-alias"
+    try:
+        alias.symlink_to(secret)
+    except OSError as exc:  # pragma: no cover - host policy, primarily native Windows
+        pytest.skip(f"symlinks unavailable on this host: {exc}")
+    manifest = target / "SKILL.md"
+    manifest.write_text(
+        manifest.read_text(encoding="utf-8") + "\n[hidden](evals/linked-secret-alias)\n",
+        encoding="utf-8",
+    )
+
+    task = generate_harbor_tasks(
+        target,
+        tmp_path / "linked-lexical-alias",
+        reference_skills_dir=references_dir,
+        workspace_skill_paths=[workspace],
+        copy_repo=False,
+    )[0]
+
+    environment = task / "environment"
+    assert "LINKED-REPO-SECRET" not in "\n".join(
+        path.read_text(encoding="utf-8", errors="ignore") for path in environment.rglob("*") if path.is_file()
+    )
+
+
+def test_copy_repo_filters_lowercase_skill_manifest_evals(tmp_path: Path) -> None:
+    _, target, references_dir, workspace = _write_projection_fixture(tmp_path)
+    lowercase_skill = target.parent / "lowercase-skill"
+    (lowercase_skill / "evals").mkdir(parents=True)
+    (lowercase_skill / "skill.md").write_text("# Lowercase\n", encoding="utf-8")
+    (lowercase_skill / "evals" / "secret.txt").write_text("LOWERCASE-ORACLE\n", encoding="utf-8")
+
+    task = generate_harbor_tasks(
+        target,
+        tmp_path / "lowercase-filter",
+        reference_skills_dir=references_dir,
+        workspace_skill_paths=[workspace],
+        copy_repo=True,
+    )[0]
+
+    assert not (task / "environment" / "repo" / lowercase_skill.name / "evals").exists()
+
+
+def test_copy_repo_excludes_configured_in_repo_output_root(tmp_path: Path) -> None:
+    repo, target, references_dir, workspace = _write_projection_fixture(tmp_path)
+    output_dir = repo / "custom-results"
+    leaked_entry = output_dir / "prior-task" / "tests" / "entry.json"
+    leaked_entry.parent.mkdir(parents=True)
+    leaked_entry.write_text('{"ground_truth": "PRIOR-RUN-SECRET"}\n', encoding="utf-8")
+
+    task = generate_harbor_tasks(
+        target,
+        output_dir,
+        reference_skills_dir=references_dir,
+        workspace_skill_paths=[workspace],
+        copy_repo=True,
+    )[0]
+
+    assert not (task / "environment" / "repo" / output_dir.name).exists()
+
+
+def test_runtime_skill_projection_excludes_shared_in_skill_output_root(tmp_path: Path) -> None:
+    _, target, references_dir, workspace = _write_projection_fixture(tmp_path)
+    output_root = target / "Custom-Results"
+    configured_output_root = target / "custom-results"
+    first_output = output_root / "agent-a"
+    generate_harbor_tasks(
+        target,
+        first_output,
+        reference_skills_dir=references_dir,
+        workspace_skill_paths=[workspace],
+        repo_context_exclude_paths=(configured_output_root,),
+    )
+
+    second = generate_harbor_tasks(
+        target,
+        output_root / "agent-b",
+        reference_skills_dir=references_dir,
+        workspace_skill_paths=[workspace],
+        repo_context_exclude_paths=(configured_output_root,),
+    )[0]
+
+    assert not (second / "environment" / "skills" / target.name / output_root.name).exists()
+    pip_reqs, apt_packages = _collect_all_skill_deps(
+        target,
+        references_dir,
+        [workspace],
+        excluded_roots=(configured_output_root,),
+    )
+    assert all("custom-results" not in dep.casefold() for dep in [*pip_reqs, *apt_packages])
+
+
+def test_copy_repo_excludes_case_only_output_alias(tmp_path: Path) -> None:
+    _, target, references_dir, workspace = _write_projection_fixture(tmp_path)
+    prior_output = target / "Custom-Results"
+    prior_output.mkdir()
+    (prior_output / "prior.json").write_text("PRIOR-RESULT-ORACLE\n", encoding="utf-8")
+
+    task = generate_harbor_tasks(
+        target,
+        tmp_path / "casefold-copy-repo",
+        reference_skills_dir=references_dir,
+        workspace_skill_paths=[workspace],
+        copy_repo=True,
+        repo_context_exclude_paths=(target / "custom-results",),
+    )[0]
+
+    environment = task / "environment"
+    assert not (environment / "skills" / target.name / "Custom-Results").exists()
+    assert not (environment / "repo" / target.name / "Custom-Results").exists()
+
+
+@pytest.mark.parametrize("stager", ["generated", "native"])
+def test_declared_in_skill_output_can_be_regenerated(tmp_path: Path, stager: str) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    if stager == "native":
+        _write_minimal_native_task(target)
+    output_root = target / "custom-results"
+    output_dir = output_root / "dataset"
+    stager_fn = generate_harbor_tasks if stager == "generated" else stage_native_harbor_tasks
+
+    first = stager_fn(target, output_dir, repo_context_exclude_paths=(output_root,))
+    second = stager_fn(target, output_dir, repo_context_exclude_paths=(output_root,))
+
+    assert first and second
+    assert (target / "SKILL.md").is_file()
+    assert (output_dir / "dataset.toml").is_file()
+
+
+def test_broad_output_ancestor_does_not_empty_runtime_skill(tmp_path: Path) -> None:
+    _, target, references_dir, workspace = _write_projection_fixture(tmp_path)
+
+    task = generate_harbor_tasks(
+        target,
+        tmp_path / "ancestor-output",
+        reference_skills_dir=references_dir,
+        workspace_skill_paths=[workspace],
+        repo_context_exclude_paths=(tmp_path,),
+    )[0]
+
+    staged_target = task / "environment" / "skills" / target.name
+    assert (staged_target / "SKILL.md").is_file()
+    assert (staged_target / "scripts" / "run.py").is_file()
+    pip_reqs, _ = _collect_all_skill_deps(target, references_dir, [workspace], excluded_roots=(tmp_path,))
+    assert "target-runtime==1" in pip_reqs
+
+
+@pytest.mark.parametrize("source_name", ["files", "environment"])
+def test_generated_rejects_output_root_inside_evaluator_source(tmp_path: Path, source_name: str) -> None:
+    _, target, references_dir, workspace = _write_projection_fixture(tmp_path)
+    unsafe_root = target / "evals" / source_name / "configured-results"
+
+    with pytest.raises(ValueError, match="output root must not be inside evaluator source"):
+        generate_harbor_tasks(
+            target,
+            tmp_path / f"unsafe-generated-{source_name}",
+            reference_skills_dir=references_dir,
+            workspace_skill_paths=[workspace],
+            repo_context_exclude_paths=(unsafe_root,),
+        )
+
+
+def test_native_rejects_output_root_inside_evaluator_source(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    _write_minimal_native_task(target)
+    unsafe_root = target / "evals" / "harbor" / "configured-results"
+
+    with pytest.raises(ValueError, match="output root must not be inside evaluator source"):
+        stage_native_harbor_tasks(
+            target,
+            tmp_path / "unsafe-native-output",
+            repo_context_exclude_paths=(unsafe_root,),
+        )
+
+
+def test_default_results_root_remains_supported(tmp_path: Path) -> None:
+    _, target, references_dir, workspace = _write_projection_fixture(tmp_path)
+
+    tasks = generate_harbor_tasks(
+        target,
+        tmp_path / "safe-default-results",
+        reference_skills_dir=references_dir,
+        workspace_skill_paths=[workspace],
+        repo_context_exclude_paths=(target / "evals" / "results",),
+    )
+
+    assert tasks
+
+
+def test_declared_custom_in_skill_results_root_remains_supported(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+
+    validate_results_root_location(target, target / "custom-results")
+    with pytest.raises(ValueError, match="runtime skill source"):
+        validate_results_root_location(target, target / "scripts" / "results")
+
+
+@pytest.mark.parametrize("source_alias", ["FILES", "Environment", "HARBOR"])
+def test_results_root_rejects_case_alias_of_evaluator_source(tmp_path: Path, source_alias: str) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+
+    with pytest.raises(ValueError, match="output root must not be inside evaluator source"):
+        validate_results_root_location(target, target / "evals" / source_alias / "prior-results")
+
+
+def test_excluded_root_matching_is_case_insensitive(tmp_path: Path) -> None:
+    actual = tmp_path / "Custom-Results" / "agent-a"
+    typed_alias = tmp_path / "custom-results"
+
+    assert _path_is_excluded(actual, (typed_alias,))
+
+
+def test_prebuild_uses_each_tasks_exact_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dataset = tmp_path / "dataset"
+    build_calls: list[tuple[str, Path]] = []
+    for case_id, fixture in (("case-a", "ALPHA"), ("case-b", "BETA")):
+        task = dataset / case_id
+        environment = task / "environment"
+        (environment / "input").mkdir(parents=True)
+        (environment / "Dockerfile").write_text(
+            "FROM python:3.12-slim\nCOPY input/ /workspace/input/\n",
+            encoding="utf-8",
+        )
+        (environment / "input" / "fixture.txt").write_text(fixture, encoding="utf-8")
+        (task / "task.toml").write_text("[environment]\n", encoding="utf-8")
+
+    class _Result:
+        def __init__(self, returncode: int) -> None:
+            self.returncode = returncode
+            self.stderr = ""
+            self.stdout = ""
+
+    def _fake_run(command: list[str], **_kwargs: object) -> _Result:
+        if command[:3] == ["docker", "image", "inspect"]:
+            return _Result(1)
+        assert command[:3] == ["docker", "build", "-t"]
+        build_calls.append((command[3], Path(command[4])))
+        return _Result(0)
+
+    monkeypatch.setenv("SKILL_EVAL_HARBOR_PREBUILD_TASK_ENVS", "1")
+    monkeypatch.setattr("skillevaluator.tier3.harbor.adapter.subprocess.run", _fake_run)
+
+    assert prebuild_task_environments([dataset]) == 2
+    assert {path.name for _, path in build_calls} == {"environment"}
+    assert {path.parent.name for _, path in build_calls} == {"case-a", "case-b"}
+    assert len({tag for tag, _ in build_calls}) == 2
+    task_tags = {
+        task.name: next(
+            line for line in (task / "task.toml").read_text(encoding="utf-8").splitlines() if "docker_image" in line
+        )
+        for task in sorted(dataset.iterdir())
+    }
+    assert task_tags["case-a"] != task_tags["case-b"]
+
+    first_build_tags = {path.parent.name: tag for tag, path in build_calls}
+    (dataset / "case-a" / "environment" / "input" / "fixture.txt").chmod(0o755)
+    for task in dataset.iterdir():
+        (task / "task.toml").write_text("[environment]\n", encoding="utf-8")
+    build_calls.clear()
+
+    assert prebuild_task_environments([dataset]) == 2
+    second_build_tags = {path.parent.name: tag for tag, path in build_calls}
+    assert second_build_tags["case-a"] != first_build_tags["case-a"]
+    assert second_build_tags["case-b"] == first_build_tags["case-b"]
+
+
+def test_prebuild_skips_task_with_compose_build_override(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("SKILL_EVAL_HARBOR_PREBUILD_TASK_ENVS", "1")
+    dataset = tmp_path / "dataset"
+    task = dataset / "case-a"
+    environment = task / "environment"
+    environment.mkdir(parents=True)
+    (environment / "Dockerfile").write_text("FROM python:3.12-slim\n", encoding="utf-8")
+    (environment / "docker-compose.yaml").write_text(
+        "services:\n  main:\n    build:\n      context: ./alternate\n",
+        encoding="utf-8",
+    )
+    (task / "task.toml").write_text("[environment]\n", encoding="utf-8")
+    calls: list[list[str]] = []
+
+    def _unexpected_run(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr("skillevaluator.tier3.harbor.adapter.subprocess.run", _unexpected_run)
+
+    assert prebuild_task_environments([dataset]) == 0
+    assert calls == []
+    assert "docker_image" not in (task / "task.toml").read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("stager", ["generated", "native"])
+@pytest.mark.parametrize("output_kind", ["evals", "skill"])
+def test_staging_rejects_output_that_contains_evaluator_sources_before_mutation(
+    tmp_path: Path,
+    stager: str,
+    output_kind: str,
+) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    if stager == "native":
+        _write_minimal_native_task(target)
+    output_dir = target / "evals" if output_kind == "evals" else target
+
+    with pytest.raises(ValueError, match="Staging output directory overlaps evaluator source"):
+        if stager == "generated":
+            generate_harbor_tasks(target, output_dir)
+        else:
+            stage_native_harbor_tasks(target, output_dir)
+
+    assert (target / "SKILL.md").is_file()
+    assert (target / "evals" / "evals.json").is_file()
+
+
+@pytest.mark.parametrize("stager", ["generated", "native"])
+@pytest.mark.parametrize("eval_subdir", ["data", "tests"])
+def test_staging_rejects_output_inside_any_evaluator_source_subtree(
+    tmp_path: Path,
+    stager: str,
+    eval_subdir: str,
+) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    if stager == "native":
+        _write_minimal_native_task(target)
+    output_dir = target / "evals" / eval_subdir
+    output_dir.mkdir(exist_ok=True)
+    sentinel = output_dir / "keep.txt"
+    sentinel.write_text("preserve\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Staging output directory overlaps evaluator source"):
+        if stager == "generated":
+            generate_harbor_tasks(target, output_dir)
+        else:
+            stage_native_harbor_tasks(target, output_dir)
+
+    assert sentinel.read_text(encoding="utf-8") == "preserve\n"
+
+
+@pytest.mark.parametrize("stager", ["generated", "native"])
+@pytest.mark.parametrize("alias", ["Results", "RESULTS"])
+def test_staging_rejects_case_alias_of_reserved_results_directory(
+    tmp_path: Path,
+    stager: str,
+    alias: str,
+) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    if stager == "native":
+        _write_minimal_native_task(target)
+    output_dir = target / "evals" / alias
+    output_dir.mkdir()
+    sentinel = output_dir / "keep.txt"
+    sentinel.write_text("preserve\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="evaluator source"):
+        stager_fn = generate_harbor_tasks if stager == "generated" else stage_native_harbor_tasks
+        stager_fn(target, output_dir)
+
+    assert sentinel.read_text(encoding="utf-8") == "preserve\n"
+
+
+@pytest.mark.parametrize("stager", ["generated", "native", "results-root"])
+def test_output_path_rejects_parent_traversal_before_evaluator_source_mutation(tmp_path: Path, stager: str) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    if stager == "native":
+        _write_minimal_native_task(target)
+    sentinel = target / "evals" / "files" / "selected.txt"
+    output_dir = target / "evals" / "results" / ".." / "files"
+
+    with pytest.raises(ValueError, match="parent traversal"):
+        if stager == "generated":
+            generate_harbor_tasks(target, output_dir)
+        elif stager == "native":
+            stage_native_harbor_tasks(target, output_dir)
+        else:
+            validate_results_root_location(target, output_dir)
+
+    assert sentinel.read_text(encoding="utf-8") == "SELECTED-FIXTURE\n"
+
+
+@pytest.mark.parametrize("stager", ["generated", "native"])
+@pytest.mark.parametrize("source_kind", ["reference", "reference-parent", "workspace", "workspace-parent"])
+def test_staging_rejects_output_overlapping_supplied_skill_sources(
+    tmp_path: Path,
+    stager: str,
+    source_kind: str,
+) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    if stager == "native":
+        _write_minimal_native_task(target)
+    reference_parent = tmp_path / "external-reference-source"
+    references = reference_parent / "references"
+    reference = _write_runtime_skill(references / "reference", "reference-external")
+    workspace_parent = tmp_path / "external-workspace-source"
+    workspace = _write_runtime_skill(workspace_parent / "workspace", "workspace-external")
+    output_dir = {
+        "reference": reference,
+        "reference-parent": reference_parent,
+        "workspace": workspace,
+        "workspace-parent": workspace_parent,
+    }[source_kind]
+    marker = output_dir / "source-marker.txt"
+    marker.write_text("preserve\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Staging output directory overlaps runtime skill source"):
+        stager_fn = generate_harbor_tasks if stager == "generated" else stage_native_harbor_tasks
+        stager_fn(
+            target,
+            output_dir,
+            reference_skills_dir=references,
+            workspace_skill_paths=[workspace],
+        )
+
+    assert marker.read_text(encoding="utf-8") == "preserve\n"
+
+
+@pytest.mark.parametrize("stager", ["generated", "native"])
+def test_staging_rejects_undeclared_output_inside_target_runtime_tree(tmp_path: Path, stager: str) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    runtime_source = target / "src"
+    runtime_source.mkdir()
+    marker = runtime_source / "runtime.py"
+    marker.write_text("print('preserve')\n", encoding="utf-8")
+    if stager == "native":
+        _write_minimal_native_task(target)
+
+    with pytest.raises(ValueError, match="Staging output directory overlaps runtime skill source"):
+        stager_fn = generate_harbor_tasks if stager == "generated" else stage_native_harbor_tasks
+        stager_fn(target, runtime_source)
+
+    assert marker.read_text(encoding="utf-8") == "print('preserve')\n"
+
+
+@pytest.mark.parametrize("stager", ["generated", "native"])
+def test_declared_output_cannot_replace_standard_runtime_source(tmp_path: Path, stager: str) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    scripts = target / "scripts"
+    marker = scripts / "run.py"
+    if stager == "native":
+        _write_minimal_native_task(target)
+
+    with pytest.raises(ValueError, match="runtime skill source"):
+        stager_fn = generate_harbor_tasks if stager == "generated" else stage_native_harbor_tasks
+        stager_fn(target, scripts, repo_context_exclude_paths=(scripts,))
+
+    assert marker.read_text(encoding="utf-8") == "print('runtime')\n"
+
+
+@pytest.mark.parametrize("stager", ["generated", "native"])
+def test_declared_output_root_cannot_contain_authored_nested_skill(tmp_path: Path, stager: str) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    declared_root = target / "addons"
+    nested_skill = declared_root / "helper"
+    nested_skill.mkdir(parents=True)
+    (nested_skill / "SKILL.md").write_text("# Helper\n", encoding="utf-8")
+    marker = nested_skill / "runtime.txt"
+    marker.write_text("preserve\n", encoding="utf-8")
+    if stager == "native":
+        _write_minimal_native_task(target)
+
+    with pytest.raises(ValueError, match="output root must not overlap runtime skill source"):
+        stager_fn = generate_harbor_tasks if stager == "generated" else stage_native_harbor_tasks
+        stager_fn(
+            target,
+            declared_root / "generated" / "dataset",
+            repo_context_exclude_paths=(declared_root,),
+        )
+
+    assert marker.read_text(encoding="utf-8") == "preserve\n"
+
+
+def test_declared_output_does_not_trust_authored_dataset_manifest(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    declared_root = target / "addons"
+    nested_skill = declared_root / "helper"
+    nested_skill.mkdir(parents=True)
+    (declared_root / "dataset.toml").write_text('[dataset]\nname = "authored"\n', encoding="utf-8")
+    (nested_skill / "SKILL.md").write_text("# Authored helper\n", encoding="utf-8")
+    sentinel = nested_skill / "runtime.txt"
+    sentinel.write_text("preserve\n", encoding="utf-8")
+    (target / "evals" / "evals.json").write_text(
+        json.dumps([{"id": "helper", "question": "Do not replace authored content."}]),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="overlaps runtime skill source"):
+        generate_harbor_tasks(target, declared_root, repo_context_exclude_paths=(declared_root,))
+
+    assert sentinel.read_text(encoding="utf-8") == "preserve\n"
+
+
+def test_marked_prior_run_does_not_block_declared_results_root(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    results_root = target / "custom-results"
+    prior_run = results_root / "run-old"
+    mark_generated_output_root(prior_run)
+    retained_skill = prior_run / "jobs" / "case-001" / "workspace" / "skills" / target.name
+    retained_skill.mkdir(parents=True)
+    (retained_skill / "SKILL.md").write_text("# Retained generated copy\n", encoding="utf-8")
+
+    validate_results_root_location(target, results_root)
+
+
+def test_declared_in_skill_output_recovers_after_partial_generation_failure(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    (target / "evals" / "evals.json").write_text(
+        json.dumps(
+            [
+                {"id": "case-a", "question": "Stage existing.", "files": ["evals/files/selected.txt"]},
+                {"id": "case-b", "question": "Stage missing.", "files": ["evals/files/later.txt"]},
+            ]
+        ),
+        encoding="utf-8",
+    )
+    declared_root = target / "custom-results"
+    output_dir = declared_root / "dataset"
+
+    with pytest.raises(FileNotFoundError, match="does not exist"):
+        generate_harbor_tasks(target, output_dir, repo_context_exclude_paths=(declared_root,))
+
+    (target / "evals" / "files" / "later.txt").write_text("LATER\n", encoding="utf-8")
+    tasks = generate_harbor_tasks(target, output_dir, repo_context_exclude_paths=(declared_root,))
+
+    assert {task.name for task in tasks} == {"case-a", "case-b"}
+    assert (output_dir / ".skillevaluator-generated-output").is_file()
+
+
+@pytest.mark.parametrize("stager", ["generated", "native"])
+def test_staging_rejects_symlinked_output_parent_without_replacing_target(tmp_path: Path, stager: str) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    if stager == "native":
+        _write_minimal_native_task(target)
+    victim_parent = tmp_path / "victim-parent"
+    victim_output = victim_parent / "dataset"
+    victim_output.mkdir(parents=True)
+    sentinel = victim_output / "keep.txt"
+    sentinel.write_text("preserve\n", encoding="utf-8")
+    alias = tmp_path / "output-alias"
+    alias.symlink_to(victim_parent, target_is_directory=True)
+
+    with pytest.raises(ValueError, match=r"symlink|reparse|junction"):
+        stager_fn = generate_harbor_tasks if stager == "generated" else stage_native_harbor_tasks
+        stager_fn(target, alias / "dataset")
+
+    assert sentinel.read_text(encoding="utf-8") == "preserve\n"
+
+
+def test_legacy_input_rejects_symlinked_evals_ancestor(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    outside_evals = tmp_path / "outside-evals"
+    (target / "evals").rename(outside_evals)
+    (outside_evals / "evals.json").write_text(
+        json.dumps([{"id": "case-001", "question": "Legacy shared inputs."}]),
+        encoding="utf-8",
+    )
+    (target / "evals").symlink_to(outside_evals, target_is_directory=True)
+
+    with pytest.raises(ValueError, match=r"evals directory must be a real directory.*symlink"):
+        generate_harbor_tasks(target, tmp_path / "symlinked-evals-output")
+
+    assert not (tmp_path / "symlinked-evals-output").exists()
+
+
+@pytest.mark.parametrize("invalid_entries", [[{"id": ".."}], [{"id": "case-001"}, {"id": "Case-001"}]])
+def test_native_rejects_invalid_or_colliding_case_ids_before_output_mutation(
+    tmp_path: Path,
+    invalid_entries: list[dict[str, str]],
+) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    _write_minimal_native_task(target)
+    (target / "evals" / "evals.json").write_text(json.dumps(invalid_entries), encoding="utf-8")
+    output_dir = tmp_path / "native-existing-output"
+    output_dir.mkdir()
+    sentinel = output_dir / "keep.txt"
+    sentinel.write_text("preserve\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match=r"invalid case id|cross-platform colliding case id"):
+        stage_native_harbor_tasks(target, output_dir)
+
+    assert sentinel.read_text(encoding="utf-8") == "preserve\n"
+
+
+def test_native_rejects_unsafe_task_directory_name_before_output_mutation(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    _write_minimal_native_task(target)
+    native_root = target / "evals" / "harbor"
+    (native_root / "case-001").rename(native_root / 'bad"name')
+    output_dir = tmp_path / "native-invalid-directory"
+
+    with pytest.raises(ValueError, match="invalid case id"):
+        stage_native_harbor_tasks(target, output_dir)
+
+    assert not output_dir.exists()
+
+
+def test_results_root_rejects_supplied_skill_source(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    references = tmp_path / "external-references"
+    reference = _write_runtime_skill(references / "reference", "reference-output")
+    workspace = _write_runtime_skill(tmp_path / "external-workspace", "workspace-output")
+
+    for unsafe_root in (reference / "evals" / "files" / "results", workspace / "scripts" / "results"):
+        with pytest.raises(ValueError, match="output root must not be inside runtime skill source"):
+            validate_results_root_location(
+                target,
+                unsafe_root,
+                reference_skills_dir=references,
+                workspace_skill_paths=[workspace],
+            )
+
+
+def test_baseline_rejects_target_copied_under_reference_alias(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    references_dir = tmp_path / "aliased-references"
+    aliased_target = references_dir / "alias-target"
+    shutil.copytree(target, aliased_target)
+    (aliased_target / "extra.txt").write_text("tree changed but instructions are identical\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="alias of target skill"):
+        generate_harbor_tasks(
+            target,
+            tmp_path / "baseline-reference-alias",
+            with_skill=False,
+            reference_skills_dir=references_dir,
+        )
+
+
+@pytest.mark.parametrize("stager", ["generated", "native"])
+def test_baseline_reference_parent_skips_real_target_candidate(tmp_path: Path, stager: str) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    if stager == "native":
+        _write_minimal_native_task(target)
+        tasks = stage_native_harbor_tasks(
+            target,
+            tmp_path / "native-parent-references",
+            with_skill=False,
+            reference_skills_dir=target.parent,
+        )
+    else:
+        tasks = generate_harbor_tasks(
+            target,
+            tmp_path / "generated-parent-references",
+            with_skill=False,
+            reference_skills_dir=target.parent,
+        )
+
+    assert tasks
+
+
+def test_baseline_alias_scan_ignores_unstaged_candidate_results(tmp_path: Path) -> None:
+    _, target, references_dir, workspace = _write_projection_fixture(tmp_path)
+    archived = references_dir / "reference-skill" / "results" / "archived.txt"
+    archived.parent.mkdir()
+    archived.write_bytes((target / "SKILL.md").read_bytes())
+
+    task = generate_harbor_tasks(
+        target,
+        tmp_path / "ignored-reference-results",
+        with_skill=False,
+        reference_skills_dir=references_dir,
+        workspace_skill_paths=[workspace],
+    )[0]
+
+    assert not (task / "environment" / "skills" / "reference-skill" / "results").exists()
+
+
+@pytest.mark.parametrize("stager", ["generated", "native"])
+@pytest.mark.parametrize("candidate_kind", ["reference", "workspace"])
+def test_baseline_rejects_target_nested_inside_skill_candidate(
+    tmp_path: Path,
+    stager: str,
+    candidate_kind: str,
+) -> None:
+    _, target, references_dir, workspace = _write_projection_fixture(tmp_path)
+    candidate = references_dir / "reference-skill" if candidate_kind == "reference" else workspace
+    nested_alias = candidate / "references" / "target-copy"
+    nested_alias.mkdir(parents=True)
+    (nested_alias / "SKILL.md").write_bytes((target / "SKILL.md").read_bytes())
+
+    kwargs = {
+        "with_skill": False,
+        "reference_skills_dir": references_dir,
+        "workspace_skill_paths": [workspace],
+    }
+    with pytest.raises(ValueError, match="alias of target skill"):
+        if stager == "generated":
+            generate_harbor_tasks(target, tmp_path / f"nested-alias-{candidate_kind}", **kwargs)
+        else:
+            _write_minimal_native_task(target)
+            stage_native_harbor_tasks(target, tmp_path / f"native-nested-alias-{candidate_kind}", **kwargs)
+
+
+@pytest.mark.parametrize("stager", ["generated", "native"])
+def test_copy_repo_baseline_rejects_renamed_target_payload(tmp_path: Path, stager: str) -> None:
+    repo, target, references_dir, workspace = _write_projection_fixture(tmp_path)
+    archived = repo / "archive" / "renamed-target.md"
+    archived.parent.mkdir()
+    archived.write_bytes((target / "SKILL.md").read_bytes())
+    kwargs = {
+        "with_skill": False,
+        "reference_skills_dir": references_dir,
+        "workspace_skill_paths": [workspace],
+        "copy_repo": True,
+    }
+
+    with pytest.raises(ValueError, match="target skill instructions"):
+        if stager == "generated":
+            generate_harbor_tasks(target, tmp_path / "repo-payload-alias", **kwargs)
+        else:
+            _write_minimal_native_task(target)
+            stage_native_harbor_tasks(target, tmp_path / "native-repo-payload-alias", **kwargs)
+
+
+def test_baseline_projects_reference_and_workspace_skills_without_root_evals(tmp_path: Path) -> None:
+    _, target, references_dir, workspace = _write_projection_fixture(tmp_path)
+
+    task = generate_harbor_tasks(
+        target,
+        tmp_path / "baseline",
+        with_skill=False,
+        reference_skills_dir=references_dir,
+        workspace_skill_paths=[workspace],
+        copy_repo=True,
+    )[0]
+
+    environment = task / "environment"
+    assert not (environment / "skills" / target.name).exists()
+    for name in ("reference-skill", workspace.name):
+        assert (environment / "skills" / name / "SKILL.md").is_file()
+        assert not (environment / "skills" / name / "evals").exists()
+        assert (environment / "skills" / name / "references" / "evals" / "keep.md").is_file()
+    assert not (environment / "repo" / target.name).exists()
+    assert not (environment / "repo" / "reference-skills" / "reference-skill" / "evals").exists()
+    assert not (environment / "repo" / workspace.name / "evals").exists()
+    assert (environment / "repo" / "docs" / "evals" / "keep.txt").is_file()
+    assert (environment / "input" / "selected.txt").is_file()
+    assert "GROUND-TRUTH-SECRET" not in "\n".join(
+        path.read_text(encoding="utf-8", errors="ignore") for path in environment.rglob("*") if path.is_file()
+    )
+
+
+def test_linked_repo_context_excludes_skill_evals_but_keeps_unrelated_evals(tmp_path: Path) -> None:
+    _, target, references_dir, workspace = _write_projection_fixture(tmp_path)
+    (target / "SKILL.md").write_text(
+        "# Target\n\n"
+        "[Hidden evaluator data](../reference-skills/reference-skill/evals/evals.json)\n"
+        "[Runtime documentation](../docs/evals/keep.txt)\n",
+        encoding="utf-8",
+    )
+
+    task = generate_harbor_tasks(
+        target,
+        tmp_path / "linked",
+        reference_skills_dir=references_dir,
+        workspace_skill_paths=[workspace],
+        copy_repo=False,
+    )[0]
+
+    staged_repo = task / "environment" / "repo"
+    assert not (staged_repo / "reference-skills" / "reference-skill" / "evals" / "evals.json").exists()
+    assert (staged_repo / "docs" / "evals" / "keep.txt").is_file()
+
+
+@pytest.mark.parametrize("files_value", [[], ["evals/files/selected.txt"]])
+@pytest.mark.parametrize("source", ["INPUT/", "Input/fixture.txt"])
+def test_custom_dockerfile_rejects_noncanonical_input_case(
+    tmp_path: Path,
+    files_value: list[str],
+    source: str,
+) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    (target / "evals" / "evals.json").write_text(
+        json.dumps([{"id": "case-001", "question": "Use fixtures.", "files": files_value}]),
+        encoding="utf-8",
+    )
+    custom_environment = target / "evals" / "environment"
+    authored_input = custom_environment / "INPUT"
+    authored_input.mkdir()
+    (authored_input / "fixture.txt").write_text("UNDECLARED-UPPERCASE-INPUT\n", encoding="utf-8")
+    (custom_environment / "Dockerfile").write_text(
+        f"FROM python:3.12-slim\nCOPY {source} /workspace/input/\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="canonical lowercase path"):
+        generate_harbor_tasks(target, tmp_path / "uppercase-input")
+
+
+@pytest.mark.parametrize("custom_dockerfile_mode", ["preserve", "rebase"])
+@pytest.mark.parametrize(
+    "copy_instruction",
+    [
+        "COPY input/ /workspace/input/",
+        "COPY input/. /workspace/input/",
+        "COPY ../input/ /workspace/input/",
+        "COPY --chown=0:0\tinput/\t/workspace/input/",
+        'COPY --chown=0:0 ["input/", "/workspace/input/"]',
+        'COPY ["../input/", "/workspace/input/"]',
+    ],
+)
+def test_explicit_empty_input_keeps_authored_copy_input_buildable(
+    tmp_path: Path,
+    custom_dockerfile_mode: str,
+    copy_instruction: str,
+) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    (target / "evals" / "evals.json").write_text(
+        json.dumps([{"id": "case-001", "question": "No fixture.", "files": []}]),
+        encoding="utf-8",
+    )
+    custom_environment = target / "evals" / "environment"
+    authored_input = custom_environment / "input"
+    authored_input.mkdir()
+    (authored_input / "hidden.txt").write_text("UNDECLARED-CUSTOM-INPUT\n", encoding="utf-8")
+    (custom_environment / "Dockerfile").write_text(
+        f"FROM python:3.12-slim\n{copy_instruction}\n",
+        encoding="utf-8",
+    )
+
+    task = generate_harbor_tasks(
+        target,
+        tmp_path / f"custom-empty-{custom_dockerfile_mode}",
+        custom_dockerfile_mode=custom_dockerfile_mode,
+        base_image="python:3.12-slim" if custom_dockerfile_mode == "rebase" else "",
+    )[0]
+
+    input_dir = task / "environment" / "input"
+    assert input_dir.is_dir()
+    assert list(input_dir.iterdir()) == []
+    assert copy_instruction in (task / "environment" / "Dockerfile").read_text(encoding="utf-8")
+
+
+def test_native_copy_input_without_fixtures_gets_empty_build_context_directory(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    (target / "evals" / "evals.json").write_text(
+        json.dumps([{"id": "case-001", "question": "No fixture.", "files": []}]),
+        encoding="utf-8",
+    )
+    native_task = target / "evals" / "harbor" / "case-001"
+    environment = native_task / "environment"
+    environment.mkdir(parents=True)
+    (environment / "Dockerfile").write_text(
+        "FROM python:3.12-slim\nCOPY input/ /workspace/input/\n",
+        encoding="utf-8",
+    )
+    (native_task / "instruction.md").write_text("Run the native case.\n", encoding="utf-8")
+    (native_task / "task.toml").write_text(
+        'schema_version = "1.3"\n\n[task]\nname = "nvidia/case-001"\n\n'
+        '[metadata]\nentry_id = "case-001"\n\n[environment]\n',
+        encoding="utf-8",
+    )
+
+    task = stage_native_harbor_tasks(target, tmp_path / "native-empty-input")[0]
+
+    input_dir = task / "environment" / "input"
+    assert input_dir.is_dir()
+    assert list(input_dir.iterdir()) == []
+
+
+def test_native_input_is_preserved_without_eval_fixture_declaration(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    shutil.rmtree(target / "evals" / "files")
+    (target / "evals" / "evals.json").write_text(
+        json.dumps([{"id": "case-001", "question": "Use native input."}]),
+        encoding="utf-8",
+    )
+    native_task = target / "evals" / "harbor" / "case-001"
+    environment = native_task / "environment"
+    native_input = environment / "input"
+    native_input.mkdir(parents=True)
+    (native_input / "native-only.txt").write_text("NATIVE-ONLY\n", encoding="utf-8")
+    (environment / "Dockerfile").write_text("FROM python:3.12-slim\n", encoding="utf-8")
+    (native_task / "instruction.md").write_text("Run the native case.\n", encoding="utf-8")
+    (native_task / "task.toml").write_text(
+        'schema_version = "1.3"\n\n[task]\nname = "nvidia/case-001"\n\n'
+        '[metadata]\nentry_id = "case-001"\n\n[environment]\n',
+        encoding="utf-8",
+    )
+
+    task = stage_native_harbor_tasks(target, tmp_path / "native-preserved-input")[0]
+
+    assert (task / "environment" / "input" / "native-only.txt").read_text(encoding="utf-8") == "NATIVE-ONLY\n"
+
+
+def test_generated_baseline_rejects_aliased_authored_skill(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    custom_environment = target / "evals" / "environment"
+    alias = custom_environment / "alias"
+    alias.mkdir()
+    (alias / "SKILL.md").write_text((target / "SKILL.md").read_text(encoding="utf-8"), encoding="utf-8")
+    (custom_environment / "Dockerfile").write_text(
+        "FROM python:3.12-slim\nCOPY alias/ /root/.agents/skills/alias/\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="unmanaged skill"):
+        generate_harbor_tasks(target, tmp_path / "baseline-alias", with_skill=False)
+
+
+def test_generated_baseline_rejects_renamed_target_manifest_payload(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    custom_environment = target / "evals" / "environment"
+    (custom_environment / "payload.txt").write_bytes((target / "SKILL.md").read_bytes())
+    (custom_environment / "Dockerfile").write_text(
+        "FROM python:3.12-slim\nCOPY payload.txt /root/.agents/skills/alias/SKILL.md\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="target skill instructions"):
+        generate_harbor_tasks(target, tmp_path / "baseline-renamed-payload", with_skill=False)
+
+
+@pytest.mark.parametrize(
+    "project_skill_root",
+    [
+        "/workspace/.agents/skills",
+        "/workspace/.claude/skills",
+        "/workspace/.codex/skills",
+        "/workspace/.config/opencode/skills",
+        "/workspace/.cursor/skills",
+        "/workspace/.gemini/skills",
+        "/workspace/.opencode/skills",
+    ],
+)
+def test_final_projection_clears_authored_project_skill_root(
+    tmp_path: Path,
+    project_skill_root: str,
+) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    environment = target / "evals" / "environment"
+    hidden_manifest = f"{project_skill_root}/hidden/SKILL.md"
+    (environment / "Dockerfile").write_text(
+        "FROM python:3.12-slim\n"
+        f"RUN mkdir -p {project_skill_root}/hidden && "
+        f"printf 'PROJECT-ROOT-ORACLE\\n' > {hidden_manifest}\n",
+        encoding="utf-8",
+    )
+
+    task = generate_harbor_tasks(target, tmp_path / "project-skill-reset", with_skill=False)[0]
+
+    dockerfile = (task / "environment" / "Dockerfile").read_text(encoding="utf-8")
+    authored_index = dockerfile.index("PROJECT-ROOT-ORACLE")
+    reset_line = next(
+        line
+        for line in dockerfile.splitlines()
+        if line.startswith('RUN ["/bin/rm", "-rf"') and f'"{project_skill_root}"' in line
+    )
+    assert dockerfile.index(reset_line) > authored_index
+
+
+def test_final_projection_clears_effective_workdir_ancestors_and_home(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    environment = target / "evals" / "environment"
+    (environment / "Dockerfile").write_text(
+        "FROM python:3.12-slim\n"
+        "ENV HOME=/home/agent\n"
+        "WORKDIR /app\n"
+        "RUN mkdir -p /app/.claude/skills/hidden /home/agent/.claude/skills/hidden && "
+        "printf 'AUTHORED-CWD-ORACLE\\n' > /app/.claude/skills/hidden/SKILL.md && "
+        "printf 'AUTHORED-HOME-ORACLE\\n' > /home/agent/.claude/skills/hidden/SKILL.md\n"
+        "USER 12345\n",
+        encoding="utf-8",
+    )
+
+    task = generate_harbor_tasks(
+        target,
+        tmp_path / "dynamic-skill-root-reset",
+        with_skill=False,
+        grading_mode="custom_only",
+        agent_workdir="/opt/task/subdir",
+    )[0]
+
+    dockerfile = (task / "environment" / "Dockerfile").read_text(encoding="utf-8")
+    final_projection = dockerfile.index("# SkillEvaluator: final runtime projection")
+    assert dockerfile.index("AUTHORED-CWD-ORACLE") < final_projection
+    assert dockerfile.index("AUTHORED-HOME-ORACLE") < final_projection
+    assert dockerfile.count("current=$(/bin/pwd -P)") >= 2
+    assert "$home/$rel" in dockerfile
+    assert "done < /etc/passwd" in dockerfile
+    assert r"[ -d \"$home\" ] || continue" in dockerfile
+    assert r"[ -e \"$passwd_home\" ] && [ ! -d \"$passwd_home\" ] && continue" in dockerfile
+    assert "${CODEX_HOME:-}" in dockerfile
+    assert "${OPENCODE_CONFIG_DIR:-}" in dockerfile
+    assert "canonical=$(CDPATH= cd -P" in dockerfile
+    assert "ENTRYPOINT []" in dockerfile
+    assert "HEALTHCHECK NONE" in dockerfile
+    assert 'BASH_ENV=""' in dockerfile
+    assert 'CLAUDE_CODE_DISABLE_POLICY_SKILLS="1"' in dockerfile
+    assert "/etc/codex/skills" in dockerfile
+    assert "WORKDIR /opt/task/subdir" in dockerfile[final_projection:]
+    assert dockerfile.rindex("current=$(/bin/pwd -P)") > dockerfile.rindex("COPY input/ /workspace/input/")
+    task_toml = (task / "task.toml").read_text(encoding="utf-8")
+    assert 'workdir = "/opt/task/subdir"' in task_toml
+    assert '"BASH_ENV" = ""' in task_toml
+    assert '"CLAUDE_CODE_DISABLE_POLICY_SKILLS" = "1"' in task_toml
+
+
+@pytest.mark.parametrize("agent_workdir", ["relative", "/opt/../tmp", "/opt/task path"])
+def test_generated_tasks_reject_unsafe_agent_workdir(tmp_path: Path, agent_workdir: str) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+
+    with pytest.raises(ValueError, match="normalized absolute POSIX path"):
+        generate_harbor_tasks(target, tmp_path / "unsafe-agent-workdir", agent_workdir=agent_workdir)
+
+
+@pytest.mark.parametrize(
+    "agent_workdir",
+    [
+        "/workspace/input",
+        "/workspace/input/subdir",
+        "/workspace/repo/subdir",
+        "/workspace/skills",
+        "/opt/project/.claude/skills/hidden",
+    ],
+)
+def test_generated_tasks_reject_workdir_inside_runtime_projection(tmp_path: Path, agent_workdir: str) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+
+    with pytest.raises(ValueError, match=r"runtime projection|skill discovery"):
+        generate_harbor_tasks(target, tmp_path / "overlapping-agent-workdir", agent_workdir=agent_workdir)
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "HOME",
+        "USERPROFILE",
+        "XDG_CONFIG_HOME",
+        "CLAUDE_CONFIG_DIR",
+        "CLAUDE_CODE_DISABLE_POLICY_SKILLS",
+        "CODEX_HOME",
+        "GEMINI_CLI_HOME",
+        "OPENCODE_CONFIG_DIR",
+    ],
+)
+def test_generated_tasks_reject_runtime_skill_discovery_environment(tmp_path: Path, name: str) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+
+    with pytest.raises(ValueError, match="skill discovery"):
+        generate_harbor_tasks(
+            target,
+            tmp_path / "runtime-discovery-env",
+            runtime_env={name: "/runtime/hidden"},
+        )
+
+
+@pytest.mark.parametrize(
+    ("environment_toml", "message"),
+    [
+        ('[environment.env]\nHOME = "/runtime/hidden"\n', "skill discovery"),
+        ('[environment.env]\nBASH_ENV = "/runtime/seed.sh"\n', "process loader"),
+        ('[environment.env]\n"BASH_FUNC_hidden%%" = "/runtime/seed.sh"\n', "process loader"),
+        ('[environment.env]\nCLAUDE_CODE_DISABLE_POLICY_SKILLS = "0"\n', "skill discovery"),
+        ('skills_dir = "/workspace/input"\n', "skills_dir"),
+        ('docker_image = "prebuilt:latest"\n', "docker_image"),
+    ],
+)
+def test_native_tasks_reject_runtime_projection_bypasses(tmp_path: Path, environment_toml: str, message: str) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    native_task = target / "evals" / "harbor" / "case-001"
+    native_task.mkdir(parents=True)
+    (native_task / "task.toml").write_text(
+        'schema_version = "1.3"\n\n[task]\nname = "nvidia/case-001"\n\n'
+        '[metadata]\nentry_id = "case-001"\n\n[environment]\n' + environment_toml,
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match=message):
+        stage_native_harbor_tasks(target, tmp_path / "native-projection-bypass", grading_mode="custom_only")
+
+
+def test_native_tasks_pin_skills_dir_to_controlled_projection(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    native_task = target / "evals" / "harbor" / "case-001"
+    (native_task / "environment").mkdir(parents=True)
+    (native_task / "tests").mkdir()
+    (native_task / "task.toml").write_text(
+        'schema_version = "1.3"\n\n[task]\nname = "nvidia/case-001"\n\n'
+        '[metadata]\nentry_id = "case-001"\n\n[environment]\n',
+        encoding="utf-8",
+    )
+    (native_task / "environment" / "Dockerfile").write_text("FROM python:3.12-slim\n", encoding="utf-8")
+    (native_task / "tests" / "test.sh").write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+
+    staged = stage_native_harbor_tasks(
+        target,
+        tmp_path / "native-controlled-skills-dir",
+        grading_mode="custom_only",
+    )[0]
+
+    staged_toml = (staged / "task.toml").read_text(encoding="utf-8")
+    assert 'skills_dir = "/workspace/skills"' in staged_toml
+    assert '"BASH_ENV" = ""' in staged_toml
+    assert '"CLAUDE_CODE_DISABLE_POLICY_SKILLS" = "1"' in staged_toml
+
+
+@pytest.mark.parametrize("name", ["BASH_ENV", "BASH_FUNC_hidden%%"])
+def test_generated_tasks_reject_runtime_process_loader_environment(tmp_path: Path, name: str) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+
+    with pytest.raises(ValueError, match="process loader"):
+        generate_harbor_tasks(
+            target,
+            tmp_path / "runtime-loader-env",
+            runtime_env={name: "/runtime/seed.sh"},
+        )
+
+
+def test_native_baseline_rejects_aliased_authored_skill(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    native_task = target / "evals" / "harbor" / "case-001"
+    environment = native_task / "environment"
+    alias = environment / "skills" / "alias"
+    alias.mkdir(parents=True)
+    (alias / "SKILL.md").write_text((target / "SKILL.md").read_text(encoding="utf-8"), encoding="utf-8")
+    (native_task / "instruction.md").write_text("Run the native case.\n", encoding="utf-8")
+    (native_task / "task.toml").write_text(
+        'schema_version = "1.3"\n\n[task]\nname = "nvidia/case-001"\n\n'
+        '[metadata]\nentry_id = "case-001"\n\n[environment]\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="unmanaged skill"):
+        stage_native_harbor_tasks(target, tmp_path / "native-baseline-alias", with_skill=False)
+
+
+def test_native_baseline_rejects_renamed_target_manifest_payload(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    native_task = target / "evals" / "harbor" / "case-001"
+    environment = native_task / "environment"
+    environment.mkdir(parents=True)
+    (environment / "payload.txt").write_bytes((target / "SKILL.md").read_bytes())
+    (environment / "Dockerfile").write_text(
+        "FROM python:3.12-slim\nCOPY payload.txt /root/.agents/skills/alias/SKILL.md\n",
+        encoding="utf-8",
+    )
+    (native_task / "instruction.md").write_text("Run the native case.\n", encoding="utf-8")
+    (native_task / "task.toml").write_text(
+        'schema_version = "1.3"\n\n[task]\nname = "nvidia/case-001"\n\n'
+        '[metadata]\nentry_id = "case-001"\n\n[environment]\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="target skill instructions"):
+        stage_native_harbor_tasks(target, tmp_path / "native-renamed-payload", with_skill=False)
+
+
+@pytest.mark.parametrize("payload_kind", ["manifest", "renamed"])
+def test_native_baseline_ignores_target_payload_in_unstaged_results(tmp_path: Path, payload_kind: str) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    _write_minimal_native_task(target)
+    results = target / "evals" / "harbor" / "case-001" / "environment" / "results"
+    payload = (target / "SKILL.md").read_bytes()
+    if payload_kind == "manifest":
+        alias = results / "alias"
+        alias.mkdir(parents=True)
+        (alias / "SKILL.md").write_bytes(payload)
+    else:
+        results.mkdir(parents=True)
+        (results / "archived.txt").write_bytes(payload)
+
+    task = stage_native_harbor_tasks(
+        target,
+        tmp_path / f"native-ignored-results-{payload_kind}",
+        with_skill=False,
+    )[0]
+
+    assert not (task / "environment" / "results").exists()
+
+
+@pytest.mark.parametrize(
+    "copy_instruction",
+    [
+        "COPY input/missing.txt /workspace/input/missing.txt",
+        "COPY ../input/missing.txt /workspace/input/missing.txt",
+        'COPY ["../input/missing.txt", "/workspace/input/missing.txt"]',
+        "RUN --mount=type=bind,source=input/missing.txt,target=/payload true",
+    ],
+)
+def test_explicit_empty_rejects_specific_custom_docker_input_child(
+    tmp_path: Path,
+    copy_instruction: str,
+) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    (target / "evals" / "evals.json").write_text(
+        json.dumps([{"id": "case-001", "question": "No fixture.", "files": []}]),
+        encoding="utf-8",
+    )
+    (target / "evals" / "environment" / "Dockerfile").write_text(
+        f"FROM python:3.12-slim\n{copy_instruction}\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="specific input path"):
+        generate_harbor_tasks(target, tmp_path / "specific-empty-input")
+
+
+def test_explicit_empty_rejects_dynamic_custom_docker_input_source(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    (target / "evals" / "evals.json").write_text(
+        json.dumps([{"id": "case-001", "question": "No fixture.", "files": []}]),
+        encoding="utf-8",
+    )
+    (target / "evals" / "environment" / "Dockerfile").write_text(
+        "FROM python:3.12-slim\nCOPY ${SRC}/../input/ /workspace/input/\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="ambiguous input source"):
+        generate_harbor_tasks(target, tmp_path / "ambiguous-empty-input")
+
+
+def test_explicit_empty_rejects_unresolved_docker_parameter_expansion(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    (target / "evals" / "evals.json").write_text(
+        json.dumps([{"id": "case-001", "question": "No fixture.", "files": []}]),
+        encoding="utf-8",
+    )
+    (target / "evals" / "environment" / "Dockerfile").write_text(
+        "FROM python:3.12-slim\nARG INPUT_DIR\nCOPY ${INPUT_DIR:-input}/ /workspace/input/\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="ambiguous input source"):
+        generate_harbor_tasks(target, tmp_path / "parameter-expansion-empty-input")
+
+
+@pytest.mark.parametrize("declaration", ["ARG INPUT_DIR=input", "ENV INPUT_DIR=input"])
+def test_explicit_empty_resolves_static_dynamic_input_directory(tmp_path: Path, declaration: str) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    (target / "evals" / "evals.json").write_text(
+        json.dumps([{"id": "case-001", "question": "No fixture.", "files": []}]),
+        encoding="utf-8",
+    )
+    (target / "evals" / "environment" / "Dockerfile").write_text(
+        f"FROM python:3.12-slim\n{declaration}\nCOPY ${{INPUT_DIR}}/ /workspace/input/\n",
+        encoding="utf-8",
+    )
+
+    task = generate_harbor_tasks(target, tmp_path / "static-dynamic-empty-input")[0]
+
+    assert (task / "environment" / "input").is_dir()
+
+
+def test_explicit_empty_resolves_docker_variables_at_each_instruction(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    (target / "evals" / "evals.json").write_text(
+        json.dumps([{"id": "case-001", "question": "No fixture.", "files": []}]),
+        encoding="utf-8",
+    )
+    fixtures = target / "evals" / "environment" / "fixtures"
+    fixtures.mkdir()
+    (fixtures / "runtime.txt").write_text("runtime\n", encoding="utf-8")
+    (target / "evals" / "environment" / "Dockerfile").write_text(
+        "FROM python:3.12-slim AS first\n"
+        "ARG SRC=input\n"
+        "COPY ${SRC}/ /workspace/input/\n"
+        "FROM first AS final\n"
+        "ARG SRC=fixtures\n"
+        "COPY ${SRC}/ /app/\n",
+        encoding="utf-8",
+    )
+
+    task = generate_harbor_tasks(target, tmp_path / "instruction-scoped-dynamic-input")[0]
+
+    assert (task / "environment" / "input").is_dir()
+
+
+def test_explicit_empty_does_not_expose_global_arg_without_stage_redeclaration(tmp_path: Path) -> None:
+    dockerfile = tmp_path / "Dockerfile"
+    dockerfile.write_text(
+        "ARG SRC=input\nFROM python:3.12-slim\nCOPY ${SRC}/ /workspace/input/\n",
+        encoding="utf-8",
+    )
+
+    assert _dockerfile_resolved_build_context_sources(dockerfile) == [("${SRC}/", "${SRC}/", True)]
+
+
+def test_explicit_empty_inherits_arg_and_env_from_parent_stage(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    (target / "evals" / "evals.json").write_text(
+        json.dumps([{"id": "case-001", "question": "No fixture.", "files": []}]),
+        encoding="utf-8",
+    )
+    (target / "evals" / "environment" / "Dockerfile").write_text(
+        "FROM python:3.12-slim AS base\n"
+        "ARG ROOT=workspace\n"
+        "ENV SRC=input\n"
+        "FROM base AS final\n"
+        "COPY ${SRC}/ /${ROOT}/input/\n",
+        encoding="utf-8",
+    )
+
+    task = generate_harbor_tasks(target, tmp_path / "parent-stage-scope")
+
+    assert (task[0] / "environment" / "input").is_dir()
+
+
+def test_explicit_empty_uses_pre_instruction_env_snapshot(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    (target / "evals" / "evals.json").write_text(
+        json.dumps([{"id": "case-001", "question": "No fixture.", "files": []}]),
+        encoding="utf-8",
+    )
+    environment = target / "evals" / "environment"
+    fixtures = environment / "fixtures"
+    fixtures.mkdir()
+    (fixtures / "runtime.txt").write_text("runtime\n", encoding="utf-8")
+    (environment / "Dockerfile").write_text(
+        "FROM python:3.12-slim\nENV SRC=fixtures\nENV SRC=input COPY_ROOT=$SRC\nCOPY ${COPY_ROOT}/ /app/\n",
+        encoding="utf-8",
+    )
+
+    task = generate_harbor_tasks(target, tmp_path / "env-snapshot")
+
+    assert (task[0] / "environment" / "input").is_dir()
+    assert list((task[0] / "environment" / "input").iterdir()) == []
+
+
+def test_explicit_empty_does_not_retroactively_resolve_unknown_env(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    (target / "evals" / "evals.json").write_text(
+        json.dumps([{"id": "case-001", "question": "No fixture.", "files": []}]),
+        encoding="utf-8",
+    )
+    (target / "evals" / "environment" / "Dockerfile").write_text(
+        "FROM python:3.12-slim\nENV COPY_ROOT=$SRC\nENV SRC=input\nCOPY ${COPY_ROOT}/ /app/\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="ambiguous input source"):
+        generate_harbor_tasks(target, tmp_path / "unknown-env-snapshot")
+
+
+def test_explicit_empty_ignores_docker_heredoc_body_in_variable_scope(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    (target / "evals" / "evals.json").write_text(
+        json.dumps([{"id": "case-001", "question": "No fixture.", "files": []}]),
+        encoding="utf-8",
+    )
+    (target / "evals" / "environment" / "Dockerfile").write_text(
+        "FROM python:3.12-slim\n"
+        "ARG SRC=input\n"
+        "COPY <<EOF /fake-script\n"
+        "ARG SRC=fixtures\n"
+        "COPY fixtures/ /not-an-instruction/\n"
+        "EOF\n"
+        "COPY ${SRC}/ /workspace/input/\n",
+        encoding="utf-8",
+    )
+
+    task = generate_harbor_tasks(target, tmp_path / "heredoc-scope")
+
+    assert (task[0] / "environment" / "input").is_dir()
+
+
+def test_punctuation_heredoc_body_cannot_change_restored_runtime_user(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    environment = target / "evals" / "environment"
+    (environment / "Dockerfile").write_text(
+        "FROM python:3.12-slim\nCOPY <<'E!' /payload\nUSER 12345\nE!\n",
+        encoding="utf-8",
+    )
+
+    task = generate_harbor_tasks(target, tmp_path / "punctuation-heredoc-user")[0]
+
+    dockerfile = (task / "environment" / "Dockerfile").read_text(encoding="utf-8")
+    assert not dockerfile.rstrip().endswith("USER 12345")
+
+
+@pytest.mark.parametrize("source", ["'$SRC'/", r"\$SRC/", "$$SRC/"])
+def test_explicit_empty_rejects_literal_or_escaped_docker_dollar_source(tmp_path: Path, source: str) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    (target / "evals" / "evals.json").write_text(
+        json.dumps([{"id": "case-001", "question": "No fixture.", "files": []}]),
+        encoding="utf-8",
+    )
+    (target / "evals" / "environment" / "Dockerfile").write_text(
+        f"FROM python:3.12-slim\nARG SRC=input\nCOPY {source} /workspace/input/\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match=r"safely parse|ambiguous"):
+        generate_harbor_tasks(target, tmp_path / "literal-dollar-source")
+
+
+@pytest.mark.parametrize("declaration", ["ARG COPY_ROOT='$SRC'", "ENV COPY_ROOT='$SRC'", r"ENV COPY_ROOT=\$SRC"])
+def test_explicit_empty_rejects_literal_dollar_in_docker_variable_declaration(
+    tmp_path: Path,
+    declaration: str,
+) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    (target / "evals" / "evals.json").write_text(
+        json.dumps([{"id": "case-001", "question": "No fixture.", "files": []}]),
+        encoding="utf-8",
+    )
+    (target / "evals" / "environment" / "Dockerfile").write_text(
+        f"FROM python:3.12-slim\nARG SRC=input\n{declaration}\nCOPY ${{COPY_ROOT}}/ /workspace/input/\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match=r"quoted or escaped Dockerfile"):
+        generate_harbor_tasks(target, tmp_path / "literal-dollar-declaration")
+
+
+def test_explicit_empty_honors_deferred_onbuild_copy(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    (target / "evals" / "evals.json").write_text(
+        json.dumps([{"id": "case-001", "question": "No fixture.", "files": []}]),
+        encoding="utf-8",
+    )
+    (target / "evals" / "environment" / "Dockerfile").write_text(
+        "FROM python:3.12-slim AS base\n"
+        "ONBUILD COPY input/ /workspace/input/\n"
+        "FROM base AS final\n"
+        "RUN test -d /workspace/input\n",
+        encoding="utf-8",
+    )
+
+    task = generate_harbor_tasks(target, tmp_path / "onbuild-input")
+
+    assert (task[0] / "environment" / "input").is_dir()
+
+
+def test_quoted_shell_text_is_not_treated_as_docker_heredoc(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    (target / "evals" / "evals.json").write_text(
+        json.dumps([{"id": "case-001", "question": "No fixture.", "files": []}]),
+        encoding="utf-8",
+    )
+    (target / "evals" / "environment" / "Dockerfile").write_text(
+        "FROM python:3.12-slim\nRUN echo 'x <<EOF y'\nCOPY input/ /workspace/input/\n",
+        encoding="utf-8",
+    )
+
+    task = generate_harbor_tasks(target, tmp_path / "quoted-heredoc-text")
+
+    assert (task[0] / "environment" / "input").is_dir()
+
+
+def test_explicit_empty_reads_compose_yml_build_arg_override(tmp_path: Path) -> None:
+    environment = tmp_path / "environment"
+    environment.mkdir()
+    dockerfile = environment / "Dockerfile"
+    dockerfile.write_text(
+        "FROM python:3.12-slim\nARG SRC=fixtures\nCOPY ${SRC}/ /workspace/input/\n",
+        encoding="utf-8",
+    )
+    (environment / "docker-compose.yml").write_text(
+        "services:\n  main:\n    build:\n      context: .\n      args:\n        SRC: input\n",
+        encoding="utf-8",
+    )
+
+    _ensure_empty_custom_docker_input_compatibility(environment, dockerfile, has_input=False)
+
+    assert (environment / "input").is_dir()
+
+
+def test_explicit_empty_allows_broad_custom_docker_wildcard(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    (target / "evals" / "evals.json").write_text(
+        json.dumps([{"id": "case-001", "question": "No fixture.", "files": []}]),
+        encoding="utf-8",
+    )
+    (target / "evals" / "environment" / "app.txt").write_text("runtime asset\n", encoding="utf-8")
+    (target / "evals" / "environment" / "Dockerfile").write_text(
+        "FROM python:3.12-slim\nCOPY * /app/\n",
+        encoding="utf-8",
+    )
+
+    assert generate_harbor_tasks(target, tmp_path / "broad-wildcard")
+
+
+def test_explicit_empty_allows_unrelated_nested_input_glob(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    (target / "evals" / "evals.json").write_text(
+        json.dumps([{"id": "case-001", "question": "No fixture.", "files": []}]),
+        encoding="utf-8",
+    )
+    fixtures = target / "evals" / "environment" / "fixtures"
+    fixtures.mkdir()
+    (fixtures / "myinput-data.txt").write_text("runtime asset\n", encoding="utf-8")
+    (target / "evals" / "environment" / "Dockerfile").write_text(
+        "FROM python:3.12-slim\nCOPY fixtures/myinput*.txt /app/\n",
+        encoding="utf-8",
+    )
+
+    task = generate_harbor_tasks(target, tmp_path / "unrelated-input-glob")
+    assert task
+
+
+@pytest.mark.parametrize(
+    ("declaration", "source", "source_dir"),
+    [
+        ("ARG APP_DIR=fixtures", "${APP_DIR}/", "fixtures"),
+        ("ARG ARCH=amd64", "fixtures/${ARCH}/", "fixtures/amd64"),
+    ],
+)
+def test_explicit_empty_allows_unrelated_dynamic_custom_docker_source(
+    tmp_path: Path,
+    declaration: str,
+    source: str,
+    source_dir: str,
+) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    (target / "evals" / "evals.json").write_text(
+        json.dumps([{"id": "case-001", "question": "No fixture.", "files": []}]),
+        encoding="utf-8",
+    )
+    runtime_source = target / "evals" / "environment" / source_dir
+    runtime_source.mkdir(parents=True)
+    (runtime_source / "runtime.txt").write_text("runtime asset\n", encoding="utf-8")
+    (target / "evals" / "environment" / "Dockerfile").write_text(
+        f"FROM python:3.12-slim\n{declaration}\nCOPY {source} /app/\n",
+        encoding="utf-8",
+    )
+
+    assert generate_harbor_tasks(target, tmp_path / "unrelated-dynamic-source")
+
+
+@pytest.mark.parametrize("escape_char", ["\\", "`"])
+def test_explicit_empty_honors_custom_docker_escape_directive(tmp_path: Path, escape_char: str) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    (target / "evals" / "evals.json").write_text(
+        json.dumps([{"id": "case-001", "question": "No fixture.", "files": []}]),
+        encoding="utf-8",
+    )
+    (target / "evals" / "environment" / "Dockerfile").write_text(
+        f"# escape={escape_char}\n"
+        "FROM python:3.12-slim\n"
+        f"COPY {escape_char}\n"
+        f"  input/ {escape_char}\n"
+        "  /workspace/input/\n",
+        encoding="utf-8",
+    )
+
+    task = generate_harbor_tasks(target, tmp_path / f"escape-{ord(escape_char)}")[0]
+
+    assert (task / "environment" / "input").is_dir()
+
+
+def _write_explicit_empty_entry(target: Path) -> None:
+    (target / "evals" / "evals.json").write_text(
+        json.dumps([{"id": "case-001", "question": "No fixture.", "files": []}]),
+        encoding="utf-8",
+    )
+
+
+def test_explicit_empty_materializes_compose_additional_input_context(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    _write_explicit_empty_entry(target)
+    environment = target / "evals" / "environment"
+    (environment / "Dockerfile").write_text("FROM python:3.12-slim\n", encoding="utf-8")
+    (environment / "docker-compose.yaml").write_text(
+        "services:\n"
+        "  helper:\n"
+        "    build:\n"
+        "      context: .\n"
+        "      dockerfile_inline: |\n"
+        "        FROM scratch\n"
+        "        COPY --from=taskinput . /payload/\n"
+        "      additional_contexts:\n"
+        "        taskinput: input\n",
+        encoding="utf-8",
+    )
+
+    task = generate_harbor_tasks(target, tmp_path / "compose-additional-input")[0]
+
+    assert (task / "environment" / "input").is_dir()
+    assert list((task / "environment" / "input").iterdir()) == []
+
+
+def test_explicit_empty_materializes_compose_primary_input_context(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    _write_explicit_empty_entry(target)
+    environment = target / "evals" / "environment"
+    (environment / "Dockerfile").write_text("FROM python:3.12-slim\n", encoding="utf-8")
+    (environment / "docker-compose.yaml").write_text(
+        "services:\n"
+        "  helper:\n"
+        "    build:\n"
+        "      context: input\n"
+        "      dockerfile_inline: |\n"
+        "        FROM scratch\n"
+        "        COPY . /payload/\n",
+        encoding="utf-8",
+    )
+
+    task = generate_harbor_tasks(target, tmp_path / "compose-primary-input")[0]
+
+    assert (task / "environment" / "input").is_dir()
+    assert list((task / "environment" / "input").iterdir()) == []
+
+
+def test_explicit_empty_rejects_specific_source_from_compose_primary_input_context(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    _write_explicit_empty_entry(target)
+    environment = target / "evals" / "environment"
+    (environment / "Dockerfile").write_text("FROM python:3.12-slim\n", encoding="utf-8")
+    (environment / "docker-compose.yaml").write_text(
+        "services:\n"
+        "  helper:\n"
+        "    build:\n"
+        "      context: input\n"
+        "      dockerfile_inline: |\n"
+        "        FROM scratch\n"
+        "        COPY missing.txt /payload/\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="specific path from the input build context"):
+        generate_harbor_tasks(target, tmp_path / "compose-primary-specific-source")
+
+
+@pytest.mark.parametrize(
+    "instruction",
+    [
+        "COPY --from=taskinput missing.txt /payload/",
+        "RUN --mount=type=bind,from=taskinput,source=missing.txt,target=/payload true",
+    ],
+)
+def test_explicit_empty_rejects_specific_source_from_named_input_context(
+    tmp_path: Path,
+    instruction: str,
+) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    _write_explicit_empty_entry(target)
+    environment = target / "evals" / "environment"
+    (environment / "Dockerfile").write_text("FROM python:3.12-slim\n", encoding="utf-8")
+    (environment / "docker-compose.yaml").write_text(
+        "services:\n"
+        "  helper:\n"
+        "    build:\n"
+        "      context: .\n"
+        "      dockerfile_inline: |\n"
+        "        FROM scratch\n"
+        f"        {instruction}\n"
+        "      additional_contexts:\n"
+        "        taskinput: input\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="specific path from an input context"):
+        generate_harbor_tasks(target, tmp_path / "compose-named-specific-source")
+
+
+def test_explicit_empty_resolves_compose_escaped_inline_arg(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    _write_explicit_empty_entry(target)
+    environment = target / "evals" / "environment"
+    (environment / "Dockerfile").write_text("FROM python:3.12-slim\n", encoding="utf-8")
+    (environment / "docker-compose.yaml").write_text(
+        "services:\n"
+        "  helper:\n"
+        "    build:\n"
+        "      context: .\n"
+        "      args:\n"
+        "        SRC: input\n"
+        "      dockerfile_inline: |\n"
+        "        FROM scratch\n"
+        "        ARG SRC\n"
+        "        COPY $${SRC}/ /payload/\n",
+        encoding="utf-8",
+    )
+
+    task = generate_harbor_tasks(target, tmp_path / "compose-inline-arg")[0]
+
+    assert (task / "environment" / "input").is_dir()
+
+
+def test_explicit_empty_rejects_specific_compose_input_context(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    _write_explicit_empty_entry(target)
+    environment = target / "evals" / "environment"
+    (environment / "Dockerfile").write_text("FROM python:3.12-slim\n", encoding="utf-8")
+    (environment / "docker-compose.yaml").write_text(
+        "services:\n"
+        "  helper:\n"
+        "    build:\n"
+        "      context: .\n"
+        "      dockerfile_inline: 'FROM scratch'\n"
+        "      additional_contexts:\n"
+        "        taskinput: input/missing\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="specific input context"):
+        generate_harbor_tasks(target, tmp_path / "compose-specific-input")
+
+
+def test_compose_rejects_build_with_global_image_tag(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    environment = target / "evals" / "environment"
+    (environment / "Dockerfile").write_text("FROM python:3.12-slim\n", encoding="utf-8")
+    (environment / "docker-compose.yaml").write_text(
+        "services:\n  helper:\n    image: trusted-global-name:latest\n    build:\n      context: sidecar\n",
+        encoding="utf-8",
+    )
+    (environment / "sidecar" / "Dockerfile").write_text("FROM scratch\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="image together with build"):
+        generate_harbor_tasks(target, tmp_path / "compose-image-poisoning")
+
+
+def test_compose_rejects_non_string_mapping_keys(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    environment = target / "evals" / "environment"
+    (environment / "Dockerfile").write_text("FROM python:3.12-slim\n", encoding="utf-8")
+    (environment / "docker-compose.yaml").write_text(
+        "1: unsafe\nservices:\n  helper:\n    image: alpine:3.20\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="keys must be strings"):
+        generate_harbor_tasks(target, tmp_path / "compose-non-string-key")
+
+
+def test_rebase_accepts_tab_from_and_preserves_alias_and_runtime_user(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    environment = target / "evals" / "environment"
+    (environment / "Dockerfile").write_text(
+        "FROM\tpython:3.12-slim AS app\nUSER 12345\n",
+        encoding="utf-8",
+    )
+
+    task = generate_harbor_tasks(
+        target,
+        tmp_path / "rebase-tab-from",
+        base_image="skillevaluator-base:test",
+        custom_dockerfile_mode="rebase",
+    )[0]
+
+    dockerfile = (task / "environment" / "Dockerfile").read_text(encoding="utf-8")
+    assert dockerfile.startswith("FROM\tskillevaluator-base:test AS app\n")
+    assert dockerfile.rstrip().endswith("USER 12345")
+
+
+def test_rebase_rejects_multi_stage_dockerfile(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    (target / "evals" / "environment" / "Dockerfile").write_text(
+        "FROM python:3.12-slim AS build\nFROM build AS final\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="exactly one FROM"):
+        generate_harbor_tasks(
+            target,
+            tmp_path / "rebase-multi-stage",
+            base_image="skillevaluator-base:test",
+            custom_dockerfile_mode="rebase",
+        )
+
+
+def test_rebase_rejects_continued_from_instruction(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    (target / "evals" / "environment" / "Dockerfile").write_text(
+        "FROM \\\n  python:3.12-slim\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="continued FROM"):
+        generate_harbor_tasks(
+            target,
+            tmp_path / "rebase-continued-from",
+            base_image="skillevaluator-base:test",
+            custom_dockerfile_mode="rebase",
+        )
+
+
+def test_custom_projection_uses_exec_runs_and_ignores_comment_decoys(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    environment = target / "evals" / "environment"
+    (environment / "Dockerfile").write_text(
+        "FROM python:3.12-slim\n"
+        'SHELL ["python", "-c"]\n'
+        "# ragas langchain anthropic\n"
+        "# COPY skills/ /root/.agents/skills/\n"
+        "# RUN rm -rf /workspace/input && mkdir -p /workspace/input\n"
+        "USER 12345\n",
+        encoding="utf-8",
+    )
+
+    task = generate_harbor_tasks(target, tmp_path / "custom-exec-projection")[0]
+
+    dockerfile = (task / "environment" / "Dockerfile").read_text(encoding="utf-8")
+    assert 'RUN ["/bin/sh", "-c"' in dockerfile
+    assert '"python", "-m", "pip", "install"' in dockerfile
+    assert 'RUN ["/bin/rm", "-rf", "/workspace/input"]' in dockerfile
+    assert dockerfile.rstrip().endswith("USER 12345")
+
+
+def test_preserve_projection_restores_user_inherited_from_authored_stage(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    environment = target / "evals" / "environment"
+    (environment / "Dockerfile").write_text(
+        "FROM python:3.12-slim AS base\nUSER 12345\nFROM base AS final\n",
+        encoding="utf-8",
+    )
+
+    task = generate_harbor_tasks(target, tmp_path / "inherited-user-projection")[0]
+
+    dockerfile = (task / "environment" / "Dockerfile").read_text(encoding="utf-8")
+    assert "USER root\n" in dockerfile
+    assert dockerfile.rstrip().endswith("USER 12345")
+
+
+def test_managed_projection_survives_authored_path_override(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    environment = target / "evals" / "environment"
+    (environment / "Dockerfile").write_text(
+        "FROM python:3.12-slim\nENV PATH=/custom\n",
+        encoding="utf-8",
+    )
+
+    task = generate_harbor_tasks(target, tmp_path / "managed-path-projection")[0]
+
+    dockerfile = (task / "environment" / "Dockerfile").read_text(encoding="utf-8")
+    assert 'PATH=\\"${PATH:+$PATH:}/usr/local/bin:/usr/bin:/bin\\"' in dockerfile
+    assert 'RUN ["/bin/rm", "-rf", "/workspace/input"]' in dockerfile
+
+
+def test_verifier_constraint_and_skill_requirements_share_resolver_transaction(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    (target / "scripts" / "requirements.txt").write_text(
+        "langchain-community>=0.4.2\n",
+        encoding="utf-8",
+    )
+
+    task = generate_harbor_tasks(target, tmp_path / "verifier-requirement-conflict")[0]
+
+    dockerfile = (task / "environment" / "Dockerfile").read_text(encoding="utf-8")
+    install_line = next(line for line in dockerfile.splitlines() if '"pip", "install"' in line)
+    assert "langchain-community<0.4.2" in install_line
+    assert "langchain-community>=0.4.2" in install_line
+    assert dockerfile.count('"pip", "install"') == 1
+    assert "from ragas.llms.base import llm_factory" in dockerfile
+
+
+def test_rebase_reasserts_verifier_constraint_after_authored_dependencies(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    environment = target / "evals" / "environment"
+    (environment / "Dockerfile").write_text(
+        "FROM python:3.12-slim\nRUN python -m pip install 'langchain-community>=0.4.2'\n",
+        encoding="utf-8",
+    )
+
+    task = generate_harbor_tasks(
+        target,
+        tmp_path / "rebase-verifier-constraint",
+        base_image="skillevaluator-base:test",
+        custom_dockerfile_mode="rebase",
+    )[0]
+
+    dockerfile = (task / "environment" / "Dockerfile").read_text(encoding="utf-8")
+    assert dockerfile.rfind("langchain-community<0.4.2") > dockerfile.find("langchain-community>=0.4.2")
+    assert dockerfile.rfind("from ragas.llms.base import llm_factory") > dockerfile.find("langchain-community>=0.4.2")
+
+
+def test_baseline_rejects_target_manifest_payload_with_appended_comment(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    environment = target / "evals" / "environment"
+    payload = (target / "SKILL.md").read_text(encoding="utf-8") + "\n# harmless comment\n"
+    (environment / "payload.txt").write_text(payload, encoding="utf-8")
+    (environment / "Dockerfile").write_text(
+        "FROM python:3.12-slim\nCOPY payload.txt /root/.agents/skills/alias/SKILL.md\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="target skill instructions"):
+        generate_harbor_tasks(target, tmp_path / "baseline-appended-payload", with_skill=False)
+
+
+def test_linked_repo_projection_rejects_reserved_workspace_input(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "SKILLEVALUATOR_OUTPUT_PROVENANCE_KEY_FILE",
+        str(tmp_path.parent / f"{tmp_path.name}-state" / "output-provenance.key"),
+    )
+    repo, target, _, _ = _write_projection_fixture(tmp_path)
+    (tmp_path / ".git").mkdir()
+    outside_input = tmp_path / "input"
+    outside_input.mkdir()
+    (outside_input / "hidden.txt").write_text("RESERVED-INPUT-ORACLE\n", encoding="utf-8")
+    manifest = target / "SKILL.md"
+    manifest.write_text(
+        manifest.read_text(encoding="utf-8") + "\n[hidden](../../input/hidden.txt)\n",
+        encoding="utf-8",
+    )
+    assert repo.is_dir()
+
+    with pytest.raises(ValueError, match="reserved runtime path '/workspace/input'"):
+        generate_harbor_tasks(target, tmp_path / "reserved-linked-input", copy_repo=False)
+
+
+@pytest.mark.parametrize(
+    ("linked_path", "linked_target"),
+    [
+        ("skills/target-skill/SKILL.md", "../../skills/target-skill/SKILL.md"),
+        (".claude/skills/hidden/SKILL.md", "../../.claude/skills/hidden/SKILL.md"),
+    ],
+)
+def test_linked_repo_cannot_overlay_agent_discovery_roots(
+    tmp_path: Path,
+    linked_path: str,
+    linked_target: str,
+) -> None:
+    repo, original_target, references, workspace = _write_projection_fixture(tmp_path)
+    target = repo / "packages" / original_target.name
+    target.parent.mkdir()
+    shutil.move(original_target, target)
+    (repo / ".git").mkdir()
+    hidden_manifest = repo / linked_path
+    hidden_manifest.parent.mkdir(parents=True, exist_ok=True)
+    hidden_manifest.write_text("HIDDEN-DISCOVERY-ORACLE\n", encoding="utf-8")
+    manifest = target / "SKILL.md"
+    manifest.write_text(
+        manifest.read_text(encoding="utf-8") + f"\n[hidden]({linked_target})\n",
+        encoding="utf-8",
+    )
+
+    task = generate_harbor_tasks(
+        target,
+        tmp_path / f"linked-discovery-{hidden_manifest.parent.name}",
+        reference_skills_dir=references,
+        workspace_skill_paths=[workspace],
+        copy_repo=False,
+    )[0]
+
+    linked_root = task / "environment" / "repo-linked-root"
+    staged_text = (
+        "\n".join(
+            path.read_text(encoding="utf-8", errors="ignore") for path in linked_root.rglob("*") if path.is_file()
+        )
+        if linked_root.exists()
+        else ""
+    )
+    assert "HIDDEN-DISCOVERY-ORACLE" not in staged_text
+
+
+@pytest.mark.skipif(os.name != "nt", reason="requires Windows junctions")
+@pytest.mark.parametrize("location", ["runtime", "input"])
+def test_windows_junction_sources_are_rejected(tmp_path: Path, location: str) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    outside = tmp_path / "outside-junction"
+    outside.mkdir()
+    (outside / "hidden.txt").write_text("JUNCTION-ORACLE\n", encoding="utf-8")
+    if location == "runtime":
+        junction = target / "references" / "junction"
+    else:
+        junction = target / "evals" / "files" / "junction"
+        (target / "evals" / "evals.json").write_text(
+            json.dumps([{"id": "case-001", "question": "No explicit files."}]),
+            encoding="utf-8",
+        )
+    subprocess.run(
+        ["cmd", "/c", "mklink", "/J", str(junction), str(outside)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    with pytest.raises(ValueError, match=r"symlink|reparse|junction"):
+        generate_harbor_tasks(target, tmp_path / f"windows-junction-{location}")
+
+
+@pytest.mark.parametrize("kind", ["symlink", "hardlink", "fifo"])
+def test_eval_dataset_file_must_be_regular_and_unlinked(tmp_path: Path, kind: str) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    dataset = target / "evals" / "evals.json"
+    dataset.unlink()
+    outside = tmp_path / "outside-evals.json"
+    outside.write_text('[{"id":"case-001","question":"ORACLE"}]\n', encoding="utf-8")
+    try:
+        if kind == "symlink":
+            dataset.symlink_to(outside)
+        elif kind == "hardlink":
+            dataset.hardlink_to(outside)
+        elif hasattr(os, "mkfifo"):
+            os.mkfifo(dataset)
+        else:
+            pytest.skip("FIFO creation is unavailable")
+    except OSError as exc:
+        pytest.skip(f"{kind} creation is unavailable: {exc}")
+
+    with pytest.raises(ValueError, match="regular non-linked file"):
+        generate_harbor_tasks(target, tmp_path / f"unsafe-dataset-{kind}")

--- a/tests/test_harbor_runtime_skill_isolation.py
+++ b/tests/test_harbor_runtime_skill_isolation.py
@@ -440,6 +440,40 @@ def test_copy_repo_excludes_configured_in_repo_output_root(tmp_path: Path) -> No
     assert not (task / "environment" / "repo" / output_dir.name).exists()
 
 
+@pytest.mark.parametrize("stager", ["generated", "native"])
+def test_copy_repo_excludes_private_in_repo_staging_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    stager: str,
+) -> None:
+    repo, target, references_dir, workspace = _write_projection_fixture(tmp_path)
+    private_canary = "PRIVATE-STAGING-CANARY"
+    entries = json.loads((target / "evals" / "evals.json").read_text(encoding="utf-8"))
+    entries[0]["ground_truth"] = private_canary
+    (target / "evals" / "evals.json").write_text(json.dumps(entries), encoding="utf-8")
+    if stager == "native":
+        _write_minimal_native_task(target)
+    in_repo_temp_root = repo / "tmp"
+    in_repo_temp_root.mkdir()
+    monkeypatch.setattr(tempfile, "tempdir", os.fspath(in_repo_temp_root))
+    stager_fn = generate_harbor_tasks if stager == "generated" else stage_native_harbor_tasks
+
+    task = stager_fn(
+        target,
+        tmp_path / f"{stager}-private-root",
+        reference_skills_dir=references_dir,
+        workspace_skill_paths=[workspace],
+        copy_repo=True,
+    )[0]
+
+    environment = task / "environment"
+    readable_environment = "\n".join(
+        path.read_text(encoding="utf-8", errors="ignore") for path in environment.rglob("*") if path.is_file()
+    )
+    assert private_canary not in readable_environment
+    assert not (environment / "repo" / in_repo_temp_root.relative_to(repo)).exists()
+
+
 def test_runtime_skill_projection_excludes_shared_in_skill_output_root(tmp_path: Path) -> None:
     _, target, references_dir, workspace = _write_projection_fixture(tmp_path)
     output_root = target / "Custom-Results"
@@ -1254,6 +1288,49 @@ def test_linked_repo_context_excludes_skill_evals_but_keeps_unrelated_evals(tmp_
     assert (staged_repo / "docs" / "evals" / "keep.txt").is_file()
 
 
+@pytest.mark.parametrize("stager", ["generated", "native"])
+def test_linked_repo_context_prunes_excluded_artifacts_before_resolving(
+    tmp_path: Path,
+    stager: str,
+) -> None:
+    repo, target, references_dir, workspace = _write_projection_fixture(tmp_path)
+    excluded = repo / "custom-results"
+    excluded.mkdir()
+    try:
+        (excluded / "loop").symlink_to("loop")
+        (excluded / "dangling").symlink_to("missing")
+    except OSError as exc:  # pragma: no cover - host policy, primarily native Windows
+        pytest.skip(f"symlinks unavailable on this host: {exc}")
+    if hasattr(os, "mkfifo"):
+        os.mkfifo(excluded / "artifact.fifo")
+    unreadable = excluded / "unreadable.txt"
+    unreadable.write_text("private", encoding="utf-8")
+    unreadable.chmod(0)
+    links = "\n".join(
+        f"[{name}](../custom-results/{name})" for name in ("loop", "dangling", "artifact.fifo", "unreadable.txt")
+    )
+    (target / "SKILL.md").write_text(f"# Target\n\n{links}\n", encoding="utf-8")
+    if stager == "native":
+        _write_minimal_native_task(target)
+        stage = stage_native_harbor_tasks
+    else:
+        stage = generate_harbor_tasks
+
+    try:
+        task = stage(
+            target,
+            tmp_path / f"{stager}-linked-excluded",
+            reference_skills_dir=references_dir,
+            workspace_skill_paths=[workspace],
+            copy_repo=False,
+            repo_context_exclude_paths=(excluded,),
+        )[0]
+    finally:
+        unreadable.chmod(0o600)
+
+    assert not (task / "environment" / "repo" / excluded.relative_to(repo)).exists()
+
+
 @pytest.mark.parametrize("files_value", [[], ["evals/files/selected.txt"]])
 @pytest.mark.parametrize("source", ["INPUT/", "Input/fixture.txt"])
 def test_custom_dockerfile_rejects_noncanonical_input_case(
@@ -1566,6 +1643,10 @@ def test_generated_tasks_reject_unsafe_agent_workdir(tmp_path: Path, agent_workd
         "/workspace/input/subdir",
         "/workspace/repo/subdir",
         "/workspace/skills",
+        "/workspace/.gemini/extensions/nested",
+        "/etc/codex/skills/nested",
+        "/logs/agent/sessions/skills/nested",
+        "/opt/project/.claude/commands/hidden",
         "/opt/project/.claude/skills/hidden",
         "/opt/project/.cline/skills/hidden",
         "/opt/project/.config/goose/skills/hidden",

--- a/tests/test_harbor_runtime_skill_isolation.py
+++ b/tests/test_harbor_runtime_skill_isolation.py
@@ -8,10 +8,12 @@ from __future__ import annotations
 import json
 import os
 import shutil
+import stat
 import subprocess
 import sys
 import tempfile
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -722,15 +724,21 @@ def test_prebuild_uses_each_tasks_exact_environment(
     assert task_tags["case-a"] != task_tags["case-b"]
 
     first_build_tags = {path.parent.name: tag for tag, path in build_calls}
-    (dataset / "case-a" / "environment" / "input" / "fixture.txt").chmod(0o755)
-    for task in dataset.iterdir():
-        (task / "task.toml").write_text("[environment]\n", encoding="utf-8")
-    build_calls.clear()
+    fixture_path = dataset / "case-a" / "environment" / "input" / "fixture.txt"
+    original_mode = stat.S_IMODE(fixture_path.stat().st_mode)
+    changed_mode = original_mode & ~stat.S_IWRITE if os.name == "nt" else original_mode | stat.S_IXUSR
+    try:
+        fixture_path.chmod(changed_mode)
+        for task in dataset.iterdir():
+            (task / "task.toml").write_text("[environment]\n", encoding="utf-8")
+        build_calls.clear()
 
-    assert prebuild_task_environments([dataset]) == 2
-    second_build_tags = {path.parent.name: tag for tag, path in build_calls}
-    assert second_build_tags["case-a"] != first_build_tags["case-a"]
-    assert second_build_tags["case-b"] == first_build_tags["case-b"]
+        assert prebuild_task_environments([dataset]) == 2
+        second_build_tags = {path.parent.name: tag for tag, path in build_calls}
+        assert second_build_tags["case-a"] != first_build_tags["case-a"]
+        assert second_build_tags["case-b"] == first_build_tags["case-b"]
+    finally:
+        fixture_path.chmod(original_mode)
 
 
 def test_prebuild_skips_task_with_compose_build_override(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -3039,6 +3047,193 @@ def test_selective_evaluator_snapshot_rejects_fixture_selection_change_during_co
         pass
 
     assert mutated
+
+
+@pytest.mark.parametrize(
+    ("task_source", "selected_relative"),
+    [
+        ("evals_json", Path("files/selected.txt")),
+        ("evals_json", Path("grader.py")),
+        ("evals_json", Path("environment/sidecar/seed.txt")),
+        ("native_harbor", Path("harbor/case-001/instruction.md")),
+    ],
+)
+def test_selective_evaluator_snapshot_rejects_selected_content_change_during_copy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    task_source: str,
+    selected_relative: Path,
+) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    if task_source == "native_harbor":
+        _write_minimal_native_task(target)
+    selected_path = target / "evals" / selected_relative
+    original_copytree = adapter_module.copytree_secure
+    mutated = False
+
+    def mutate_content_then_copy(source: Path, destination: Path, *args: object, **kwargs: object) -> None:
+        nonlocal mutated
+        if Path(source) == target / "evals" and not mutated:
+            selected_path.write_text(selected_path.read_text(encoding="utf-8") + "MUTATED\n", encoding="utf-8")
+            mutated = True
+        original_copytree(source, destination, *args, **kwargs)
+
+    monkeypatch.setattr(adapter_module, "copytree_secure", mutate_content_then_copy)
+
+    with (
+        pytest.raises(ValueError, match="selection changed"),
+        private_evaluator_skill_snapshot(target, task_source=task_source),
+    ):
+        pass
+
+    assert mutated
+
+
+@pytest.mark.skipif(os.name != "posix", reason="requires POSIX executable mode semantics")
+def test_selective_evaluator_snapshot_rejects_selected_mode_change_during_copy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    script = target / "evals" / "environment" / "run.sh"
+    script.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    script.chmod(0o644)
+    original_copytree = adapter_module.copytree_secure
+    mutated = False
+
+    def mutate_mode_then_copy(source: Path, destination: Path, *args: object, **kwargs: object) -> None:
+        nonlocal mutated
+        if Path(source) == target / "evals" and not mutated:
+            script.chmod(0o755)
+            mutated = True
+        original_copytree(source, destination, *args, **kwargs)
+
+    monkeypatch.setattr(adapter_module, "copytree_secure", mutate_mode_then_copy)
+
+    with (
+        pytest.raises(ValueError, match="selection changed"),
+        private_evaluator_skill_snapshot(target, task_source="evals_json"),
+    ):
+        pass
+
+    assert mutated
+
+
+def test_evaluator_read_accepts_windows_crt_descriptor_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    evals = tmp_path / "evals"
+    evals.mkdir()
+    dataset = evals / "evals.json"
+    dataset.write_text("[]\n", encoding="utf-8")
+    original_read_bytes = adapter_module.SecureRoot.read_bytes
+
+    def read_with_windows_crt_identity(
+        secure_root: adapter_module.SecureRoot,
+        relative_path: Path,
+        max_bytes: int,
+        *,
+        expected: os.stat_result | None = None,
+    ) -> tuple[bytes, object]:
+        raw, opened = original_read_bytes(secure_root, relative_path, max_bytes, expected=expected)
+        return raw, SimpleNamespace(
+            st_dev=opened.st_dev + 10_000,
+            st_ino=opened.st_ino + 10_000,
+            st_mode=opened.st_mode,
+            st_nlink=opened.st_nlink,
+            st_size=opened.st_size,
+            st_mtime_ns=opened.st_mtime_ns,
+            st_ctime_ns=opened.st_ctime_ns,
+        )
+
+    monkeypatch.setattr(adapter_module, "_PATH_DESCRIPTOR_IDENTITIES_COMPARABLE", False, raising=False)
+    monkeypatch.setattr(adapter_module.SecureRoot, "read_bytes", read_with_windows_crt_identity)
+
+    assert adapter_module._read_regular_evals_file(dataset, allowed_root=evals) == b"[]\n"
+
+
+@pytest.mark.parametrize("task_source", ["evals_json", "native_harbor"])
+def test_baseline_alias_candidates_are_scanned_once_per_multi_case_staging(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    task_source: str,
+) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    entries = [
+        {
+            "id": f"case-{index:03d}",
+            "question": f"Run case {index}.",
+            "files": ["evals/files/selected.txt"],
+        }
+        for index in range(1, 4)
+    ]
+    (target / "evals" / "evals.json").write_text(json.dumps(entries), encoding="utf-8")
+    if task_source == "native_harbor":
+        for entry in entries:
+            native_task = target / "evals" / "harbor" / entry["id"]
+            native_task.mkdir(parents=True)
+            (native_task / "instruction.md").write_text("Run the native case.\n", encoding="utf-8")
+            (native_task / "task.toml").write_text(
+                'schema_version = "1.3"\n\n[task]\n'
+                f'name = "nvidia/{entry["id"]}"\n\n'
+                f'[metadata]\nentry_id = "{entry["id"]}"\n\n[environment]\n',
+                encoding="utf-8",
+            )
+
+    scans = 0
+
+    def count_scan(*args: object, **kwargs: object) -> None:
+        nonlocal scans
+        scans += 1
+
+    monkeypatch.setattr(adapter_module, "_check_baseline_skill_candidates_do_not_alias_target", count_scan)
+    stager = generate_harbor_tasks if task_source == "evals_json" else stage_native_harbor_tasks
+
+    tasks = stager(target, tmp_path / f"{task_source}-scan-count", with_skill=False)
+
+    assert len(tasks) == 3
+    assert scans == 1
+
+
+def test_run_scoped_baseline_alias_validation_skips_rescan_and_is_path_bound(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, target, references_dir, workspace = _write_projection_fixture(tmp_path)
+    excluded_root = target / "evals" / "results"
+    validation = adapter_module._prevalidate_baseline_skill_candidates(
+        target,
+        references_dir,
+        [workspace],
+        excluded_roots=(excluded_root,),
+    )
+
+    def reject_rescan(*args: object, **kwargs: object) -> None:
+        raise AssertionError("run-scoped validation should suppress repeated source scans")
+
+    monkeypatch.setattr(adapter_module, "_check_baseline_skill_candidates_do_not_alias_target", reject_rescan)
+    tasks = generate_harbor_tasks(
+        target,
+        tmp_path / "validated-baseline",
+        with_skill=False,
+        reference_skills_dir=references_dir,
+        workspace_skill_paths=[workspace],
+        repo_context_exclude_paths=(excluded_root,),
+        _baseline_alias_validation=validation,
+    )
+
+    assert len(tasks) == 1
+    with pytest.raises(ValueError, match="does not match"):
+        generate_harbor_tasks(
+            target,
+            tmp_path / "mismatched-validation",
+            with_skill=False,
+            reference_skills_dir=references_dir,
+            workspace_skill_paths=[],
+            repo_context_exclude_paths=(excluded_root,),
+            _baseline_alias_validation=validation,
+        )
 
 
 def test_in_repo_temp_evaluator_snapshot_is_excluded_from_copy_repo(

--- a/tests/test_harbor_runtime_skill_isolation.py
+++ b/tests/test_harbor_runtime_skill_isolation.py
@@ -9,6 +9,8 @@ import json
 import os
 import shutil
 import subprocess
+import sys
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -880,6 +882,117 @@ def test_marked_prior_run_does_not_block_declared_results_root(tmp_path: Path) -
     validate_results_root_location(target, results_root)
 
 
+@pytest.mark.parametrize("copy_repo", [False, True])
+@pytest.mark.parametrize("stager_name", ["generated", "native"])
+def test_rotated_generated_output_is_excluded_from_runtime_skill_and_repo(
+    tmp_path: Path,
+    copy_repo: bool,
+    stager_name: str,
+) -> None:
+    repo, target, _, _ = _write_projection_fixture(tmp_path)
+    (target / "evals" / "files" / "selected.txt").write_text("OLD-CASE-SECRET\n", encoding="utf-8")
+    old_output_root = target / "archived-output"
+    old_dataset = old_output_root / "dataset"
+    generate_harbor_tasks(
+        target,
+        old_dataset,
+        repo_context_exclude_paths=(old_output_root,),
+    )
+    assert (old_dataset / "case-001" / "environment" / "input" / "selected.txt").is_file()
+    older_output_root = target / "older-output"
+    older_dataset = older_output_root / "dataset"
+    generate_harbor_tasks(
+        target,
+        older_dataset,
+        repo_context_exclude_paths=(older_output_root,),
+    )
+
+    (target / "evals" / "evals.json").write_text(
+        json.dumps([{"id": "case-001", "question": "Do not use old fixtures.", "files": []}]),
+        encoding="utf-8",
+    )
+    if stager_name == "native":
+        _write_minimal_native_task(target)
+        stager = stage_native_harbor_tasks
+    else:
+        stager = generate_harbor_tasks
+
+    task = stager(target, tmp_path / f"current-{stager_name}-{copy_repo}", copy_repo=copy_repo)[0]
+    environment = task / "environment"
+    for copied_relative in (Path("archived-output") / "dataset", Path("older-output") / "dataset"):
+        assert not (environment / "skills" / target.name / copied_relative).exists()
+        if copy_repo:
+            assert not (environment / "repo" / target.relative_to(repo) / copied_relative).exists()
+    readable = "\n".join(
+        path.read_text(encoding="utf-8", errors="ignore") for path in environment.rglob("*") if path.is_file()
+    )
+    assert "OLD-CASE-SECRET" not in readable
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="requires the macOS /var root alias")
+def test_rotated_output_is_excluded_through_macos_platform_root_alias() -> None:
+    with tempfile.TemporaryDirectory(prefix="issue29-platform-alias-") as temporary:
+        root = Path(temporary)
+        if root.absolute() == root.resolve():
+            pytest.skip("temporary directory does not use a platform root alias")
+        _, target, _, _ = _write_projection_fixture(root)
+        selected = target / "evals" / "files" / "selected.txt"
+        selected.write_text("PLATFORM-ALIAS-SECRET\n", encoding="utf-8")
+        old_root = target / "archived-output"
+        generate_harbor_tasks(
+            target,
+            old_root / "dataset",
+            repo_context_exclude_paths=(old_root,),
+        )
+        (target / "evals" / "evals.json").write_text(
+            json.dumps([{"id": "case-001", "question": "No old fixtures.", "files": []}]),
+            encoding="utf-8",
+        )
+
+        task = generate_harbor_tasks(target, root / "current", copy_repo=True)[0]
+
+        readable = "\n".join(
+            path.read_text(encoding="utf-8", errors="ignore")
+            for path in (task / "environment").rglob("*")
+            if path.is_file()
+        )
+        assert "PLATFORM-ALIAS-SECRET" not in readable
+
+
+@pytest.mark.parametrize("marker_state", ["copied", "rotated-key"])
+def test_unverifiable_historical_generated_output_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    marker_state: str,
+) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    old_output_root = target / "archived-output"
+    old_dataset = old_output_root / "dataset"
+    generate_harbor_tasks(
+        target,
+        old_dataset,
+        repo_context_exclude_paths=(old_output_root,),
+    )
+
+    if marker_state == "copied":
+        shutil.copytree(old_dataset, target / "copied-output")
+    else:
+        monkeypatch.setenv(
+            "SKILLEVALUATOR_OUTPUT_PROVENANCE_KEY_FILE",
+            str(tmp_path / ".rotated-state" / "output-provenance.key"),
+        )
+
+    (target / "evals" / "evals.json").write_text(
+        json.dumps([{"id": "case-001", "question": "Do not use old fixtures.", "files": []}]),
+        encoding="utf-8",
+    )
+    current = tmp_path / f"current-{marker_state}"
+    with pytest.raises(ValueError, match=r"marker.*(?:invalid|authenticated|verified)"):
+        generate_harbor_tasks(target, current, copy_repo=True)
+
+    assert not current.exists()
+
+
 def test_declared_in_skill_output_recovers_after_partial_generation_failure(tmp_path: Path) -> None:
     _, target, _, _ = _write_projection_fixture(tmp_path)
     (target / "evals" / "evals.json").write_text(
@@ -1294,11 +1407,14 @@ def test_generated_baseline_rejects_renamed_target_manifest_payload(tmp_path: Pa
     [
         "/workspace/.agents/skills",
         "/workspace/.claude/skills",
+        "/workspace/.cline/skills",
         "/workspace/.codex/skills",
+        "/workspace/.config/goose/skills",
         "/workspace/.config/opencode/skills",
         "/workspace/.cursor/skills",
         "/workspace/.gemini/skills",
         "/workspace/.opencode/skills",
+        "/workspace/.qwen/skills",
     ],
 )
 def test_final_projection_clears_authored_project_skill_root(
@@ -1366,6 +1482,10 @@ def test_final_projection_clears_effective_workdir_ancestors_and_home(tmp_path: 
     assert 'BASH_ENV=""' in dockerfile
     assert 'CLAUDE_CODE_DISABLE_POLICY_SKILLS="1"' in dockerfile
     assert "/etc/codex/skills" in dockerfile
+    assert "/tmp/codex-home/skills" in dockerfile
+    assert ".config/goose/skills" in dockerfile
+    assert ".cline/skills" in dockerfile
+    assert ".qwen/skills" in dockerfile
     assert "WORKDIR /opt/task/subdir" in dockerfile[final_projection:]
     assert dockerfile.rindex("current=$(/bin/pwd -P)") > dockerfile.rindex("COPY input/ /workspace/input/")
     task_toml = (task / "task.toml").read_text(encoding="utf-8")
@@ -1390,6 +1510,9 @@ def test_generated_tasks_reject_unsafe_agent_workdir(tmp_path: Path, agent_workd
         "/workspace/repo/subdir",
         "/workspace/skills",
         "/opt/project/.claude/skills/hidden",
+        "/opt/project/.cline/skills/hidden",
+        "/opt/project/.config/goose/skills/hidden",
+        "/opt/project/.qwen/skills/hidden",
     ],
 )
 def test_generated_tasks_reject_workdir_inside_runtime_projection(tmp_path: Path, agent_workdir: str) -> None:
@@ -2278,6 +2401,9 @@ def test_linked_repo_projection_rejects_reserved_workspace_input(
     [
         ("skills/target-skill/SKILL.md", "../../skills/target-skill/SKILL.md"),
         (".claude/skills/hidden/SKILL.md", "../../.claude/skills/hidden/SKILL.md"),
+        (".cline/skills/hidden/SKILL.md", "../../.cline/skills/hidden/SKILL.md"),
+        (".config/goose/skills/hidden/SKILL.md", "../../.config/goose/skills/hidden/SKILL.md"),
+        (".qwen/skills/hidden/SKILL.md", "../../.qwen/skills/hidden/SKILL.md"),
     ],
 )
 def test_linked_repo_cannot_overlay_agent_discovery_roots(

--- a/tests/test_harbor_runtime_skill_isolation.py
+++ b/tests/test_harbor_runtime_skill_isolation.py
@@ -827,7 +827,10 @@ def test_staging_rejects_case_alias_of_reserved_results_directory(
     sentinel = output_dir / "keep.txt"
     sentinel.write_text("preserve\n", encoding="utf-8")
 
-    with pytest.raises(ValueError, match="evaluator source"):
+    with pytest.raises(
+        ValueError,
+        match=r"Staging output directory overlaps evaluator source|Generated output marker is missing",
+    ):
         stager_fn = generate_harbor_tasks if stager == "generated" else stage_native_harbor_tasks
         stager_fn(target, output_dir)
 
@@ -1248,7 +1251,7 @@ def test_native_rejects_unsafe_task_directory_name_before_output_mutation(tmp_pa
     _, target, _, _ = _write_projection_fixture(tmp_path)
     _write_minimal_native_task(target)
     native_root = target / "evals" / "harbor"
-    (native_root / "case-001").rename(native_root / 'bad"name')
+    (native_root / "case-001").rename(native_root / "bad name")
     output_dir = tmp_path / "native-invalid-directory"
 
     with pytest.raises(ValueError, match="invalid case id"):
@@ -1280,7 +1283,10 @@ def test_baseline_rejects_target_copied_under_reference_alias(tmp_path: Path) ->
     shutil.copytree(target, aliased_target)
     (aliased_target / "extra.txt").write_text("tree changed but instructions are identical\n", encoding="utf-8")
 
-    with pytest.raises(ValueError, match="alias of target skill"):
+    with pytest.raises(
+        ValueError,
+        match=r"alias of target skill|Baseline environment contains the target skill instructions",
+    ):
         generate_harbor_tasks(
             target,
             tmp_path / "baseline-reference-alias",
@@ -1346,7 +1352,10 @@ def test_baseline_rejects_target_nested_inside_skill_candidate(
         "reference_skills_dir": references_dir,
         "workspace_skill_paths": [workspace],
     }
-    with pytest.raises(ValueError, match="alias of target skill"):
+    with pytest.raises(
+        ValueError,
+        match=r"alias of target skill|Baseline environment contains the target skill instructions",
+    ):
         if stager == "generated":
             generate_harbor_tasks(target, tmp_path / f"nested-alias-{candidate_kind}", **kwargs)
         else:
@@ -3126,7 +3135,8 @@ def test_evaluator_read_accepts_windows_crt_descriptor_identity(
     evals = tmp_path / "evals"
     evals.mkdir()
     dataset = evals / "evals.json"
-    dataset.write_text("[]\n", encoding="utf-8")
+    payload = b"[]\n"
+    dataset.write_bytes(payload)
     original_read_bytes = adapter_module.SecureRoot.read_bytes
 
     def read_with_windows_crt_identity(
@@ -3150,7 +3160,7 @@ def test_evaluator_read_accepts_windows_crt_descriptor_identity(
     monkeypatch.setattr(adapter_module, "_PATH_DESCRIPTOR_IDENTITIES_COMPARABLE", False, raising=False)
     monkeypatch.setattr(adapter_module.SecureRoot, "read_bytes", read_with_windows_crt_identity)
 
-    assert adapter_module._read_regular_evals_file(dataset, allowed_root=evals) == b"[]\n"
+    assert adapter_module._read_regular_evals_file(dataset, allowed_root=evals) == payload
 
 
 @pytest.mark.parametrize("task_source", ["evals_json", "native_harbor"])
@@ -3344,3 +3354,15 @@ def test_native_projection_does_not_read_task_directory_on_another_device(
 
     assert adapter_module._native_projection_entry_ids(native_root) == ()
     assert not read_task_config
+
+
+def test_link_or_reparse_check_accepts_missing_windows_file_attributes(tmp_path: Path) -> None:
+    path = tmp_path / "regular-file"
+    path.write_text("regular\n", encoding="utf-8")
+    metadata = path.lstat()
+    partial_metadata = SimpleNamespace(
+        st_mode=metadata.st_mode,
+        st_file_attributes=None,
+    )
+
+    assert not adapter_module._path_is_link_or_reparse(path, partial_metadata)

--- a/tests/test_harbor_runtime_skill_isolation.py
+++ b/tests/test_harbor_runtime_skill_isolation.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 import pytest
 
+import skillevaluator.tier3.harbor.adapter as adapter_module
 from skillevaluator.tier3.harbor.adapter import (
     _collect_all_skill_deps,
     _dockerfile_resolved_build_context_sources,
@@ -1322,6 +1323,62 @@ def test_explicit_empty_input_keeps_authored_copy_input_buildable(
     assert copy_instruction in (task / "environment" / "Dockerfile").read_text(encoding="utf-8")
 
 
+def test_readonly_custom_environment_snapshot_stays_outside_docker_context(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    if os.name != "posix":
+        pytest.skip("POSIX directory modes required")
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    (target / "evals" / "evals.json").write_text(
+        json.dumps([{"id": "case-001", "question": "No fixture.", "files": []}]),
+        encoding="utf-8",
+    )
+    custom_environment = target / "evals" / "environment"
+    snapshot_destinations: list[Path] = []
+    original_copytree = adapter_module.copytree_secure
+
+    def record_custom_snapshot(source: Path, destination: Path, *args: object, **kwargs: object) -> None:
+        if Path(source) == custom_environment:
+            snapshot_destinations.append(Path(destination))
+        original_copytree(source, destination, *args, **kwargs)
+
+    monkeypatch.setattr(adapter_module, "copytree_secure", record_custom_snapshot)
+    authored_input = custom_environment / "input"
+    authored_input.mkdir()
+    (authored_input / "hidden.txt").write_text("UNDECLARED-CUSTOM-INPUT\n", encoding="utf-8")
+    (custom_environment / "Dockerfile").write_text(
+        "FROM python:3.12-slim\nCOPY . /context\n",
+        encoding="utf-8",
+    )
+    sidecar = custom_environment / "sidecar"
+    sidecar.chmod(0o555)
+    custom_environment.chmod(0o555)
+    try:
+        task = generate_harbor_tasks(
+            target,
+            tmp_path / "readonly-custom-environment",
+            custom_dockerfile_mode="preserve",
+            grading_mode="custom_only",
+        )[0]
+    finally:
+        custom_environment.chmod(0o755)
+        sidecar.chmod(0o755)
+
+    environment = task / "environment"
+    assert len(snapshot_destinations) == 1
+    assert not snapshot_destinations[0].absolute().is_relative_to(environment.absolute())
+    assert not any(path.name == ".skillevaluator-custom-environment" for path in environment.rglob("*"))
+    assert "COPY . /context" in (environment / "Dockerfile").read_text(encoding="utf-8")
+    assert (environment / "input").is_dir()
+    assert list((environment / "input").iterdir()) == []
+    assert not (environment / "input" / "hidden.txt").exists()
+    readable_environment = "\n".join(
+        path.read_text(encoding="utf-8", errors="ignore") for path in environment.rglob("*") if path.is_file()
+    )
+    assert "UNDECLARED-CUSTOM-INPUT" not in readable_environment
+
+
 def test_native_copy_input_without_fixtures_gets_empty_build_context_directory(tmp_path: Path) -> None:
     _, target, _, _ = _write_projection_fixture(tmp_path)
     (target / "evals" / "evals.json").write_text(
@@ -1668,6 +1725,49 @@ def test_native_baseline_ignores_target_payload_in_unstaged_results(tmp_path: Pa
     )[0]
 
     assert not (task / "environment" / "results").exists()
+
+
+def test_native_task_discovery_ignores_unstaged_root_results(tmp_path: Path) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    _write_minimal_native_task(target)
+    archived_task = target / "evals" / "harbor" / "results"
+    archived_task.mkdir()
+    (archived_task / "task.toml").write_text(
+        'schema_version = "1.3"\n\n[task]\nname = "nvidia/archived"\n\n'
+        '[metadata]\nentry_id = "archived"\n\n[environment]\nworkdir = "relative"\n',
+        encoding="utf-8",
+    )
+
+    tasks = stage_native_harbor_tasks(target, tmp_path / "native-ignored-root-results")
+
+    assert [task.name for task in tasks] == ["case-001"]
+    assert not (tmp_path / "native-ignored-root-results" / "results").exists()
+
+
+def test_native_contamination_scan_uses_shared_ignore_callback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, target, _, _ = _write_projection_fixture(tmp_path)
+    _write_minimal_native_task(target)
+    ignored = target / "evals" / "harbor" / "case-001" / "environment" / "RESULTS"
+    ignored.mkdir(parents=True)
+    (ignored / "archived.txt").write_bytes((target / "SKILL.md").read_bytes())
+
+    ignored_casefolded = frozenset(name.casefold() for name in adapter_module._NATIVE_SOURCE_IGNORE_NAMES)
+
+    def _casefolding_ignore(_directory: str, names: list[str]) -> set[str]:
+        return {name for name in names if name.casefold() in ignored_casefolded}
+
+    monkeypatch.setattr(adapter_module, "_NATIVE_SOURCE_IGNORE", _casefolding_ignore)
+
+    task = stage_native_harbor_tasks(
+        target,
+        tmp_path / "native-shared-ignore-callback",
+        with_skill=False,
+    )[0]
+
+    assert not (task / "environment" / "RESULTS").exists()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_harbor_secure_copy.py
+++ b/tests/test_harbor_secure_copy.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import ctypes
 import errno
+import hashlib
 import importlib
 import os
 import socket
@@ -700,6 +701,66 @@ def test_checked_windows_fallback_accepts_crt_descriptor_identity(
 
     assert (tree_destination / "safe.txt").read_text(encoding="utf-8") == "tree"
     assert file_destination.read_text(encoding="utf-8") == "file"
+
+
+@pytest.mark.parametrize("copy_kind", ["tree", "file"])
+def test_checked_windows_fallback_preserves_lf_bytes_in_binary_files(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    copy_kind: str,
+) -> None:
+    module = importlib.import_module("skillevaluator.tier3.harbor.secure_copy")
+    fake_binary_flag = 1 << 29
+    original_open = module.os.open
+    original_write = module.os.write
+    original_close = module.os.close
+    text_write_descriptors: set[int] = set()
+
+    def windows_open(
+        path: object,
+        flags: int,
+        mode: int = 0o777,
+        *,
+        dir_fd: int | None = None,
+    ) -> int:
+        descriptor = original_open(path, flags & ~fake_binary_flag, mode, dir_fd=dir_fd)
+        if not flags & fake_binary_flag and flags & (os.O_WRONLY | os.O_RDWR):
+            text_write_descriptors.add(descriptor)
+        return descriptor
+
+    def windows_text_write(descriptor: int, payload: bytes | bytearray | memoryview) -> int:
+        raw = bytes(payload)
+        if descriptor in text_write_descriptors:
+            raw = raw.replace(b"\n", b"\r\n")
+        return original_write(descriptor, raw)
+
+    def tracked_close(descriptor: int) -> None:
+        text_write_descriptors.discard(descriptor)
+        original_close(descriptor)
+
+    source = tmp_path / "source"
+    source.mkdir()
+    marker = source / ".skillevaluator-generated-output"
+    payload = b"SkillEvaluator generated output v2\nsignature-with-lf-only\n"
+    marker.write_bytes(payload)
+
+    monkeypatch.setattr(module, "_DESCRIPTOR_BACKEND", False)
+    monkeypatch.setattr(module, "_ATOMIC_RENAME", None)
+    monkeypatch.setattr(module, "_BINARY_FLAG", fake_binary_flag, raising=False)
+    monkeypatch.setattr(module.os, "open", windows_open)
+    monkeypatch.setattr(module.os, "write", windows_text_write)
+    monkeypatch.setattr(module.os, "close", tracked_close)
+    destination = tmp_path / "destination"
+    if copy_kind == "tree":
+        module.copytree_secure(source, destination, allowed_root=tmp_path)
+        copied = destination / marker.name
+    else:
+        module.copy_file_secure(marker, destination, allowed_root=tmp_path)
+        copied = destination
+
+    assert copied.read_bytes() == payload
+    assert copied.stat().st_size == len(payload)
+    assert hashlib.sha256(copied.read_bytes()).digest() == hashlib.sha256(payload).digest()
 
 
 @pytest.mark.skipif(os.name != "nt", reason="requires native Windows filesystem semantics")

--- a/tests/test_harbor_secure_copy.py
+++ b/tests/test_harbor_secure_copy.py
@@ -17,6 +17,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FutureTimeoutError
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -33,6 +34,15 @@ def _copytree_secure(source: Path, destination: Path, **kwargs: object) -> None:
 def _copy_file_secure(source: Path, destination: Path, **kwargs: object) -> None:
     module = importlib.import_module("skillevaluator.tier3.harbor.secure_copy")
     module.copy_file_secure(source, destination, **kwargs)
+
+
+def _assert_mode_preserved(source: Path, destination: Path) -> None:
+    source_mode = stat.S_IMODE(source.stat().st_mode)
+    destination_mode = stat.S_IMODE(destination.stat().st_mode)
+    if os.name == "nt":
+        assert bool(destination_mode & stat.S_IWRITE) == bool(source_mode & stat.S_IWRITE)
+    else:
+        assert destination_mode == source_mode
 
 
 def test_public_secure_copy_api_documents_same_uid_boundary() -> None:
@@ -595,7 +605,7 @@ def test_regular_copy_preserves_modes_and_merges_transactionally(tmp_path: Path)
 
     assert (destination / "unrelated.txt").read_text(encoding="utf-8") == "keep"
     assert (destination / "nested" / "run.sh").read_text(encoding="utf-8") == "#!/bin/sh\n"
-    assert stat.S_IMODE((destination / "nested" / "run.sh").stat().st_mode) == 0o751
+    _assert_mode_preserved(script, destination / "nested" / "run.sh")
 
 
 def test_private_stage_injection_is_rejected_before_publish(
@@ -651,7 +661,92 @@ def test_checked_non_posix_fallback_copies_tree_and_file(
     file_destination.write_text("old", encoding="utf-8")
     module.copy_file_secure(file_source, file_destination, allowed_root=tmp_path)
     assert file_destination.read_text(encoding="utf-8") == "new"
-    assert stat.S_IMODE(file_destination.stat().st_mode) == 0o640
+    _assert_mode_preserved(file_source, file_destination)
+
+
+def test_checked_windows_fallback_accepts_crt_descriptor_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = importlib.import_module("skillevaluator.tier3.harbor.secure_copy")
+    original_fstat = module.os.fstat
+
+    def windows_crt_fstat(descriptor: int) -> object:
+        opened = original_fstat(descriptor)
+        return SimpleNamespace(
+            st_dev=opened.st_dev + 10_000,
+            st_ino=opened.st_ino + 10_000,
+            st_mode=opened.st_mode,
+            st_nlink=opened.st_nlink,
+            st_size=opened.st_size,
+            st_mtime_ns=opened.st_mtime_ns,
+            st_ctime_ns=opened.st_ctime_ns,
+        )
+
+    monkeypatch.setattr(module, "_DESCRIPTOR_BACKEND", False)
+    monkeypatch.setattr(module, "_ATOMIC_RENAME", None)
+    monkeypatch.setattr(module, "_PATH_DESCRIPTOR_IDENTITIES_COMPARABLE", False, raising=False)
+    monkeypatch.setattr(module.os, "fstat", windows_crt_fstat)
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "safe.txt").write_text("tree", encoding="utf-8")
+    tree_destination = tmp_path / "tree-destination"
+    file_source = tmp_path / "file-source.txt"
+    file_source.write_text("file", encoding="utf-8")
+    file_destination = tmp_path / "file-destination.txt"
+
+    module.copytree_secure(source, tree_destination, allowed_root=tmp_path)
+    module.copy_file_secure(file_source, file_destination, allowed_root=tmp_path)
+
+    assert (tree_destination / "safe.txt").read_text(encoding="utf-8") == "tree"
+    assert file_destination.read_text(encoding="utf-8") == "file"
+
+
+@pytest.mark.skipif(os.name != "nt", reason="requires native Windows filesystem semantics")
+def test_native_windows_fallback_copies_tree_and_file(tmp_path: Path) -> None:
+    module = importlib.import_module("skillevaluator.tier3.harbor.secure_copy")
+    source = tmp_path / "source"
+    source.mkdir()
+    source_file = source / "writable.txt"
+    source_file.write_text("tree", encoding="utf-8")
+    source_file.chmod(0o666)
+    tree_destination = tmp_path / "tree-destination"
+    file_source = tmp_path / "read-only.txt"
+    file_source.write_text("file", encoding="utf-8")
+    file_source.chmod(0o444)
+    file_destination = tmp_path / "file-destination.txt"
+
+    try:
+        module.copytree_secure(source, tree_destination, allowed_root=tmp_path)
+        module.copy_file_secure(file_source, file_destination, allowed_root=tmp_path)
+
+        assert (tree_destination / "writable.txt").read_text(encoding="utf-8") == "tree"
+        assert (tree_destination / "writable.txt").stat().st_mode & stat.S_IWRITE
+        assert file_destination.read_text(encoding="utf-8") == "file"
+        assert not file_destination.stat().st_mode & stat.S_IWRITE
+    finally:
+        file_source.chmod(0o666)
+        if file_destination.exists():
+            file_destination.chmod(0o666)
+
+
+@pytest.mark.skipif(os.name != "nt", reason="requires native Windows chmod semantics")
+def test_native_windows_tree_fingerprint_binds_writable_mode(tmp_path: Path) -> None:
+    module = importlib.import_module("skillevaluator.tier3.harbor.secure_copy")
+    source = tmp_path / "source"
+    source.mkdir()
+    script = source / "run.cmd"
+    script.write_text("@echo off\r\n", encoding="utf-8")
+    script.chmod(0o666)
+
+    try:
+        writable = module.tree_content_fingerprint_secure(source, allowed_root=tmp_path)
+        script.chmod(0o444)
+        read_only = module.tree_content_fingerprint_secure(source, allowed_root=tmp_path)
+    finally:
+        script.chmod(0o666)
+
+    assert writable != read_only
 
 
 def test_checked_non_posix_tree_fallback_without_fchmod_preserves_file_mode(
@@ -661,7 +756,7 @@ def test_checked_non_posix_tree_fallback_without_fchmod_preserves_file_mode(
     module = importlib.import_module("skillevaluator.tier3.harbor.secure_copy")
     monkeypatch.setattr(module, "_DESCRIPTOR_BACKEND", False)
     monkeypatch.setattr(module, "_ATOMIC_RENAME", None)
-    monkeypatch.delattr(module.os, "fchmod")
+    monkeypatch.delattr(module.os, "fchmod", raising=False)
     source = tmp_path / "source"
     source.mkdir()
     source_file = source / "safe.txt"
@@ -673,7 +768,7 @@ def test_checked_non_posix_tree_fallback_without_fchmod_preserves_file_mode(
 
     staged_file = destination / "safe.txt"
     assert staged_file.read_text(encoding="utf-8") == "safe"
-    assert stat.S_IMODE(staged_file.stat().st_mode) == 0o640
+    _assert_mode_preserved(source_file, staged_file)
 
 
 def test_checked_non_posix_file_fallback_without_fchmod_preserves_mode(
@@ -683,7 +778,7 @@ def test_checked_non_posix_file_fallback_without_fchmod_preserves_mode(
     module = importlib.import_module("skillevaluator.tier3.harbor.secure_copy")
     monkeypatch.setattr(module, "_DESCRIPTOR_BACKEND", False)
     monkeypatch.setattr(module, "_ATOMIC_RENAME", None)
-    monkeypatch.delattr(module.os, "fchmod")
+    monkeypatch.delattr(module.os, "fchmod", raising=False)
     source = tmp_path / "source.txt"
     source.write_text("safe", encoding="utf-8")
     source.chmod(0o640)
@@ -692,7 +787,7 @@ def test_checked_non_posix_file_fallback_without_fchmod_preserves_mode(
     module.copy_file_secure(source, destination, allowed_root=tmp_path)
 
     assert destination.read_text(encoding="utf-8") == "safe"
-    assert stat.S_IMODE(destination.stat().st_mode) == 0o640
+    _assert_mode_preserved(source, destination)
 
 
 def test_checked_windows_fallback_verifies_portable_chmod_semantics(
@@ -718,7 +813,7 @@ def test_checked_windows_fallback_verifies_portable_chmod_semantics(
     monkeypatch.setattr(module, "_DESCRIPTOR_BACKEND", False)
     monkeypatch.setattr(module, "_ATOMIC_RENAME", None)
     monkeypatch.setattr(module, "_WINDOWS_CHMOD_SEMANTICS", True)
-    monkeypatch.delattr(module.os, "fchmod")
+    monkeypatch.delattr(module.os, "fchmod", raising=False)
     monkeypatch.setattr(module.Path, "chmod", windows_chmod)
     tree_destination = tmp_path / "tree-destination"
     file_destination = tmp_path / "file-destination.txt"

--- a/tests/test_harbor_secure_copy.py
+++ b/tests/test_harbor_secure_copy.py
@@ -654,6 +654,84 @@ def test_checked_non_posix_fallback_copies_tree_and_file(
     assert stat.S_IMODE(file_destination.stat().st_mode) == 0o640
 
 
+def test_checked_non_posix_tree_fallback_without_fchmod_preserves_file_mode(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = importlib.import_module("skillevaluator.tier3.harbor.secure_copy")
+    monkeypatch.setattr(module, "_DESCRIPTOR_BACKEND", False)
+    monkeypatch.setattr(module, "_ATOMIC_RENAME", None)
+    monkeypatch.delattr(module.os, "fchmod")
+    source = tmp_path / "source"
+    source.mkdir()
+    source_file = source / "safe.txt"
+    source_file.write_text("safe", encoding="utf-8")
+    source_file.chmod(0o640)
+    destination = tmp_path / "destination"
+
+    module.copytree_secure(source, destination, allowed_root=tmp_path)
+
+    staged_file = destination / "safe.txt"
+    assert staged_file.read_text(encoding="utf-8") == "safe"
+    assert stat.S_IMODE(staged_file.stat().st_mode) == 0o640
+
+
+def test_checked_non_posix_file_fallback_without_fchmod_preserves_mode(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = importlib.import_module("skillevaluator.tier3.harbor.secure_copy")
+    monkeypatch.setattr(module, "_DESCRIPTOR_BACKEND", False)
+    monkeypatch.setattr(module, "_ATOMIC_RENAME", None)
+    monkeypatch.delattr(module.os, "fchmod")
+    source = tmp_path / "source.txt"
+    source.write_text("safe", encoding="utf-8")
+    source.chmod(0o640)
+    destination = tmp_path / "destination.txt"
+
+    module.copy_file_secure(source, destination, allowed_root=tmp_path)
+
+    assert destination.read_text(encoding="utf-8") == "safe"
+    assert stat.S_IMODE(destination.stat().st_mode) == 0o640
+
+
+def test_checked_windows_fallback_verifies_portable_chmod_semantics(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = importlib.import_module("skillevaluator.tier3.harbor.secure_copy")
+    source = tmp_path / "source"
+    source.mkdir()
+    source_file = source / "writable.txt"
+    source_file.write_text("tree", encoding="utf-8")
+    source_file.chmod(0o640)
+    file_source = tmp_path / "read-only.txt"
+    file_source.write_text("file", encoding="utf-8")
+    file_source.chmod(0o440)
+    original_chmod = Path.chmod
+
+    def windows_chmod(path: Path, mode: int, *args: object, **kwargs: object) -> None:
+        executable = 0o111 if path.is_dir() else 0
+        portable_mode = (0o666 | executable) if mode & stat.S_IWRITE else (0o444 | executable)
+        original_chmod(path, portable_mode, *args, **kwargs)
+
+    monkeypatch.setattr(module, "_DESCRIPTOR_BACKEND", False)
+    monkeypatch.setattr(module, "_ATOMIC_RENAME", None)
+    monkeypatch.setattr(module, "_WINDOWS_CHMOD_SEMANTICS", True)
+    monkeypatch.delattr(module.os, "fchmod")
+    monkeypatch.setattr(module.Path, "chmod", windows_chmod)
+    tree_destination = tmp_path / "tree-destination"
+    file_destination = tmp_path / "file-destination.txt"
+
+    module.copytree_secure(source, tree_destination, allowed_root=tmp_path)
+    module.copy_file_secure(file_source, file_destination, allowed_root=tmp_path)
+
+    assert (tree_destination / "writable.txt").read_text(encoding="utf-8") == "tree"
+    assert (tree_destination / "writable.txt").stat().st_mode & stat.S_IWRITE
+    assert file_destination.read_text(encoding="utf-8") == "file"
+    assert not (file_destination.stat().st_mode & stat.S_IWRITE)
+
+
 def test_checked_non_posix_fallback_still_rejects_symlinks(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_results_location.py
+++ b/tests/test_results_location.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 from skillevaluator.tier3.results_location import external_results_root, resolve_latest_results
@@ -33,6 +34,34 @@ def test_latest_results_falls_back_to_newest_completed_run_without_symlink(tmp_p
     resolved = resolve_latest_results(skill_path, cli_results_dir, environ={})
 
     assert resolved == newest
+
+
+def test_latest_results_fallback_accepts_unique_suffixed_run_ids(tmp_path: Path) -> None:
+    skill_path = tmp_path / "demo"
+    skill_path.mkdir()
+    cli_results_dir = tmp_path / "results"
+    root = external_results_root(cli_results_dir, skill_path)
+    _write_completed_run(root, "20260705_120000_111_aaaaaaaaaaaa")
+    newest = _write_completed_run(root, "20260705_130000_222_bbbbbbbbbbbb")
+
+    resolved = resolve_latest_results(skill_path, cli_results_dir, environ={})
+
+    assert resolved == newest
+
+
+def test_latest_results_same_timestamp_uses_completion_mtime(tmp_path: Path) -> None:
+    skill_path = tmp_path / "demo"
+    skill_path.mkdir()
+    cli_results_dir = tmp_path / "results"
+    root = external_results_root(cli_results_dir, skill_path)
+    lexically_later = _write_completed_run(root, "20260705_130000_999_ffffffffffff")
+    completed_later = _write_completed_run(root, "20260705_130000_111_aaaaaaaaaaaa")
+    os.utime(lexically_later / "result.json", ns=(100, 100))
+    os.utime(completed_later / "result.json", ns=(200, 200))
+
+    resolved = resolve_latest_results(skill_path, cli_results_dir, environ={})
+
+    assert resolved == completed_later
 
 
 def test_latest_results_fallback_ignores_hidden_partial_and_malformed_directories(tmp_path: Path) -> None:

--- a/tests/test_results_location.py
+++ b/tests/test_results_location.py
@@ -7,8 +7,12 @@ from __future__ import annotations
 
 import json
 import os
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
+import pytest
+
+from skillevaluator.tier3 import results_location
 from skillevaluator.tier3.results_location import external_results_root, resolve_latest_results
 
 
@@ -64,6 +68,59 @@ def test_latest_results_same_timestamp_uses_completion_mtime(tmp_path: Path) -> 
     assert resolved == completed_later
 
 
+def test_latest_results_same_completion_time_uses_deterministic_name_order(tmp_path: Path) -> None:
+    skill_path = tmp_path / "demo"
+    skill_path.mkdir()
+    cli_results_dir = tmp_path / "results"
+    root = external_results_root(cli_results_dir, skill_path)
+    lexically_first = _write_completed_run(root, "20260705_130000_111_aaaaaaaaaaaa")
+    lexically_last = _write_completed_run(root, "20260705_130000_999_ffffffffffff")
+    os.utime(lexically_first / "result.json", ns=(100, 100))
+    os.utime(lexically_last / "result.json", ns=(100, 100))
+
+    resolved = resolve_latest_results(skill_path, cli_results_dir, environ={})
+
+    assert resolved == lexically_last
+
+
+def test_publish_latest_results_is_atomic_under_concurrency(tmp_path: Path) -> None:
+    publisher = getattr(results_location, "publish_latest_results", None)
+    assert callable(publisher), "results_location must expose a shared latest-link publisher"
+    root = tmp_path / "results"
+    run_ids = [f"20260705_130000_{index:03d}_aaaaaaaaaaaa" for index in range(8)]
+    for run_id in run_ids:
+        (root / run_id).mkdir(parents=True)
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        published = list(executor.map(lambda run_id: publisher(root, run_id), run_ids))
+    if not any(published):  # pragma: no cover - Windows installations without symlink privileges
+        pytest.skip("symlink creation is unavailable on this host")
+
+    latest = root / "latest"
+    assert latest.is_symlink()
+    assert str(latest.readlink()) in run_ids
+    assert not list(root.glob(".latest-*.tmp"))
+
+
+def test_publish_latest_results_preserves_real_directory_and_cleans_temp_link(tmp_path: Path) -> None:
+    publisher = getattr(results_location, "publish_latest_results", None)
+    assert callable(publisher), "results_location must expose a shared latest-link publisher"
+    root = tmp_path / "results"
+    latest = root / "latest"
+    latest.mkdir(parents=True)
+    marker = latest / "keep.txt"
+    marker.write_text("keep", encoding="utf-8")
+    run_id = "20260705_130000_111_aaaaaaaaaaaa"
+    (root / run_id).mkdir()
+
+    publisher(root, run_id)
+
+    assert latest.is_dir()
+    assert not latest.is_symlink()
+    assert marker.read_text(encoding="utf-8") == "keep"
+    assert not list(root.glob(".latest-*.tmp"))
+
+
 def test_latest_results_fallback_ignores_hidden_partial_and_malformed_directories(tmp_path: Path) -> None:
     skill_path = tmp_path / "demo"
     skill_path.mkdir()
@@ -88,3 +145,158 @@ def test_latest_results_fallback_ignores_hidden_partial_and_malformed_directorie
     resolved = resolve_latest_results(skill_path, cli_results_dir, environ={})
 
     assert resolved == expected
+
+
+def _symlink_or_skip(link: Path, target: Path) -> None:
+    try:
+        link.symlink_to(target)
+    except OSError as exc:  # pragma: no cover - host policy, primarily native Windows
+        pytest.skip(f"symlinks unavailable on this host: {exc}")
+
+
+def test_latest_results_prefers_valid_relative_latest_link(tmp_path: Path) -> None:
+    skill_path = tmp_path / "demo"
+    skill_path.mkdir()
+    cli_results_dir = tmp_path / "results"
+    root = external_results_root(cli_results_dir, skill_path)
+    selected = _write_completed_run(root, "20260705_120000")
+    _write_completed_run(root, "20260705_130000")
+    latest = root / "latest"
+    _symlink_or_skip(latest, Path(selected.name))
+
+    assert resolve_latest_results(skill_path, cli_results_dir, environ={}) == latest
+
+
+@pytest.mark.parametrize(
+    "latest_kind",
+    ["directory", "dangling", "escaping", "incomplete", "legacy", "absolute", "nested-alias"],
+)
+def test_latest_results_ignores_invalid_latest_pointer_and_falls_back(
+    tmp_path: Path,
+    latest_kind: str,
+) -> None:
+    skill_path = tmp_path / "demo"
+    skill_path.mkdir()
+    cli_results_dir = tmp_path / "results"
+    root = external_results_root(cli_results_dir, skill_path)
+    older = _write_completed_run(root, "20260705_120000")
+    expected = _write_completed_run(root, "20260705_130000")
+    latest = root / "latest"
+
+    if latest_kind == "directory":
+        latest.mkdir()
+    elif latest_kind == "dangling":
+        _symlink_or_skip(latest, Path("missing-run"))
+    elif latest_kind == "escaping":
+        outside = _write_completed_run(tmp_path / "outside", "20260705_140000")
+        _symlink_or_skip(latest, outside)
+    elif latest_kind == "incomplete":
+        (root / "20260705_140000").mkdir()
+        _symlink_or_skip(latest, Path("20260705_140000"))
+    elif latest_kind == "legacy":
+        legacy = root / "legacy-run"
+        legacy.mkdir()
+        (legacy / "result.json").write_text(json.dumps({"run_id": legacy.name}), encoding="utf-8")
+        _symlink_or_skip(latest, Path(legacy.name))
+    elif latest_kind == "absolute":
+        _symlink_or_skip(latest, older.resolve())
+    else:
+        (root / "alias").mkdir()
+        _symlink_or_skip(latest, Path("alias") / ".." / older.name)
+
+    assert resolve_latest_results(skill_path, cli_results_dir, environ={}) == expected
+
+
+@pytest.mark.parametrize("latest_kind", ["directory", "escaping", "incomplete"])
+def test_invalid_latest_without_completed_run_returns_safe_absent_path(
+    tmp_path: Path,
+    latest_kind: str,
+) -> None:
+    skill_path = tmp_path / "demo"
+    skill_path.mkdir()
+    cli_results_dir = tmp_path / "results"
+    root = external_results_root(cli_results_dir, skill_path)
+    root.mkdir(parents=True)
+    latest = root / "latest"
+    if latest_kind == "directory":
+        latest.mkdir()
+    elif latest_kind == "escaping":
+        outside = _write_completed_run(tmp_path / "outside", "20260705_140000")
+        _symlink_or_skip(latest, outside)
+    else:
+        partial = root / "20260705_140000"
+        partial.mkdir()
+        _symlink_or_skip(latest, Path(partial.name))
+
+    resolved = resolve_latest_results(skill_path, cli_results_dir, environ={})
+
+    assert resolved != latest
+    assert not os.path.lexists(resolved)
+    assert resolved.parent != latest
+    assert not resolved.resolve(strict=False).is_relative_to((tmp_path / "outside").resolve())
+
+
+def test_all_invalid_latest_entries_return_collision_checked_hidden_sentinel(tmp_path: Path) -> None:
+    skill_path = tmp_path / "demo"
+    skill_path.mkdir()
+    cli_results_dir = tmp_path / "results"
+    primary_root = external_results_root(cli_results_dir, skill_path)
+    legacy_root = skill_path / "evals" / "results"
+    for root in (primary_root, legacy_root):
+        (root / "latest").mkdir(parents=True)
+
+    resolved = resolve_latest_results(skill_path, cli_results_dir, environ={})
+
+    assert resolved.parent == primary_root
+    assert resolved.name.startswith(".latest-unavailable-")
+    assert not os.path.lexists(resolved)
+
+
+@pytest.mark.parametrize("artifact_kind", ["symlink", "fifo", "hardlink"])
+def test_latest_results_fallback_rejects_unsafe_result_artifact(tmp_path: Path, artifact_kind: str) -> None:
+    skill_path = tmp_path / "demo"
+    skill_path.mkdir()
+    cli_results_dir = tmp_path / "results"
+    root = external_results_root(cli_results_dir, skill_path)
+    expected = _write_completed_run(root, "20260705_120000")
+    unsafe = root / "20260705_130000"
+    unsafe.mkdir()
+    result_path = unsafe / "result.json"
+    source = tmp_path / "result-source.json"
+    source.write_text(json.dumps({"run_id": unsafe.name}), encoding="utf-8")
+    try:
+        if artifact_kind == "symlink":
+            result_path.symlink_to(source)
+        elif artifact_kind == "fifo":
+            if not hasattr(os, "mkfifo"):
+                pytest.skip("FIFO creation is unavailable on this host")
+            os.mkfifo(result_path)
+        else:
+            result_path.hardlink_to(source)
+    except OSError as exc:  # pragma: no cover - filesystem policy
+        pytest.skip(f"{artifact_kind} creation is unavailable on this host: {exc}")
+
+    assert resolve_latest_results(skill_path, cli_results_dir, environ={}) == expected
+
+
+@pytest.mark.parametrize("reparse_kind", ["run-directory", "result"])
+def test_latest_results_rejects_windows_reparse_candidates(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    reparse_kind: str,
+) -> None:
+    skill_path = tmp_path / "demo"
+    skill_path.mkdir()
+    cli_results_dir = tmp_path / "results"
+    root = external_results_root(cli_results_dir, skill_path)
+    expected = _write_completed_run(root, "20260705_120000")
+    unsafe = _write_completed_run(root, "20260705_130000")
+    marked = unsafe if reparse_kind == "run-directory" else unsafe / "result.json"
+    detect_link = results_location._path_is_link_or_reparse
+
+    def mock_windows_reparse(path: Path, metadata: os.stat_result) -> bool:
+        return path == marked or detect_link(path, metadata)
+
+    monkeypatch.setattr(results_location, "_path_is_link_or_reparse", mock_windows_reparse)
+
+    assert resolve_latest_results(skill_path, cli_results_dir, environ={}) == expected

--- a/tests/test_results_location.py
+++ b/tests/test_results_location.py
@@ -19,6 +19,7 @@ from skillevaluator.tier3.results_location import external_results_root, resolve
 def _write_completed_run(root: Path, run_id: str) -> Path:
     run_dir = root / run_id
     run_dir.mkdir(parents=True)
+    (run_dir / "run_config.json").write_text("{}", encoding="utf-8")
     (run_dir / "result.json").write_text(
         json.dumps({"run_id": run_id, "agents": {}}),
         encoding="utf-8",

--- a/tests/test_results_location.py
+++ b/tests/test_results_location.py
@@ -7,12 +7,14 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
 
 from skillevaluator.tier3 import results_location
+from skillevaluator.tier3.output_provenance import mark_generated_output_root
 from skillevaluator.tier3.results_location import external_results_root, resolve_latest_results
 
 
@@ -22,6 +24,93 @@ def _write_completed_run(root: Path, run_id: str) -> Path:
     (run_dir / "run_config.json").write_text("{}", encoding="utf-8")
     (run_dir / "result.json").write_text(
         json.dumps({"run_id": run_id, "agents": {}}),
+        encoding="utf-8",
+    )
+    return run_dir
+
+
+def _write_authenticated_current_run(
+    root: Path,
+    run_id: str,
+    *,
+    skill_name: str = "demo",
+    recorded_run_dir: str | None = None,
+    recorded_result_path: str | None = None,
+) -> Path:
+    run_dir = root / run_id
+    run_dir.mkdir(parents=True)
+    mark_generated_output_root(run_dir)
+    run_config = {
+        "config_file": "none",
+        "harbor": {
+            "environment": {"value": "local", "source": "test"},
+            "n_attempts": 1,
+            "stop_on_pass": False,
+            "n_concurrent": 1,
+            "timeout_multiplier": 1.0,
+            "base_image_mode": "disabled",
+            "jobs_retained": False,
+        },
+        "provider": {"name": "nvidia", "model": "test-model"},
+        "task_source": "evals_json",
+        "grading": {"mode": "default"},
+        "agents": {
+            "opencode": {
+                "agent": "opencode",
+                "model": "test-model",
+                "source": "test default",
+            }
+        },
+    }
+    agent_dir = run_dir / "opencode"
+    agent_result = {
+        "model": "test-model",
+        "model_source": "test default",
+        "model_resolution": {"model": "test-model", "source": "test default"},
+        "with_skill": {"security": 0.8},
+        "without_skill": {},
+        "custom_with_skill": {},
+        "custom_without_skill": {},
+        "dimensions_with_skill": {},
+        "dimensions_without_skill": {},
+        "lift": {},
+        "custom_lift": {},
+        "pass_at_k": {"with_skill": {}, "without_skill": {}, "lift": {}},
+        "security_attribution": {},
+        "agent_runtime_failures": {"with_skill": [], "without_skill": []},
+        "trial_failures": {"with_skill": [], "without_skill": []},
+        "job_failures": {"with_skill": "", "without_skill": ""},
+        "conditions": {"with_skill": {}, "without_skill": {}},
+        "execution_status": "succeeded",
+        "execution_errors": [],
+        "expected_attempts": 1,
+        "scored_attempts": 1,
+        "num_trials_with": 1,
+        "num_trials_without": 0,
+        "output_dir": str(agent_dir.resolve()),
+    }
+    (run_dir / "run_config.json").write_text(json.dumps(run_config), encoding="utf-8")
+    (run_dir / "result.json").write_text(
+        json.dumps(
+            {
+                "skill_name": skill_name,
+                "run_id": run_id,
+                "run_dir": recorded_run_dir or str(run_dir),
+                "result_path": recorded_result_path or str((run_dir / "result.json").resolve()),
+                "run_config": run_config,
+                "agents": {"opencode": agent_result},
+                "attempt_policy": {
+                    "max_attempts": 1,
+                    "pass_threshold": 0.5,
+                    "stop_on_pass": False,
+                    "score_definition": "test",
+                },
+                "execution_status": "succeeded",
+                "execution_errors": [],
+                "report_status": "complete",
+                "duration_seconds": 1.0,
+            }
+        ),
         encoding="utf-8",
     )
     return run_dir
@@ -46,12 +135,157 @@ def test_latest_results_fallback_accepts_unique_suffixed_run_ids(tmp_path: Path)
     skill_path.mkdir()
     cli_results_dir = tmp_path / "results"
     root = external_results_root(cli_results_dir, skill_path)
-    _write_completed_run(root, "20260705_120000_111_aaaaaaaaaaaa")
-    newest = _write_completed_run(root, "20260705_130000_222_bbbbbbbbbbbb")
+    _write_authenticated_current_run(root, "20260705_120000_111_aaaaaaaaaaaa")
+    newest = _write_authenticated_current_run(root, "20260705_130000_222_bbbbbbbbbbbb")
 
     resolved = resolve_latest_results(skill_path, cli_results_dir, environ={})
 
     assert resolved == newest
+
+
+def test_latest_results_rejects_unmarked_suffixed_run_that_would_shadow_historical_run(tmp_path: Path) -> None:
+    skill_path = tmp_path / "demo"
+    skill_path.mkdir()
+    cli_results_dir = tmp_path / "results"
+    root = external_results_root(cli_results_dir, skill_path)
+    historical = _write_completed_run(root, "20260705_120000")
+    _write_completed_run(root, "20260705_130000_222_bbbbbbbbbbbb")
+
+    resolved = resolve_latest_results(skill_path, cli_results_dir, environ={})
+
+    assert resolved == historical
+
+
+def test_latest_results_rejects_current_run_copied_across_results_roots(tmp_path: Path) -> None:
+    skill_path = tmp_path / "demo"
+    skill_path.mkdir()
+    cli_results_dir = tmp_path / "primary"
+    primary_root = external_results_root(cli_results_dir, skill_path)
+    historical = _write_completed_run(skill_path / "evals" / "results", "20260705_120000")
+    authentic = _write_authenticated_current_run(
+        tmp_path / "source" / skill_path.name,
+        "20260705_130000_222_bbbbbbbbbbbb",
+    )
+    copied = shutil.copytree(authentic, primary_root / authentic.name)
+    copied_result_path = copied / "result.json"
+    copied_result = json.loads(copied_result_path.read_text(encoding="utf-8"))
+    copied_result["run_dir"] = str(copied)
+    copied_result_path.write_text(json.dumps(copied_result), encoding="utf-8")
+
+    resolved = resolve_latest_results(skill_path, cli_results_dir, environ={})
+
+    assert resolved == historical
+
+
+@pytest.mark.parametrize(
+    "mutate_result",
+    [
+        lambda result: result["run_config"].update({"task_source": "native_harbor"}),
+        lambda result: result.update({"run_dir": "/tmp/different-run"}),
+    ],
+    ids=("run-config", "run-directory"),
+)
+def test_latest_results_rejects_authenticated_current_run_with_inconsistent_identity(
+    tmp_path: Path,
+    mutate_result,
+) -> None:
+    skill_path = tmp_path / "demo"
+    skill_path.mkdir()
+    cli_results_dir = tmp_path / "results"
+    root = external_results_root(cli_results_dir, skill_path)
+    historical = _write_completed_run(root, "20260705_120000")
+    current = _write_authenticated_current_run(root, "20260705_130000_222_bbbbbbbbbbbb")
+    result_path = current / "result.json"
+    result = json.loads(result_path.read_text(encoding="utf-8"))
+    mutate_result(result)
+    result_path.write_text(json.dumps(result), encoding="utf-8")
+
+    resolved = resolve_latest_results(skill_path, cli_results_dir, environ={})
+
+    assert resolved == historical
+
+
+@pytest.mark.parametrize(
+    "mutate_config",
+    [
+        lambda config: config.clear(),
+        lambda config: config.update({"agents": {}}),
+        lambda config: config["agents"]["opencode"].update({"model": ""}),
+        lambda config: config["harbor"].pop("n_attempts"),
+    ],
+    ids=("empty", "empty-agents", "empty-agent-model", "missing-harbor-field"),
+)
+def test_latest_results_rejects_authenticated_current_run_with_malformed_config_schema(
+    tmp_path: Path,
+    mutate_config,
+) -> None:
+    skill_path = tmp_path / "demo"
+    skill_path.mkdir()
+    cli_results_dir = tmp_path / "results"
+    root = external_results_root(cli_results_dir, skill_path)
+    historical = _write_completed_run(root, "20260705_120000")
+    current = _write_authenticated_current_run(root, "20260705_130000_222_bbbbbbbbbbbb")
+    config_path = current / "run_config.json"
+    result_path = current / "result.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    result = json.loads(result_path.read_text(encoding="utf-8"))
+    mutate_config(config)
+    result["run_config"] = config
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+    result_path.write_text(json.dumps(result), encoding="utf-8")
+
+    assert resolve_latest_results(skill_path, cli_results_dir, environ={}) == historical
+
+
+@pytest.mark.parametrize(
+    "mutate_result",
+    [
+        lambda result: result.update({"agents": {}}),
+        lambda result: result["agents"].update({"unexpected": result["agents"]["opencode"]}),
+        lambda result: result["agents"].update({"opencode": []}),
+        lambda result: result["agents"]["opencode"].update({"with_skill": []}),
+        lambda result: result["agents"]["opencode"]["model_resolution"].update({"model": "other-model"}),
+        lambda result: result.pop("execution_status"),
+    ],
+    ids=("empty", "extra-agent", "non-object-agent", "non-object-scores", "model-mismatch", "missing-status"),
+)
+def test_latest_results_rejects_authenticated_current_run_with_malformed_result_schema(
+    tmp_path: Path,
+    mutate_result,
+) -> None:
+    skill_path = tmp_path / "demo"
+    skill_path.mkdir()
+    cli_results_dir = tmp_path / "results"
+    root = external_results_root(cli_results_dir, skill_path)
+    historical = _write_completed_run(root, "20260705_120000")
+    current = _write_authenticated_current_run(root, "20260705_130000_222_bbbbbbbbbbbb")
+    result_path = current / "result.json"
+    result = json.loads(result_path.read_text(encoding="utf-8"))
+    mutate_result(result)
+    result_path.write_text(json.dumps(result), encoding="utf-8")
+
+    assert resolve_latest_results(skill_path, cli_results_dir, environ={}) == historical
+
+
+def test_latest_results_accepts_authenticated_current_run_with_relative_recorded_path_after_cwd_change(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    creation_cwd = tmp_path / "created-from"
+    creation_cwd.mkdir()
+    root = creation_cwd / "relative-results" / "demo"
+    run_id = "20260705_130000_222_bbbbbbbbbbbb"
+    current = _write_authenticated_current_run(
+        root,
+        run_id,
+        recorded_run_dir=str(Path("relative-results") / "demo" / run_id),
+        recorded_result_path=str(Path("relative-results") / "demo" / run_id / "result.json"),
+    )
+    different_cwd = tmp_path / "different-cwd"
+    different_cwd.mkdir()
+    monkeypatch.chdir(different_cwd)
+
+    assert results_location.run_directory_sort_key(current, require_completed_result=True) is not None
 
 
 def test_latest_results_same_timestamp_uses_completion_mtime(tmp_path: Path) -> None:
@@ -59,8 +293,8 @@ def test_latest_results_same_timestamp_uses_completion_mtime(tmp_path: Path) -> 
     skill_path.mkdir()
     cli_results_dir = tmp_path / "results"
     root = external_results_root(cli_results_dir, skill_path)
-    lexically_later = _write_completed_run(root, "20260705_130000_999_ffffffffffff")
-    completed_later = _write_completed_run(root, "20260705_130000_111_aaaaaaaaaaaa")
+    lexically_later = _write_authenticated_current_run(root, "20260705_130000_999_ffffffffffff")
+    completed_later = _write_authenticated_current_run(root, "20260705_130000_111_aaaaaaaaaaaa")
     os.utime(lexically_later / "result.json", ns=(100, 100))
     os.utime(completed_later / "result.json", ns=(200, 200))
 
@@ -74,8 +308,8 @@ def test_latest_results_same_completion_time_uses_deterministic_name_order(tmp_p
     skill_path.mkdir()
     cli_results_dir = tmp_path / "results"
     root = external_results_root(cli_results_dir, skill_path)
-    lexically_first = _write_completed_run(root, "20260705_130000_111_aaaaaaaaaaaa")
-    lexically_last = _write_completed_run(root, "20260705_130000_999_ffffffffffff")
+    lexically_first = _write_authenticated_current_run(root, "20260705_130000_111_aaaaaaaaaaaa")
+    lexically_last = _write_authenticated_current_run(root, "20260705_130000_999_ffffffffffff")
     os.utime(lexically_first / "result.json", ns=(100, 100))
     os.utime(lexically_last / "result.json", ns=(100, 100))
 

--- a/tests/test_results_location_legacy_compatibility.py
+++ b/tests/test_results_location_legacy_compatibility.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 import os
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
@@ -706,14 +707,26 @@ def test_rejects_run_config_changed_during_result_read(
     assert not _is_completed(run)
 
 
+@pytest.mark.parametrize("newest_first", [False, True], ids=("oldest-first", "newest-first"))
 def test_rejects_candidate_tree_swap_between_artifact_reads(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
+    *,
+    newest_first: bool,
 ) -> None:
-    run = _write_current_run(tmp_path)
+    completed = _write_current_run(tmp_path, "20260709_110000_111_aaaaaaaaaaaa")
+    unstable = _write_current_run(tmp_path, "20260709_120000_222_bbbbbbbbbbbb")
     moved = tmp_path / "moved-run"
+    real_iterdir = results_location.Path.iterdir
     real_read_bytes = results_location.SecureRoot.read_bytes
     swapped = False
+
+    candidates = (unstable, completed) if newest_first else (completed, unstable)
+
+    def stable_candidate_order(path: Path) -> Iterator[Path]:
+        if path == tmp_path:
+            return iter(candidates)
+        return real_iterdir(path)
 
     def swap_candidate(
         secure_root: results_location.SecureRoot,
@@ -723,12 +736,14 @@ def test_rejects_candidate_tree_swap_between_artifact_reads(
         expected: os.stat_result | None = None,
     ) -> tuple[bytes, os.stat_result]:
         nonlocal swapped
-        if not swapped and relative_path == Path("result.json"):
+        if not swapped and secure_root.root == unstable.absolute() and relative_path == Path("result.json"):
             swapped = True
-            run.rename(moved)
-            _write_current_run(tmp_path, run.name)
+            unstable.rename(moved)
+            _write_current_run(tmp_path, unstable.name)
         return real_read_bytes(secure_root, relative_path, max_bytes, expected=expected)
 
+    monkeypatch.setattr(results_location.Path, "iterdir", stable_candidate_order)
     monkeypatch.setattr(results_location.SecureRoot, "read_bytes", swap_candidate)
 
-    assert not _is_completed(run)
+    assert results_location._newest_run_dir(tmp_path) == completed
+    assert swapped

--- a/tests/test_results_location_legacy_compatibility.py
+++ b/tests/test_results_location_legacy_compatibility.py
@@ -1,0 +1,734 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Compatibility and race contracts for pre-result Tier 3 run directories."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from skillevaluator.tier3 import results_location
+from skillevaluator.tier3.output_provenance import GENERATED_OUTPUT_MARKER, mark_generated_output_root
+
+
+def _run(root: Path, name: str = "20260709_120000_1_aaaaaa") -> Path:
+    candidate = root / name
+    candidate.mkdir(parents=True)
+    return candidate
+
+
+def _write_legacy_run_config(run: Path, *agents: str) -> None:
+    (run / "run_config.json").write_text(
+        json.dumps(
+            {
+                "harbor": {"n_attempts": {"value": 1, "source": "ACES default"}},
+                "task_source": "evals_json",
+                "agents": {
+                    agent: {
+                        "agent": agent,
+                        "model": "test-model",
+                        "source": "test default",
+                        "occurrence": "1",
+                    }
+                    for agent in agents
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _pass_at_k_payload() -> dict[str, object]:
+    return {
+        "k": 1,
+        "pass_threshold": 0.5,
+        "stop_on_pass": False,
+        "passed_cases": 1,
+        "failed_cases": 0,
+        "total_cases": 1,
+        "rate": 1.0,
+        "attempts_used": 1,
+        "max_attempts_possible": 1,
+        "avg_attempts_used": 1.0,
+        "extra_cases": [],
+        "cases": {
+            "case": {
+                "passed": True,
+                "first_pass_attempt": 1,
+                "attempts_used": 1,
+                "attempts_skipped": 0,
+                "attempts_missing": 0,
+                "best_score": 0.8,
+                "attempts": [{"attempt": 1, "trial": "case__1", "score": 0.8, "passed": True}],
+            }
+        },
+    }
+
+
+def _successful_summary_payload(agent: str = "opencode") -> dict[str, object]:
+    return {
+        "agent": agent,
+        "model": "test-model",
+        "model_source": "test default",
+        "scores": {"security": 0.8},
+        "custom_scores": {},
+        "metric_set": "aces-default-v2",
+        "metrics": ["security"],
+        "dimensions": {"safety": {"score": 0.8, "sources": {"security": 1.0}}},
+        "num_trials": 1,
+        "pass_at_k": _pass_at_k_payload(),
+        "execution_status": "succeeded",
+        "execution_errors": [],
+        "expected_attempts": 1,
+        "scored_attempts": 1,
+        "job_failure": "",
+        "trial_failures": [],
+    }
+
+
+def _write_successful_summary(run: Path, *, agent: str = "opencode") -> Path:
+    summary = run / agent / "with-skill" / "summary.json"
+    summary.parent.mkdir(parents=True)
+    summary.write_text(json.dumps(_successful_summary_payload(agent)), encoding="utf-8")
+    return summary
+
+
+def _write_current_run(root: Path, name: str = "20260709_120000_1_aaaaaa") -> Path:
+    run = _run(root, name)
+    (run / "run_config.json").write_text("{}", encoding="utf-8")
+    (run / "result.json").write_text(json.dumps({"run_id": name, "agents": {}}), encoding="utf-8")
+    return run
+
+
+def _is_completed(run: Path) -> bool:
+    return results_location.run_directory_sort_key(run, require_completed_result=True) is not None
+
+
+def test_rejects_current_run_with_list_valued_run_config(tmp_path: Path) -> None:
+    run = _write_current_run(tmp_path)
+    (run / "run_config.json").write_text("[]", encoding="utf-8")
+
+    assert not _is_completed(run)
+
+
+def test_accepts_pre_result_run_with_valid_summary(tmp_path: Path) -> None:
+    run = _run(tmp_path)
+    _write_legacy_run_config(run, "opencode")
+    _write_successful_summary(run)
+
+    assert _is_completed(run)
+
+
+def test_accepts_summary_from_before_truthful_status_fields(tmp_path: Path) -> None:
+    run = _run(tmp_path)
+    _write_legacy_run_config(run, "opencode")
+    summary = run / "opencode" / "with-skill" / "summary.json"
+    summary.parent.mkdir(parents=True)
+    summary.write_text(
+        json.dumps(
+            {
+                "agent": "opencode",
+                "model": "test-model",
+                "model_source": "test default",
+                "scores": {"security": 0.8},
+                "custom_scores": {},
+                "metric_set": "aces-default-v2",
+                "metrics": ["security"],
+                "dimensions": {"safety": {"score": 0.8, "sources": {"security": 1.0}}},
+                "num_trials": 1,
+                "pass_at_k": _pass_at_k_payload(),
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert _is_completed(run)
+
+
+@pytest.mark.parametrize(
+    "run_config_payload",
+    [
+        "not-json",
+        "[]",
+        "null",
+        "1",
+        "{}",
+        '{"agents": {}}',
+        json.dumps(
+            {
+                "harbor": {"n_attempts": {"value": 1, "source": "ACES default"}},
+                "task_source": "generated",
+                "agents": {
+                    "opencode": {
+                        "agent": "opencode",
+                        "model": "test-model",
+                        "source": "test default",
+                        "occurrence": "1",
+                    }
+                },
+            }
+        ),
+        json.dumps(
+            {
+                "harbor": {"n_attempts": {"value": 1, "source": "ACES default"}},
+                "task_source": "evals_json",
+                "agents": {"opencode": {}},
+            }
+        ),
+    ],
+)
+def test_rejects_legacy_run_with_invalid_run_config(tmp_path: Path, run_config_payload: str) -> None:
+    run = _run(tmp_path)
+    (run / "run_config.json").write_text(run_config_payload, encoding="utf-8")
+    _write_successful_summary(run)
+
+    assert not _is_completed(run)
+
+
+def test_requires_summary_for_every_configured_agent(tmp_path: Path) -> None:
+    run = _run(tmp_path)
+    _write_legacy_run_config(run, "opencode", "claude")
+    _write_successful_summary(run, agent="opencode")
+
+    assert not _is_completed(run)
+
+
+def test_rejects_malformed_present_baseline_summary(tmp_path: Path) -> None:
+    run = _run(tmp_path)
+    _write_legacy_run_config(run, "opencode")
+    _write_successful_summary(run)
+    baseline = run / "opencode" / "without-skill" / "summary.json"
+    baseline.parent.mkdir()
+    baseline.write_text("not-json", encoding="utf-8")
+
+    assert not _is_completed(run)
+
+
+def test_rejects_ambiguous_flat_and_nested_summaries(tmp_path: Path) -> None:
+    run = _run(tmp_path)
+    _write_legacy_run_config(run, "opencode")
+    _write_successful_summary(run)
+    (run / "opencode" / "summary.json").write_text(
+        json.dumps(_successful_summary_payload()),
+        encoding="utf-8",
+    )
+
+    assert not _is_completed(run)
+
+
+def test_accepts_authentic_pre_status_custom_only_summary(tmp_path: Path) -> None:
+    run = _run(tmp_path)
+    _write_legacy_run_config(run, "opencode")
+    payload = _successful_summary_payload()
+    for field in (
+        "execution_status",
+        "execution_errors",
+        "expected_attempts",
+        "scored_attempts",
+        "job_failure",
+        "trial_failures",
+    ):
+        payload.pop(field)
+    payload.update(
+        {
+            "scores": {},
+            "custom_scores": {},
+            "metric_set": "custom-only",
+            "metrics": [],
+            "dimensions": {},
+        }
+    )
+    summary = run / "opencode" / "with-skill" / "summary.json"
+    summary.parent.mkdir(parents=True)
+    summary.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert _is_completed(run)
+
+
+def test_accepts_truthful_status_era_failed_summary(tmp_path: Path) -> None:
+    run = _run(tmp_path)
+    _write_legacy_run_config(run, "opencode")
+    payload = _successful_summary_payload()
+    payload.update(
+        {
+            "scores": {},
+            "dimensions": {},
+            "num_trials": 0,
+            "pass_at_k": {
+                "k": 1,
+                "pass_threshold": 0.5,
+                "stop_on_pass": False,
+                "passed_cases": 0,
+                "failed_cases": 1,
+                "total_cases": 1,
+                "rate": 0.0,
+                "attempts_used": 0,
+                "max_attempts_possible": 1,
+                "avg_attempts_used": 0.0,
+                "extra_cases": [],
+                "cases": {
+                    "case": {
+                        "passed": False,
+                        "first_pass_attempt": None,
+                        "attempts_used": 0,
+                        "attempts_skipped": 0,
+                        "attempts_missing": 1,
+                        "best_score": None,
+                        "attempts": [],
+                    }
+                },
+            },
+            "execution_status": "failed",
+            "execution_errors": ["Harbor job directory was not created"],
+            "expected_attempts": 1,
+            "scored_attempts": 0,
+            "job_failure": "Harbor job directory was not created",
+            "trial_failures": [],
+        }
+    )
+    summary = run / "opencode" / "with-skill" / "summary.json"
+    summary.parent.mkdir(parents=True)
+    summary.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert _is_completed(run)
+
+
+def test_rejects_status_summary_with_incoherent_scored_attempts(tmp_path: Path) -> None:
+    run = _run(tmp_path)
+    _write_legacy_run_config(run, "opencode")
+    payload = _successful_summary_payload()
+    payload.update(
+        {
+            "execution_status": "failed",
+            "execution_errors": ["Harbor reported a failure"],
+            "scored_attempts": 0,
+            "job_failure": "Harbor reported a failure",
+        }
+    )
+    summary = _write_successful_summary(run)
+    summary.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert not _is_completed(run)
+
+
+def test_accepts_truthful_failed_excess_attempt_coverage(tmp_path: Path) -> None:
+    run = _run(tmp_path)
+    _write_legacy_run_config(run, "opencode")
+    payload = _successful_summary_payload()
+    pass_at_k = _pass_at_k_payload()
+    attempts = [
+        {"attempt": 1, "trial": "case__attempt1", "score": 0.8, "passed": True},
+        {"attempt": 2, "trial": "case__attempt2", "score": 0.7, "passed": True},
+    ]
+    pass_at_k.update({"attempts_used": 2, "avg_attempts_used": 2.0})
+    pass_at_k["cases"] = {
+        "case": {
+            "passed": True,
+            "first_pass_attempt": 1,
+            "attempts_used": 2,
+            "attempts_skipped": 0,
+            "attempts_missing": 0,
+            "best_score": 0.8,
+            "attempts": attempts,
+        }
+    }
+    payload.update(
+        {
+            "num_trials": 2,
+            "pass_at_k": pass_at_k,
+            "execution_status": "failed",
+            "execution_errors": ["Excess scored attempts for cases: case", "Scored attempt coverage is 2/1"],
+            "expected_attempts": 1,
+            "scored_attempts": 2,
+            "job_failure": "",
+        }
+    )
+    summary = _write_successful_summary(run)
+    summary.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert _is_completed(run)
+
+
+def test_rejects_legacy_summary_without_authentic_pass_at_k(tmp_path: Path) -> None:
+    run = _run(tmp_path)
+    _write_legacy_run_config(run, "opencode")
+    payload = _successful_summary_payload()
+    payload["pass_at_k"] = {}
+    summary = run / "opencode" / "with-skill" / "summary.json"
+    summary.parent.mkdir(parents=True)
+    summary.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert not _is_completed(run)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("passed_cases", 0),
+        ("attempts_used", 0),
+        ("rate", 0.0),
+    ],
+)
+def test_rejects_incoherent_legacy_pass_at_k_totals(
+    tmp_path: Path,
+    field: str,
+    value: object,
+) -> None:
+    run = _run(tmp_path)
+    _write_legacy_run_config(run, "opencode")
+    payload = _successful_summary_payload()
+    payload["pass_at_k"] = {**_pass_at_k_payload(), field: value}
+    summary = _write_successful_summary(run)
+    summary.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert not _is_completed(run)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("passed", False),
+        ("first_pass_attempt", None),
+        ("best_score", 0.7),
+        ("attempts_missing", 1),
+    ],
+)
+def test_rejects_incoherent_legacy_pass_at_k_case(
+    tmp_path: Path,
+    field: str,
+    value: object,
+) -> None:
+    run = _run(tmp_path)
+    _write_legacy_run_config(run, "opencode")
+    payload = _successful_summary_payload()
+    pass_at_k = _pass_at_k_payload()
+    pass_at_k["cases"] = {
+        "case": {
+            **pass_at_k["cases"]["case"],
+            field: value,
+        }
+    }
+    payload["pass_at_k"] = pass_at_k
+    summary = _write_successful_summary(run)
+    summary.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert not _is_completed(run)
+
+
+def test_rejects_legacy_summary_for_wrong_agent(tmp_path: Path) -> None:
+    run = _run(tmp_path)
+    _write_legacy_run_config(run, "opencode")
+    summary = _write_successful_summary(run)
+    summary.write_text(json.dumps(_successful_summary_payload("claude")), encoding="utf-8")
+
+    assert not _is_completed(run)
+
+
+def test_rejects_legacy_run_with_malformed_sibling_summary(tmp_path: Path) -> None:
+    run = _run(tmp_path)
+    _write_legacy_run_config(run, "opencode", "claude")
+    _write_successful_summary(run)
+    malformed = run / "claude" / "with-skill" / "summary.json"
+    malformed.parent.mkdir(parents=True)
+    malformed.write_text("not-json", encoding="utf-8")
+
+    assert not _is_completed(run)
+
+
+@pytest.mark.parametrize(
+    "summary_payload",
+    [
+        {**_successful_summary_payload(), "scores": {"security": 0.8, "malformed": "not-a-number"}},
+        {**_successful_summary_payload(), "scores": {"security": 0.8, "non_finite": float("nan")}},
+        {**_successful_summary_payload(), "scores": {"security": 0.8, "overflowing": 10**1000}},
+        {**_successful_summary_payload(), "custom_scores": {"quality": 0.6, "malformed": None}},
+        {key: value for key, value in _successful_summary_payload().items() if key != "scores"},
+        {key: value for key, value in _successful_summary_payload().items() if key != "custom_scores"},
+        {key: value for key, value in _successful_summary_payload().items() if key != "model"},
+        {key: value for key, value in _successful_summary_payload().items() if key != "model_source"},
+        {key: value for key, value in _successful_summary_payload().items() if key != "metric_set"},
+        {key: value for key, value in _successful_summary_payload().items() if key != "metrics"},
+        {key: value for key, value in _successful_summary_payload().items() if key != "dimensions"},
+        {key: value for key, value in _successful_summary_payload().items() if key != "pass_at_k"},
+        {key: value for key, value in _successful_summary_payload().items() if key != "job_failure"},
+        {key: value for key, value in _successful_summary_payload().items() if key != "trial_failures"},
+        {**_successful_summary_payload(), "scores": []},
+    ],
+)
+def test_rejects_legacy_summary_with_incomplete_score_maps(
+    tmp_path: Path,
+    summary_payload: dict[str, object],
+) -> None:
+    run = _run(tmp_path)
+    _write_legacy_run_config(run, "opencode")
+    summary = _write_successful_summary(run)
+    summary.write_text(json.dumps(summary_payload), encoding="utf-8")
+
+    assert not _is_completed(run)
+
+
+@pytest.mark.parametrize(
+    "optional_fields",
+    [
+        {"execution_status": "succeeded"},
+        {"execution_errors": []},
+        {"execution_status": "succeeded", "execution_errors": []},
+        {"expected_attempts": 1, "scored_attempts": 1},
+        {"execution_status": "succeeded", "execution_errors": [], "expected_attempts": 1},
+    ],
+)
+def test_rejects_legacy_summary_with_partial_completion_fields(
+    tmp_path: Path,
+    optional_fields: dict[str, object],
+) -> None:
+    run = _run(tmp_path)
+    _write_legacy_run_config(run, "opencode")
+    payload = _successful_summary_payload()
+    for field in (
+        "execution_status",
+        "execution_errors",
+        "expected_attempts",
+        "scored_attempts",
+        "job_failure",
+        "trial_failures",
+    ):
+        payload.pop(field)
+    payload.update(optional_fields)
+    summary = _write_successful_summary(run)
+    summary.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert not _is_completed(run)
+
+
+@pytest.mark.parametrize(
+    "summary_payload",
+    [
+        "not-json",
+        json.dumps([]),
+        json.dumps(
+            {
+                "agent": "opencode",
+                "scores": {"security": 0.8},
+                "custom_scores": {},
+                "num_trials": 1,
+                "execution_status": "failed",
+                "execution_errors": ["trial failed"],
+                "expected_attempts": 1,
+                "scored_attempts": 0,
+            }
+        ),
+        json.dumps(
+            {
+                "agent": "opencode",
+                "scores": {"security": 0.8},
+                "custom_scores": {},
+                "num_trials": 1,
+                "execution_status": "succeeded",
+                "execution_errors": [],
+                "expected_attempts": 2,
+                "scored_attempts": 1,
+            }
+        ),
+    ],
+)
+def test_rejects_legacy_run_without_valid_completion_summary(tmp_path: Path, summary_payload: str) -> None:
+    run = _run(tmp_path)
+    _write_legacy_run_config(run, "opencode")
+    summary = run / "opencode" / "with-skill" / "summary.json"
+    summary.parent.mkdir(parents=True)
+    summary.write_text(summary_payload, encoding="utf-8")
+
+    assert not _is_completed(run)
+
+
+def test_rejects_authenticated_current_partial_with_legacy_summary(tmp_path: Path) -> None:
+    run = _run(tmp_path)
+    mark_generated_output_root(run)
+    _write_legacy_run_config(run, "opencode")
+    _write_successful_summary(run)
+
+    assert not _is_completed(run)
+
+
+def test_rejects_invalid_current_marker_downgrade_to_legacy(tmp_path: Path) -> None:
+    run = _run(tmp_path)
+    (run / GENERATED_OUTPUT_MARKER).write_text("tampered", encoding="utf-8")
+    _write_legacy_run_config(run, "opencode")
+    _write_successful_summary(run)
+
+    assert not _is_completed(run)
+
+
+def test_rejects_legacy_run_config_replaced_before_open(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    run = _run(tmp_path)
+    run_config = run / "run_config.json"
+    _write_legacy_run_config(run, "opencode")
+    run_config_payload = run_config.read_text(encoding="utf-8")
+    _write_successful_summary(run)
+    real_read_bytes = results_location.SecureRoot.read_bytes
+    replaced = False
+
+    def replace_before_open(
+        secure_root: results_location.SecureRoot,
+        relative_path: Path,
+        max_bytes: int,
+        *,
+        expected: os.stat_result | None = None,
+    ) -> tuple[bytes, os.stat_result]:
+        nonlocal replaced
+        if not replaced and relative_path == Path("run_config.json"):
+            replacement = run_config.with_suffix(".replacement")
+            replacement.write_text(run_config_payload, encoding="utf-8")
+            replacement.replace(run_config)
+            replaced = True
+        return real_read_bytes(secure_root, relative_path, max_bytes, expected=expected)
+
+    monkeypatch.setattr(results_location.SecureRoot, "read_bytes", replace_before_open)
+
+    assert not _is_completed(run)
+
+
+def test_rejects_same_inode_summary_rewrite_with_restored_mtime(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    run = _run(tmp_path)
+    _write_legacy_run_config(run, "opencode")
+    summary = _write_successful_summary(run)
+    summary_metadata = summary.stat()
+    summary_inode = summary_metadata.st_ino
+    original = summary.read_text(encoding="utf-8")
+    rewritten = original.replace("0.8", "0.9")
+    assert len(rewritten) == len(original)
+    real_read = os.read
+    rewritten_once = False
+
+    def rewrite_during_read(fd: int, length: int) -> bytes:
+        nonlocal rewritten_once
+        if not rewritten_once and os.fstat(fd).st_ino == summary_inode:
+            summary.write_text(rewritten, encoding="utf-8")
+            os.utime(summary, ns=(summary_metadata.st_atime_ns, summary_metadata.st_mtime_ns))
+            rewritten_once = True
+        return real_read(fd, length)
+
+    monkeypatch.setattr(results_location.os, "read", rewrite_during_read)
+
+    assert not _is_completed(run)
+
+
+def test_rejects_summary_parent_swapped_to_link_before_read(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    run = _run(tmp_path)
+    _write_legacy_run_config(run, "opencode")
+    summary = _write_successful_summary(run)
+    condition_dir = summary.parent
+    moved = run / "opencode" / "moved-with-skill"
+    real_read_bytes = results_location.SecureRoot.read_bytes
+    swapped = False
+
+    def swap_summary_parent(
+        secure_root: results_location.SecureRoot,
+        relative_path: Path,
+        max_bytes: int,
+        *,
+        expected: os.stat_result | None = None,
+    ) -> tuple[bytes, os.stat_result]:
+        nonlocal swapped
+        if not swapped and relative_path == Path("opencode/with-skill/summary.json"):
+            swapped = True
+            condition_dir.rename(moved)
+            condition_dir.symlink_to(moved, target_is_directory=True)
+        return real_read_bytes(secure_root, relative_path, max_bytes, expected=expected)
+
+    monkeypatch.setattr(results_location.SecureRoot, "read_bytes", swap_summary_parent)
+
+    assert not _is_completed(run)
+
+
+def test_rejects_current_result_replaced_during_read(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    run = _write_current_run(tmp_path)
+    result_path = run / "result.json"
+    result_inode = result_path.stat().st_ino
+    result_payload = result_path.read_text(encoding="utf-8")
+    real_read = os.read
+    replaced = False
+
+    def replace_after_read(fd: int, length: int) -> bytes:
+        nonlocal replaced
+        content = real_read(fd, length)
+        if not replaced and os.fstat(fd).st_ino == result_inode:
+            replacement = result_path.with_suffix(".replacement")
+            replacement.write_text(result_payload, encoding="utf-8")
+            replacement.replace(result_path)
+            replaced = True
+        return content
+
+    monkeypatch.setattr(results_location.os, "read", replace_after_read)
+
+    assert not _is_completed(run)
+
+
+def test_rejects_run_config_changed_during_result_read(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    run = _write_current_run(tmp_path)
+    result_path = run / "result.json"
+    result_inode = result_path.stat().st_ino
+    run_config = run / "run_config.json"
+    config_metadata = run_config.stat()
+    real_read = os.read
+    changed = False
+
+    def change_config_after_result_read(fd: int, length: int) -> bytes:
+        nonlocal changed
+        content = real_read(fd, length)
+        if not changed and os.fstat(fd).st_ino == result_inode:
+            run_config.write_text("[]", encoding="utf-8")
+            os.utime(run_config, ns=(config_metadata.st_atime_ns, config_metadata.st_mtime_ns))
+            changed = True
+        return content
+
+    monkeypatch.setattr(results_location.os, "read", change_config_after_result_read)
+
+    assert not _is_completed(run)
+
+
+def test_rejects_candidate_tree_swap_between_artifact_reads(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    run = _write_current_run(tmp_path)
+    moved = tmp_path / "moved-run"
+    real_read_bytes = results_location.SecureRoot.read_bytes
+    swapped = False
+
+    def swap_candidate(
+        secure_root: results_location.SecureRoot,
+        relative_path: Path,
+        max_bytes: int,
+        *,
+        expected: os.stat_result | None = None,
+    ) -> tuple[bytes, os.stat_result]:
+        nonlocal swapped
+        if not swapped and relative_path == Path("result.json"):
+            swapped = True
+            run.rename(moved)
+            _write_current_run(tmp_path, run.name)
+        return real_read_bytes(secure_root, relative_path, max_bytes, expected=expected)
+
+    monkeypatch.setattr(results_location.SecureRoot, "read_bytes", swap_candidate)
+
+    assert not _is_completed(run)

--- a/tests/test_results_location_legacy_compatibility.py
+++ b/tests/test_results_location_legacy_compatibility.py
@@ -9,15 +9,16 @@ import json
 import os
 from collections.abc import Iterator
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
-from skillevaluator.tier3 import results_location
+from skillevaluator.tier3 import output_provenance, results_location
 from skillevaluator.tier3.harbor.metrics import DEFAULT_METRIC_SET
 from skillevaluator.tier3.output_provenance import GENERATED_OUTPUT_MARKER, mark_generated_output_root
 
 
-def _run(root: Path, name: str = "20260709_120000_1_aaaaaa") -> Path:
+def _run(root: Path, name: str = "20260709_120000") -> Path:
     candidate = root / name
     candidate.mkdir(parents=True)
     return candidate
@@ -108,15 +109,114 @@ def _write_successful_summary(run: Path, *, agent: str = "opencode") -> Path:
     return summary
 
 
-def _write_current_run(root: Path, name: str = "20260709_120000_1_aaaaaa") -> Path:
+def _write_current_run(root: Path, name: str = "20260709_120000_1_aaaaaaaaaaaa") -> Path:
     run = _run(root, name)
-    (run / "run_config.json").write_text("{}", encoding="utf-8")
-    (run / "result.json").write_text(json.dumps({"run_id": name, "agents": {}}), encoding="utf-8")
+    mark_generated_output_root(run)
+    run_config: dict[str, object] = {
+        "config_file": "none",
+        "harbor": {
+            "environment": {"value": "local", "source": "test"},
+            "n_attempts": 1,
+            "stop_on_pass": False,
+            "n_concurrent": 1,
+            "timeout_multiplier": 1.0,
+            "base_image_mode": "disabled",
+            "jobs_retained": False,
+        },
+        "provider": {"name": "nvidia", "model": "test-model"},
+        "task_source": "evals_json",
+        "grading": {"mode": "default"},
+        "agents": {"opencode": {"agent": "opencode", "model": "test-model", "source": "test default"}},
+    }
+    agent_result = {
+        "model": "test-model",
+        "model_source": "test default",
+        "model_resolution": {"model": "test-model", "source": "test default"},
+        "with_skill": {"security": 0.8},
+        "without_skill": {},
+        "custom_with_skill": {},
+        "custom_without_skill": {},
+        "dimensions_with_skill": {},
+        "dimensions_without_skill": {},
+        "lift": {},
+        "custom_lift": {},
+        "pass_at_k": {"with_skill": {}, "without_skill": {}, "lift": {}},
+        "security_attribution": {},
+        "agent_runtime_failures": {"with_skill": [], "without_skill": []},
+        "trial_failures": {"with_skill": [], "without_skill": []},
+        "job_failures": {"with_skill": "", "without_skill": ""},
+        "conditions": {"with_skill": {}, "without_skill": {}},
+        "execution_status": "succeeded",
+        "execution_errors": [],
+        "expected_attempts": 1,
+        "scored_attempts": 1,
+        "num_trials_with": 1,
+        "num_trials_without": 0,
+        "output_dir": str((run / "opencode").resolve()),
+    }
+    (run / "run_config.json").write_text(json.dumps(run_config), encoding="utf-8")
+    (run / "result.json").write_text(
+        json.dumps(
+            {
+                "skill_name": "demo",
+                "run_id": name,
+                "run_dir": str(run),
+                "result_path": str((run / "result.json").resolve()),
+                "run_config": run_config,
+                "agents": {"opencode": agent_result},
+                "attempt_policy": {
+                    "max_attempts": 1,
+                    "pass_threshold": 0.5,
+                    "stop_on_pass": False,
+                    "score_definition": "test",
+                },
+                "execution_status": "succeeded",
+                "execution_errors": [],
+                "report_status": "complete",
+                "duration_seconds": 1.0,
+            }
+        ),
+        encoding="utf-8",
+    )
     return run
 
 
 def _is_completed(run: Path) -> bool:
     return results_location.run_directory_sort_key(run, require_completed_result=True) is not None
+
+
+def test_current_run_discovery_accepts_windows_crt_descriptor_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Windows path and CRT descriptor stat identities are not comparable."""
+    run = _write_current_run(tmp_path)
+    original_read_bytes = results_location.SecureRoot.read_bytes
+
+    def read_with_windows_crt_identity(
+        secure_root: results_location.SecureRoot,
+        relative_path: Path,
+        max_bytes: int,
+        *,
+        expected: os.stat_result | None = None,
+    ) -> tuple[bytes, object]:
+        raw, opened = original_read_bytes(secure_root, relative_path, max_bytes, expected=expected)
+        return raw, SimpleNamespace(
+            st_dev=opened.st_dev + 10_000,
+            st_ino=opened.st_ino + 10_000,
+            st_mode=opened.st_mode,
+            st_nlink=opened.st_nlink,
+            st_size=opened.st_size,
+            st_uid=opened.st_uid,
+            st_mtime_ns=opened.st_mtime_ns,
+            st_ctime_ns=opened.st_ctime_ns,
+        )
+
+    monkeypatch.setattr(results_location, "_PATH_DESCRIPTOR_IDENTITIES_COMPARABLE", False, raising=False)
+    monkeypatch.setattr(output_provenance, "_PATH_DESCRIPTOR_IDENTITIES_COMPARABLE", False)
+    monkeypatch.setattr(results_location.SecureRoot, "read_bytes", read_with_windows_crt_identity)
+
+    assert _is_completed(run)
 
 
 def test_rejects_current_run_with_list_valued_run_config(tmp_path: Path) -> None:

--- a/tests/test_results_location_legacy_compatibility.py
+++ b/tests/test_results_location_legacy_compatibility.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import pytest
 
 from skillevaluator.tier3 import results_location
+from skillevaluator.tier3.harbor.metrics import DEFAULT_METRIC_SET
 from skillevaluator.tier3.output_provenance import GENERATED_OUTPUT_MARKER, mark_generated_output_root
 
 
@@ -26,14 +27,23 @@ def _write_legacy_run_config(run: Path, *agents: str) -> None:
     (run / "run_config.json").write_text(
         json.dumps(
             {
-                "harbor": {"n_attempts": {"value": 1, "source": "ACES default"}},
+                "harbor": {
+                    "environment": {"value": "docker", "source": "CLI"},
+                    "n_attempts": 1,
+                    "stop_on_pass": False,
+                    "n_concurrent": 1,
+                    "timeout_multiplier": 1.0,
+                    "base_image_mode": "auto",
+                    "jobs_retained": False,
+                },
+                "provider": {"name": "nvidia", "model": "test-model"},
                 "task_source": "evals_json",
+                "grading": {"mode": "default"},
                 "agents": {
                     agent: {
                         "agent": agent,
                         "model": "test-model",
                         "source": "test default",
-                        "occurrence": "1",
                     }
                     for agent in agents
                 },
@@ -77,7 +87,7 @@ def _successful_summary_payload(agent: str = "opencode") -> dict[str, object]:
         "model_source": "test default",
         "scores": {"security": 0.8},
         "custom_scores": {},
-        "metric_set": "aces-default-v2",
+        "metric_set": DEFAULT_METRIC_SET,
         "metrics": ["security"],
         "dimensions": {"safety": {"score": 0.8, "sources": {"security": 1.0}}},
         "num_trials": 1,
@@ -116,12 +126,108 @@ def test_rejects_current_run_with_list_valued_run_config(tmp_path: Path) -> None
     assert not _is_completed(run)
 
 
-def test_accepts_pre_result_run_with_valid_summary(tmp_path: Path) -> None:
+def test_accepts_pre_result_run_with_public_runner_config_shape(tmp_path: Path) -> None:
     run = _run(tmp_path)
     _write_legacy_run_config(run, "opencode")
     _write_successful_summary(run)
 
     assert _is_completed(run)
+
+
+@pytest.mark.parametrize("sidecar_name", ["harbor-run-logs", "astra-cleanup"])
+def test_accepts_opaque_pre_result_runtime_sidecar(tmp_path: Path, sidecar_name: str) -> None:
+    run = _run(tmp_path)
+    _write_legacy_run_config(run, "opencode")
+    _write_successful_summary(run)
+    sidecar = run / sidecar_name
+    sidecar.mkdir()
+    (sidecar / "unexpected.log").write_text("opaque runtime data", encoding="utf-8")
+    nested = sidecar / "unexpected-directory"
+    nested.mkdir()
+    (nested / "payload.bin").write_bytes(b"opaque")
+
+    assert _is_completed(run)
+
+
+@pytest.mark.parametrize("sidecar_name", ["harbor-run-logs", "astra-cleanup"])
+def test_accepts_link_inside_opaque_pre_result_runtime_sidecar(tmp_path: Path, sidecar_name: str) -> None:
+    run = _run(tmp_path)
+    _write_legacy_run_config(run, "opencode")
+    _write_successful_summary(run)
+    sidecar = run / sidecar_name
+    sidecar.mkdir()
+    outside = tmp_path / f"outside-{sidecar_name}.log"
+    outside.write_text("opaque runtime data", encoding="utf-8")
+    try:
+        (sidecar / "unexpected-link").symlink_to(outside)
+    except OSError as exc:
+        pytest.skip(f"symlink creation unavailable: {exc}")
+
+    assert _is_completed(run)
+
+
+@pytest.mark.parametrize("sibling_name", ["staged", "unknown-runtime"])
+def test_rejects_unknown_pre_result_sibling_directory(tmp_path: Path, sibling_name: str) -> None:
+    run = _run(tmp_path)
+    _write_legacy_run_config(run, "opencode")
+    _write_successful_summary(run)
+    (run / sibling_name).mkdir()
+
+    assert not _is_completed(run)
+
+
+def test_accepts_pre_result_run_with_valid_optional_occurrence(tmp_path: Path) -> None:
+    run = _run(tmp_path)
+    _write_legacy_run_config(run, "opencode")
+    config_path = run / "run_config.json"
+    payload = json.loads(config_path.read_text(encoding="utf-8"))
+    payload["agents"]["opencode"]["occurrence"] = "2"
+    config_path.write_text(json.dumps(payload), encoding="utf-8")
+    _write_successful_summary(run)
+
+    assert _is_completed(run)
+
+
+@pytest.mark.parametrize(
+    "occurrence",
+    [
+        None,
+        "",
+        "0",
+        "not-a-number",
+        "\N{SUPERSCRIPT TWO}",
+        "\N{FULLWIDTH DIGIT ONE}",
+        "\N{ARABIC-INDIC DIGIT TWO}",
+        1,
+    ],
+)
+def test_rejects_pre_result_run_with_invalid_optional_occurrence(
+    tmp_path: Path,
+    occurrence: object,
+) -> None:
+    run = _run(tmp_path)
+    _write_legacy_run_config(run, "opencode")
+    config_path = run / "run_config.json"
+    payload = json.loads(config_path.read_text(encoding="utf-8"))
+    payload["agents"]["opencode"]["occurrence"] = occurrence
+    config_path.write_text(json.dumps(payload), encoding="utf-8")
+    _write_successful_summary(run)
+
+    assert not _is_completed(run)
+
+
+def test_rejects_oversized_ascii_occurrence_without_raising(tmp_path: Path) -> None:
+    run = _run(tmp_path)
+    _write_legacy_run_config(run, "opencode")
+    config_path = run / "run_config.json"
+    payload = json.loads(config_path.read_text(encoding="utf-8"))
+    payload["agents"]["opencode"]["occurrence"] = "9" * 5000
+
+    assert results_location._legacy_run_agents(payload) is None
+
+    config_path.write_text(json.dumps(payload), encoding="utf-8")
+    _write_successful_summary(run)
+    assert not _is_completed(run)
 
 
 def test_accepts_summary_from_before_truthful_status_fields(tmp_path: Path) -> None:

--- a/tests/test_tier3_compare.py
+++ b/tests/test_tier3_compare.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import pytest
 
 from skillevaluator.tier3.commands import compare_results
+from skillevaluator.tier3.output_provenance import mark_generated_output_root
 
 
 def _complete_current_run(run_dir: Path) -> None:
@@ -189,6 +190,8 @@ def test_compare_same_timestamp_unique_runs_uses_result_completion_time(
         (completed_later, 0.9, 200),
     ):
         run_dir = skill_results / run_id
+        run_dir.mkdir(parents=True)
+        mark_generated_output_root(run_dir)
         summary_dir = run_dir / "opencode" / "with-skill"
         summary_dir.mkdir(parents=True)
         (summary_dir / "summary.json").write_text(
@@ -196,8 +199,72 @@ def test_compare_same_timestamp_unique_runs_uses_result_completion_time(
             encoding="utf-8",
         )
         result_path = run_dir / "result.json"
-        (run_dir / "run_config.json").write_text("{}", encoding="utf-8")
-        result_path.write_text(json.dumps({"run_id": run_id, "agents": {}}), encoding="utf-8")
+        run_config: dict[str, object] = {
+            "config_file": "none",
+            "harbor": {
+                "environment": {"value": "local", "source": "test"},
+                "n_attempts": 1,
+                "stop_on_pass": False,
+                "n_concurrent": 1,
+                "timeout_multiplier": 1.0,
+                "base_image_mode": "disabled",
+                "jobs_retained": False,
+            },
+            "provider": {"name": "nvidia", "model": "test-model"},
+            "task_source": "evals_json",
+            "grading": {"mode": "default"},
+            "agents": {"opencode": {"agent": "opencode", "model": "test-model", "source": "test default"}},
+        }
+        agent_result = {
+            "model": "test-model",
+            "model_source": "test default",
+            "model_resolution": {"model": "test-model", "source": "test default"},
+            "with_skill": {"security": score},
+            "without_skill": {},
+            "custom_with_skill": {},
+            "custom_without_skill": {},
+            "dimensions_with_skill": {},
+            "dimensions_without_skill": {},
+            "lift": {},
+            "custom_lift": {},
+            "pass_at_k": {"with_skill": {}, "without_skill": {}, "lift": {}},
+            "security_attribution": {},
+            "agent_runtime_failures": {"with_skill": [], "without_skill": []},
+            "trial_failures": {"with_skill": [], "without_skill": []},
+            "job_failures": {"with_skill": "", "without_skill": ""},
+            "conditions": {"with_skill": {}, "without_skill": {}},
+            "execution_status": "succeeded",
+            "execution_errors": [],
+            "expected_attempts": 1,
+            "scored_attempts": 1,
+            "num_trials_with": 1,
+            "num_trials_without": 0,
+            "output_dir": str((run_dir / "opencode").resolve()),
+        }
+        (run_dir / "run_config.json").write_text(json.dumps(run_config), encoding="utf-8")
+        result_path.write_text(
+            json.dumps(
+                {
+                    "skill_name": skill_path.name,
+                    "run_id": run_id,
+                    "run_dir": str(run_dir),
+                    "result_path": str(result_path.resolve()),
+                    "run_config": run_config,
+                    "agents": {"opencode": agent_result},
+                    "attempt_policy": {
+                        "max_attempts": 1,
+                        "pass_threshold": 0.5,
+                        "stop_on_pass": False,
+                        "score_definition": "test",
+                    },
+                    "execution_status": "succeeded",
+                    "execution_errors": [],
+                    "report_status": "complete",
+                    "duration_seconds": 1.0,
+                }
+            ),
+            encoding="utf-8",
+        )
         os.utime(result_path, ns=(completed_ns, completed_ns))
 
     assert compare_results(skill_path, results_dir=tmp_path / "results") == 0
@@ -266,7 +333,7 @@ def test_compare_consumes_authenticated_timestamped_pre_status_run(
 ) -> None:
     skill_path = tmp_path / "demo"
     skill_path.mkdir()
-    run_id = "20260709_010000_111_aaaaaaaaaaaa"
+    run_id = "20260709_010000"
     _write_authentic_pre_status_run(tmp_path / "results" / skill_path.name, run_id)
 
     assert compare_results(skill_path, results_dir=tmp_path / "results") == 0

--- a/tests/test_tier3_compare.py
+++ b/tests/test_tier3_compare.py
@@ -15,10 +15,82 @@ from skillevaluator.tier3.commands import compare_results
 
 
 def _complete_current_run(run_dir: Path) -> None:
+    (run_dir / "run_config.json").write_text("{}", encoding="utf-8")
     (run_dir / "result.json").write_text(
         json.dumps({"run_id": run_dir.name, "agents": {}}),
         encoding="utf-8",
     )
+
+
+def _write_authentic_pre_status_run(root: Path, run_id: str, *, score: float = 0.8) -> Path:
+    run_dir = root / run_id
+    summary_dir = run_dir / "opencode" / "with-skill"
+    summary_dir.mkdir(parents=True)
+    (run_dir / "run_config.json").write_text(
+        json.dumps(
+            {
+                "harbor": {"n_attempts": {"value": 1, "source": "ACES default"}},
+                "task_source": "evals_json",
+                "agents": {
+                    "opencode": {
+                        "agent": "opencode",
+                        "model": "test-model",
+                        "source": "test default",
+                        "occurrence": "1",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (summary_dir / "summary.json").write_text(
+        json.dumps(
+            {
+                "agent": "opencode",
+                "model": "test-model",
+                "model_source": "test default",
+                "scores": {"security": score},
+                "custom_scores": {},
+                "metric_set": "aces-default-v2",
+                "metrics": ["security"],
+                "dimensions": {"safety": {"score": score, "sources": {"security": 1.0}}},
+                "num_trials": 1,
+                "pass_at_k": {
+                    "k": 1,
+                    "pass_threshold": 0.5,
+                    "stop_on_pass": False,
+                    "passed_cases": 1,
+                    "failed_cases": 0,
+                    "total_cases": 1,
+                    "rate": 1.0,
+                    "attempts_used": 1,
+                    "max_attempts_possible": 1,
+                    "avg_attempts_used": 1.0,
+                    "extra_cases": [],
+                    "cases": {
+                        "case": {
+                            "passed": True,
+                            "first_pass_attempt": 1,
+                            "attempts_used": 1,
+                            "attempts_skipped": 0,
+                            "attempts_missing": 0,
+                            "best_score": score,
+                            "attempts": [
+                                {
+                                    "attempt": 1,
+                                    "trial": "case__attempt1",
+                                    "score": score,
+                                    "passed": True,
+                                }
+                            ],
+                        }
+                    },
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    return run_dir
 
 
 def test_compare_rejects_partial_scores_from_failed_summary(tmp_path: Path) -> None:
@@ -124,6 +196,7 @@ def test_compare_same_timestamp_unique_runs_uses_result_completion_time(
             encoding="utf-8",
         )
         result_path = run_dir / "result.json"
+        (run_dir / "run_config.json").write_text("{}", encoding="utf-8")
         result_path.write_text(json.dumps({"run_id": run_id, "agents": {}}), encoding="utf-8")
         os.utime(result_path, ns=(completed_ns, completed_ns))
 
@@ -185,6 +258,21 @@ def test_compare_retains_non_timestamp_legacy_summary_directory(
 
     assert compare_results(skill_path, results_dir=tmp_path / "results") == 0
     assert legacy.name in capsys.readouterr().out
+
+
+def test_compare_consumes_authenticated_timestamped_pre_status_run(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    skill_path = tmp_path / "demo"
+    skill_path.mkdir()
+    run_id = "20260709_010000_111_aaaaaaaaaaaa"
+    _write_authentic_pre_status_run(tmp_path / "results" / skill_path.name, run_id)
+
+    assert compare_results(skill_path, results_dir=tmp_path / "results") == 0
+    output = capsys.readouterr().out
+    assert run_id in output
+    assert "opencode" in output
 
 
 @pytest.mark.parametrize("primary_kind", ["empty", "partial", "non-object"])

--- a/tests/test_tier3_compare.py
+++ b/tests/test_tier3_compare.py
@@ -6,13 +6,19 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
-from typing import TYPE_CHECKING
+
+import pytest
 
 from skillevaluator.tier3.commands import compare_results
 
-if TYPE_CHECKING:
-    import pytest
+
+def _complete_current_run(run_dir: Path) -> None:
+    (run_dir / "result.json").write_text(
+        json.dumps({"run_id": run_dir.name, "agents": {}}),
+        encoding="utf-8",
+    )
 
 
 def test_compare_rejects_partial_scores_from_failed_summary(tmp_path: Path) -> None:
@@ -33,6 +39,7 @@ def test_compare_rejects_partial_scores_from_failed_summary(tmp_path: Path) -> N
         ),
         encoding="utf-8",
     )
+    _complete_current_run(summary_dir.parents[1])
 
     assert compare_results(skill_path, results_dir=results_root) == 1
 
@@ -55,6 +62,7 @@ def test_compare_ignores_failed_baseline_scores(
             json.dumps({"execution_status": status, "scores": {"security": score}}),
             encoding="utf-8",
         )
+    _complete_current_run(agent_dir.parent)
 
     assert compare_results(skill_path, results_dir=results_root) == 0
     assert "lift" not in capsys.readouterr().out.lower()
@@ -80,6 +88,7 @@ def test_compare_never_pairs_baseline_from_a_different_timestamp(
             json.dumps({"execution_status": status, "scores": {"security": score}}),
             encoding="utf-8",
         )
+    _complete_current_run(newest.parent)
 
     older = skill_results / "20260709_010000" / "opencode" / "with-skill"
     older.mkdir(parents=True)
@@ -87,6 +96,156 @@ def test_compare_never_pairs_baseline_from_a_different_timestamp(
         json.dumps({"execution_status": "succeeded", "scores": {"security": 1.0}}),
         encoding="utf-8",
     )
+    _complete_current_run(older.parents[1])
 
     assert compare_results(skill_path, results_dir=results_root) == 0
     assert "lift" not in capsys.readouterr().out.lower()
+
+
+def test_compare_same_timestamp_unique_runs_uses_result_completion_time(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    skill_path = tmp_path / "demo"
+    skill_path.mkdir()
+    skill_results = tmp_path / "results" / "demo"
+    lexically_later = "20260709_010000_999_ffffffffffff"
+    completed_later = "20260709_010000_111_aaaaaaaaaaaa"
+
+    for run_id, score, completed_ns in (
+        (lexically_later, 0.1, 100),
+        (completed_later, 0.9, 200),
+    ):
+        run_dir = skill_results / run_id
+        summary_dir = run_dir / "opencode" / "with-skill"
+        summary_dir.mkdir(parents=True)
+        (summary_dir / "summary.json").write_text(
+            json.dumps({"execution_status": "succeeded", "scores": {"security": score}}),
+            encoding="utf-8",
+        )
+        result_path = run_dir / "result.json"
+        result_path.write_text(json.dumps({"run_id": run_id, "agents": {}}), encoding="utf-8")
+        os.utime(result_path, ns=(completed_ns, completed_ns))
+
+    assert compare_results(skill_path, results_dir=tmp_path / "results") == 0
+    output = capsys.readouterr().out
+    assert completed_later in output
+    assert lexically_later not in output
+
+
+@pytest.mark.parametrize("partial_kind", ["missing", "malformed", "mismatched"])
+def test_compare_ignores_newer_partial_timestamp_run(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    partial_kind: str,
+) -> None:
+    skill_path = tmp_path / "demo"
+    skill_path.mkdir()
+    skill_results = tmp_path / "results" / "demo"
+    older = skill_results / "20260709_010000"
+    older_summary = older / "opencode" / "with-skill" / "summary.json"
+    older_summary.parent.mkdir(parents=True)
+    older_summary.write_text(
+        json.dumps({"execution_status": "succeeded", "scores": {"security": 0.8}}),
+        encoding="utf-8",
+    )
+    _complete_current_run(older)
+
+    newer = skill_results / "20260709_020000"
+    newer_summary = newer / "opencode" / "with-skill" / "summary.json"
+    newer_summary.parent.mkdir(parents=True)
+    newer_summary.write_text(
+        json.dumps({"execution_status": "succeeded", "scores": {"security": 0.1}}),
+        encoding="utf-8",
+    )
+    if partial_kind == "malformed":
+        (newer / "result.json").write_text("{not json", encoding="utf-8")
+    elif partial_kind == "mismatched":
+        (newer / "result.json").write_text(json.dumps({"run_id": "different"}), encoding="utf-8")
+
+    assert compare_results(skill_path, results_dir=tmp_path / "results") == 0
+    output = capsys.readouterr().out
+    assert older.name in output
+    assert newer.name not in output
+
+
+def test_compare_retains_non_timestamp_legacy_summary_directory(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    skill_path = tmp_path / "demo"
+    skill_path.mkdir()
+    legacy = tmp_path / "results" / "demo" / "legacy-run"
+    summary = legacy / "opencode" / "with-skill" / "summary.json"
+    summary.parent.mkdir(parents=True)
+    summary.write_text(
+        json.dumps({"execution_status": "succeeded", "scores": {"security": 0.7}}),
+        encoding="utf-8",
+    )
+
+    assert compare_results(skill_path, results_dir=tmp_path / "results") == 0
+    assert legacy.name in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("primary_kind", ["empty", "partial", "non-object"])
+def test_compare_falls_back_from_unusable_primary_root_to_valid_legacy_root(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    primary_kind: str,
+) -> None:
+    skill_path = tmp_path / "demo"
+    skill_path.mkdir()
+    primary = tmp_path / "results" / skill_path.name
+    primary.mkdir(parents=True)
+    if primary_kind == "partial":
+        partial = primary / "20260709_020000" / "codex" / "with-skill"
+        partial.mkdir(parents=True)
+        (partial / "summary.json").write_text(
+            json.dumps({"execution_status": "succeeded", "scores": {"security": 0.1}}),
+            encoding="utf-8",
+        )
+    elif primary_kind == "non-object":
+        completed = primary / "20260709_020000"
+        summary = completed / "codex" / "with-skill" / "summary.json"
+        summary.parent.mkdir(parents=True)
+        summary.write_text("[]\n", encoding="utf-8")
+        _complete_current_run(completed)
+
+    legacy = skill_path / "evals" / "results" / "legacy-run" / "opencode" / "with-skill"
+    legacy.mkdir(parents=True)
+    (legacy / "summary.json").write_text(
+        json.dumps({"execution_status": "succeeded", "scores": {"security": 0.9}}),
+        encoding="utf-8",
+    )
+
+    assert compare_results(skill_path, results_dir=tmp_path / "results") == 0
+    output = capsys.readouterr().out
+    assert "opencode" in output
+    assert "legacy-run" in output
+
+
+def test_compare_never_mixes_agents_across_candidate_roots(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    skill_path = tmp_path / "demo"
+    skill_path.mkdir()
+    primary_run = tmp_path / "results" / "demo" / "20260709_020000"
+    primary = primary_run / "codex" / "with-skill"
+    primary.mkdir(parents=True)
+    (primary / "summary.json").write_text(
+        json.dumps({"execution_status": "succeeded", "scores": {"security": 0.8}}),
+        encoding="utf-8",
+    )
+    _complete_current_run(primary_run)
+    legacy = skill_path / "evals" / "results" / "legacy-run" / "opencode" / "with-skill"
+    legacy.mkdir(parents=True)
+    (legacy / "summary.json").write_text(
+        json.dumps({"execution_status": "succeeded", "scores": {"security": 0.9}}),
+        encoding="utf-8",
+    )
+
+    assert compare_results(skill_path, results_dir=tmp_path / "results") == 0
+    output = capsys.readouterr().out
+    assert "codex" in output
+    assert "opencode" not in output

--- a/tests/test_tier3_progress.py
+++ b/tests/test_tier3_progress.py
@@ -10,6 +10,7 @@ import io
 import json
 import subprocess
 import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, ClassVar
@@ -686,6 +687,40 @@ def test_default_run_cleans_transient_harbor_artifacts(
     persisted = json.loads(Path(result["result_path"]).read_text(encoding="utf-8"))
     assert persisted["harbor_jobs_retained"] is False
     assert persisted["run_config"]["harbor"]["jobs_retained"] is False
+
+
+def test_runner_rejects_preexisting_run_symlink_before_child_creation(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    runner, skill = _stub_runner(monkeypatch, tmp_path)
+    timestamp = "20260804_123456"
+    fixed_now = SimpleNamespace(strftime=lambda _format: timestamp)
+    monkeypatch.setattr(runner, "datetime", SimpleNamespace(now=lambda _timezone: fixed_now))
+    monkeypatch.setattr(runner.os, "getpid", lambda: 12345)
+    monkeypatch.setattr(runner, "uuid4", lambda: SimpleNamespace(hex="abcdef012345"))
+    run_id = f"{timestamp}_12345_abcdef012345"
+    results_root = tmp_path / "results"
+    victim = tmp_path / "victim"
+    results_root.mkdir()
+    victim.mkdir()
+    (results_root / run_id).symlink_to(victim, target_is_directory=True)
+
+    result = runner.run_harbor_eval(skill, ["codex"], output_dir=results_root)
+
+    assert "unique Tier 3 run directory" in str(result["error"][0])
+    assert not (victim / "_harbor-jobs").exists()
+
+
+def test_runner_reserves_unique_run_directories_concurrently(tmp_path: Path) -> None:
+    from skillevaluator.tier3.harbor import runner
+
+    results_root = tmp_path / "results"
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        run_dirs = list(executor.map(lambda _index: runner._reserve_run_dir(results_root, "20260804_123456"), range(8)))
+
+    assert len(set(run_dirs)) == 8
+    assert all((run_dir / ".skillevaluator-generated-output").is_file() for run_dir in run_dirs)
 
 
 def test_runner_persists_compact_feedback_to_result_json(

--- a/tests/test_tier3_progress.py
+++ b/tests/test_tier3_progress.py
@@ -5,10 +5,12 @@
 
 from __future__ import annotations
 
+import errno
 import importlib
 import io
 import json
 import subprocess
+import tempfile
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -701,6 +703,54 @@ def test_runner_returns_error_when_private_evaluator_snapshot_cannot_be_created(
     assert result["error"] == [f"No evaluator source directory found at {skill / 'evals'}"]
 
 
+def test_runner_returns_structured_error_and_cleans_partial_snapshot_on_enospc(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from skillevaluator.tier3.harbor import adapter, runner
+
+    skill = tmp_path / "snapshot-enospc-skill"
+    (skill / "evals").mkdir(parents=True)
+    (skill / "SKILL.md").write_text("# Snapshot ENOSPC\n", encoding="utf-8")
+    dataset = skill / "evals" / "evals.json"
+    dataset.write_text(json.dumps([{"id": "case-1", "question": "Use the skill."}]), encoding="utf-8")
+    temporary_root = tmp_path / "snapshot-temporary-root"
+    temporary_root.mkdir()
+    reporter = _RecordingReporter()
+    provider_resolution_calls: list[bool] = []
+
+    def fail_snapshot_copy(_source: Path, destination: Path, **_kwargs: Any) -> None:
+        destination.mkdir(parents=True)
+        (destination / "partial-copy").write_text("partial\n", encoding="utf-8")
+        raise OSError(errno.ENOSPC, "No space left on device")
+
+    def unexpected_provider_resolution() -> None:
+        provider_resolution_calls.append(True)
+        raise AssertionError("provider resolution must not start after snapshot failure")
+
+    monkeypatch.setattr(adapter, "copytree_secure", fail_snapshot_copy)
+    monkeypatch.setattr(tempfile, "tempdir", str(temporary_root))
+    monkeypatch.setattr(runner, "resolve_llm_provider", unexpected_provider_resolution)
+    results_root = tmp_path / "results"
+
+    result = runner.run_harbor_eval(
+        skill,
+        ["codex"],
+        output_dir=results_root,
+        progress_reporter=reporter,
+    )
+
+    assert result["error"] == ["[Errno 28] No space left on device"]
+    assert provider_resolution_calls == []
+    assert not results_root.exists()
+    assert list(temporary_root.iterdir()) == []
+    assert json.loads(dataset.read_text(encoding="utf-8")) == [{"id": "case-1", "question": "Use the skill."}]
+    transitions = [(event.stage, event.state) for event in reporter.events]
+    assert ("configuration", "failed") in transitions
+    assert transitions[-1] == ("run-finished", "failed")
+    assert transitions.count(("run-finished", "failed")) == 1
+
+
 @pytest.mark.parametrize("kind", ["symlink", "hardlink"])
 def test_runner_returns_error_for_unsafe_evals_config(tmp_path: Path, kind: str) -> None:
     from skillevaluator.tier3.harbor import runner
@@ -883,6 +933,66 @@ def test_default_task_staging_failure_cleans_transient_artifacts(
     assert not (run_dir / "_harbor-jobs").exists()
     assert not (run_dir / "_harbor-tasks").exists()
     assert result["harbor_jobs_retained"] is False
+
+
+@pytest.mark.parametrize("failure_arm", ["with-skill", "baseline"])
+def test_task_staging_enospc_returns_structured_error_without_launch_and_cleans_artifacts(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    failure_arm: str,
+) -> None:
+    launches: list[dict[str, Any]] = []
+    evaluator_snapshots: list[Path] = []
+
+    def fail_staging(_skill: Path, output: Path, **kwargs: Any) -> list[Path]:
+        evaluator_snapshots.append(Path(kwargs["evaluator_skill_path"]))
+        output.mkdir(parents=True)
+        (output / "partial-copy").write_text("partial\n", encoding="utf-8")
+        should_fail = (failure_arm == "with-skill" and kwargs["with_skill"]) or (
+            failure_arm == "baseline" and not kwargs["with_skill"]
+        )
+        if should_fail:
+            raise OSError(errno.ENOSPC, "No space left on device")
+        return [output / "case-1"]
+
+    def record_launch(**kwargs: Any) -> list[str]:
+        launches.append(kwargs)
+        return []
+
+    runner, skill = _stub_runner(
+        monkeypatch,
+        tmp_path,
+        task_emitter=fail_staging,
+        run_agent=record_launch,
+    )
+    reporter = _RecordingReporter()
+
+    result = runner.run_harbor_eval(
+        skill,
+        ["codex"],
+        skip_baseline=False,
+        output_dir=tmp_path / "results",
+        progress_reporter=reporter,
+    )
+
+    run_dir = Path(result["run_dir"])
+    assert result["error"] == ["[Errno 28] No space left on device"]
+    assert launches == []
+    assert len(evaluator_snapshots) == (1 if failure_arm == "with-skill" else 2)
+    assert len(set(evaluator_snapshots)) == 1
+    assert not evaluator_snapshots[0].exists()
+    assert not (run_dir / "_harbor-jobs").exists()
+    assert not (run_dir / "_harbor-tasks").exists()
+    assert result["harbor_jobs_retained"] is False
+    transitions = [(event.stage, event.state) for event in reporter.events]
+    expected_stage = "with-skill-tasks" if failure_arm == "with-skill" else "baseline-tasks"
+    assert (expected_stage, "running") in transitions
+    assert (expected_stage, "failed") in transitions
+    if failure_arm == "baseline":
+        assert ("with-skill-tasks", "failed") not in transitions
+    assert not any(stage.startswith("agent:") and state == "running" for stage, state in transitions)
+    assert transitions[-1] == ("run-finished", "failed")
+    assert transitions.count(("run-finished", "failed")) == 1
 
 
 def test_default_collection_exception_cleans_transient_artifacts(

--- a/tests/test_tier3_progress.py
+++ b/tests/test_tier3_progress.py
@@ -817,6 +817,47 @@ def test_all_agent_and_baseline_arms_share_one_private_evaluator_snapshot(
     assert not snapshots[0].exists()
 
 
+def test_multi_agent_run_prevalidates_baseline_alias_candidates_once(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    validation_token = object()
+    validation_calls: list[tuple[Path, tuple[Path, ...]]] = []
+    baseline_tokens: list[object | None] = []
+
+    def prevalidate(
+        skill_path: Path,
+        _reference_skills_dir: Path | None,
+        _workspace_skill_paths: list[Path] | None,
+        *,
+        excluded_roots: tuple[Path, ...],
+    ) -> object:
+        validation_calls.append((skill_path, excluded_roots))
+        return validation_token
+
+    def emit_tasks(_skill: Path, output: Path, **kwargs: Any) -> list[Path]:
+        if not kwargs["with_skill"]:
+            baseline_tokens.append(kwargs.get("_baseline_alias_validation"))
+        task = output / "case-1"
+        task.mkdir(parents=True)
+        return [task]
+
+    runner, skill = _stub_runner(monkeypatch, tmp_path, task_emitter=emit_tasks)
+    monkeypatch.setattr(runner, "_prevalidate_baseline_skill_candidates", prevalidate, raising=False)
+
+    result = runner.run_harbor_eval(
+        skill,
+        ["codex", "opencode"],
+        output_dir=tmp_path / "results",
+        agent_runtime_preflight=False,
+    )
+
+    assert "error" not in result
+    assert len(validation_calls) == 1
+    assert validation_calls[0][0] == skill
+    assert baseline_tokens == [validation_token, validation_token]
+
+
 def test_runner_rejects_preexisting_run_symlink_before_child_creation(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -849,6 +890,113 @@ def test_runner_reserves_unique_run_directories_concurrently(tmp_path: Path) -> 
 
     assert len(set(run_dirs)) == 8
     assert all((run_dir / ".skillevaluator-generated-output").is_file() for run_dir in run_dirs)
+
+
+def test_failed_run_reservation_cleanup_refuses_a_substituted_empty_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from skillevaluator.tier3.harbor import runner
+
+    results_root = tmp_path / "results"
+    moved_run = tmp_path / "moved-run"
+    monkeypatch.setattr(runner.os, "getpid", lambda: 12345)
+    monkeypatch.setattr(runner, "uuid4", lambda: SimpleNamespace(hex="abcdef012345"))
+    expected_run = results_root / "20260804_123456_12345_abcdef012345"
+
+    def substitute_then_fail(path: Path) -> None:
+        path.rename(moved_run)
+        path.mkdir()
+        raise OSError("injected marker failure")
+
+    monkeypatch.setattr(runner, "mark_generated_output_root", substitute_then_fail)
+
+    with pytest.raises(OSError, match="injected marker failure"):
+        runner._reserve_run_dir(results_root, "20260804_123456")
+
+    assert expected_run.is_dir()
+    assert moved_run.is_dir()
+
+
+def test_jobs_directory_creation_failure_returns_structured_error_and_removes_owned_run(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    runner, skill = _stub_runner(monkeypatch, tmp_path)
+    reporter = _RecordingReporter()
+    original_mkdir = Path.mkdir
+
+    def fail_jobs_mkdir(path: Path, *args: Any, **kwargs: Any) -> None:
+        if path.name == "_harbor-jobs":
+            raise OSError(errno.ENOSPC, "No space left on device")
+        original_mkdir(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "mkdir", fail_jobs_mkdir)
+    results_root = tmp_path / "results"
+
+    result = runner.run_harbor_eval(
+        skill,
+        ["codex"],
+        output_dir=results_root,
+        progress_reporter=reporter,
+    )
+
+    assert result == {"error": ["[Errno 28] No space left on device"]}
+    assert results_root.is_dir()
+    assert list(results_root.iterdir()) == []
+    transitions = [(event.stage, event.state) for event in reporter.events]
+    assert transitions[-1] == ("run-finished", "failed")
+    assert transitions.count(("run-finished", "failed")) == 1
+
+
+def test_jobs_directory_failure_cleans_owned_empty_run_without_descriptor_backend(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from skillevaluator.tier3 import output_provenance
+
+    runner, skill = _stub_runner(monkeypatch, tmp_path)
+    original_mkdir = Path.mkdir
+
+    def fail_jobs_mkdir(path: Path, *args: Any, **kwargs: Any) -> None:
+        if path.name == "_harbor-jobs":
+            raise OSError("injected jobs directory failure")
+        original_mkdir(path, *args, **kwargs)
+
+    monkeypatch.setattr(output_provenance, "_DESCRIPTOR_BACKEND", False)
+    monkeypatch.setattr(Path, "mkdir", fail_jobs_mkdir)
+    results_root = tmp_path / "results"
+
+    result = runner.run_harbor_eval(skill, ["codex"], output_dir=results_root)
+
+    assert result == {"error": ["injected jobs directory failure"]}
+    assert list(results_root.iterdir()) == []
+
+
+def test_jobs_directory_creation_failure_preserves_run_after_provenance_is_lost(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    runner, skill = _stub_runner(monkeypatch, tmp_path)
+    original_mkdir = Path.mkdir
+    reserved_run: list[Path] = []
+
+    def fail_after_tampering(path: Path, *args: Any, **kwargs: Any) -> None:
+        if path.name == "_harbor-jobs":
+            reserved_run.append(path.parent)
+            marker = path.parent / ".skillevaluator-generated-output"
+            marker.write_text("not an authentic marker\n", encoding="utf-8")
+            (path.parent / "preserve.txt").write_text("unowned\n", encoding="utf-8")
+            raise OSError("injected jobs directory failure")
+        original_mkdir(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "mkdir", fail_after_tampering)
+
+    result = runner.run_harbor_eval(skill, ["codex"], output_dir=tmp_path / "results")
+
+    assert result == {"error": ["injected jobs directory failure"]}
+    assert len(reserved_run) == 1
+    assert (reserved_run[0] / "preserve.txt").read_text(encoding="utf-8") == "unowned\n"
 
 
 def test_runner_publishes_latest_through_shared_atomic_helper(
@@ -1495,29 +1643,59 @@ def test_runner_terminalizes_report_when_result_write_raises(
 ) -> None:
     runner, skill = _stub_runner(monkeypatch, tmp_path)
     reporter = _RecordingReporter()
-    original_write_text = Path.write_text
+    original_replace = runner.os.replace
 
-    def fail_result_write(path: Path, *args, **kwargs):
-        if path.name == "result.json":
+    def fail_result_write(source: str | Path, destination: str | Path, *args, **kwargs):
+        if Path(destination).name == "result.json":
             raise OSError("result write failed")
-        return original_write_text(path, *args, **kwargs)
+        return original_replace(source, destination, *args, **kwargs)
 
-    monkeypatch.setattr(Path, "write_text", fail_result_write)
+    monkeypatch.setattr(runner.os, "replace", fail_result_write)
+    results_root = tmp_path / "results"
 
     with pytest.raises(OSError, match="result write failed"):
         runner.run_harbor_eval(
             skill,
             ["codex"],
-            output_dir=tmp_path / "results",
+            output_dir=results_root,
             keep_harbor_jobs=True,
             progress_reporter=reporter,
         )
 
+    run_dirs = [candidate for candidate in results_root.iterdir() if candidate.is_dir()]
+    assert len(run_dirs) == 1
+    assert not (run_dirs[0] / "result.json").exists()
+    assert not list(run_dirs[0].glob(".result.json.*.tmp"))
     transitions = [(event.stage, event.state) for event in reporter.events]
     assert ("report", "running") in transitions
     assert ("report", "failed") in transitions
     assert transitions[-1] == ("run-finished", "failed")
     assert transitions.count(("run-finished", "failed")) == 1
+
+
+def test_runner_atomically_publishes_one_complete_final_result(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    runner, skill = _stub_runner(monkeypatch, tmp_path)
+    original_replace = runner.os.replace
+    published_payloads: list[dict[str, Any]] = []
+
+    def inspect_result_publication(source: str | Path, destination: str | Path, *args, **kwargs):
+        destination_path = Path(destination)
+        if destination_path.name == "result.json":
+            assert not destination_path.exists()
+            published_payloads.append(json.loads(Path(source).read_text(encoding="utf-8")))
+        return original_replace(source, destination, *args, **kwargs)
+
+    monkeypatch.setattr(runner.os, "replace", inspect_result_publication)
+
+    result = runner.run_harbor_eval(skill, ["codex"], output_dir=tmp_path / "results")
+
+    assert len(published_payloads) == 1
+    assert published_payloads[0]["execution_status"] == "succeeded"
+    assert published_payloads[0]["run_id"] == result["run_id"]
+    assert json.loads(Path(result["result_path"]).read_text(encoding="utf-8")) == published_payloads[0]
 
 
 def test_runner_continues_when_reporter_callbacks_raise(

--- a/tests/test_tier3_progress.py
+++ b/tests/test_tier3_progress.py
@@ -723,6 +723,25 @@ def test_runner_reserves_unique_run_directories_concurrently(tmp_path: Path) -> 
     assert all((run_dir / ".skillevaluator-generated-output").is_file() for run_dir in run_dirs)
 
 
+def test_runner_publishes_latest_through_shared_atomic_helper(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    runner, skill = _stub_runner(monkeypatch, tmp_path)
+    published: list[tuple[Path, str]] = []
+    monkeypatch.setattr(
+        runner,
+        "publish_latest_results",
+        lambda root, run_id: published.append((root, run_id)),
+        raising=False,
+    )
+    results_root = tmp_path / "results"
+
+    result = runner.run_harbor_eval(skill, ["codex"], output_dir=results_root)
+
+    assert published == [(results_root, Path(result["run_dir"]).name)]
+
+
 def test_runner_persists_compact_feedback_to_result_json(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_tier3_progress.py
+++ b/tests/test_tier3_progress.py
@@ -689,6 +689,84 @@ def test_default_run_cleans_transient_harbor_artifacts(
     assert persisted["run_config"]["harbor"]["jobs_retained"] is False
 
 
+def test_runner_returns_error_when_private_evaluator_snapshot_cannot_be_created(tmp_path: Path) -> None:
+    from skillevaluator.tier3.harbor import runner
+
+    skill = tmp_path / "missing-evals-skill"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text("# Missing evals\n", encoding="utf-8")
+
+    result = runner.run_harbor_eval(skill, ["codex"])
+
+    assert result["error"] == [f"No evaluator source directory found at {skill / 'evals'}"]
+
+
+@pytest.mark.parametrize("kind", ["symlink", "hardlink"])
+def test_runner_returns_error_for_unsafe_evals_config(tmp_path: Path, kind: str) -> None:
+    from skillevaluator.tier3.harbor import runner
+
+    skill = tmp_path / "unsafe-config-skill"
+    (skill / "evals").mkdir(parents=True)
+    (skill / "evals" / "evals.json").write_text("[]\n", encoding="utf-8")
+    outside = tmp_path / "outside-config.yml"
+    outside.write_text("schema_version: 1\n", encoding="utf-8")
+    config = skill / "evals" / "config.yml"
+    try:
+        if kind == "symlink":
+            config.symlink_to(outside)
+        else:
+            config.hardlink_to(outside)
+    except OSError as exc:
+        pytest.skip(f"{kind} creation is unavailable: {exc}")
+
+    result = runner.run_harbor_eval(skill, ["codex"])
+
+    assert result["error"] == [f"Eval configuration must be a regular non-linked file: {config}"]
+
+
+def test_all_agent_and_baseline_arms_share_one_private_evaluator_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    snapshots: list[Path] = []
+    observed_questions: list[str] = []
+    skill_ref: list[Path] = []
+
+    def emit_tasks(_skill: Path, output: Path, **kwargs: Any) -> list[Path]:
+        snapshot = Path(kwargs["evaluator_skill_path"])
+        snapshots.append(snapshot)
+        entries = json.loads((snapshot / "evals" / "evals.json").read_text(encoding="utf-8"))
+        observed_questions.append(entries[0]["question"])
+        if len(snapshots) == 1:
+            (skill_ref[0] / "evals" / "evals.json").write_text(
+                json.dumps([{"id": "case-1", "question": "Mutated after snapshot."}]),
+                encoding="utf-8",
+            )
+        task = output / "case-1"
+        task.mkdir(parents=True)
+        return [task]
+
+    runner, skill = _stub_runner(monkeypatch, tmp_path, task_emitter=emit_tasks)
+    skill_ref.append(skill)
+    (skill / "evals" / "evals.json").write_text(
+        json.dumps([{"id": "case-1", "question": "Use the original fixture."}]),
+        encoding="utf-8",
+    )
+
+    result = runner.run_harbor_eval(
+        skill,
+        ["codex", "opencode"],
+        output_dir=tmp_path / "results",
+        agent_runtime_preflight=False,
+    )
+
+    assert "error" not in result
+    assert len(snapshots) == 4
+    assert len(set(snapshots)) == 1
+    assert observed_questions == ["Use the original fixture."] * 4
+    assert not snapshots[0].exists()
+
+
 def test_runner_rejects_preexisting_run_symlink_before_child_creation(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -864,10 +942,17 @@ def test_cleanup_failure_degrades_terminal_progress_after_retention_finalizes(
     reporter = _RecordingReporter()
     from skillevaluator.tier3.harbor import artifact_retention
 
+    real_rmtree = artifact_retention.shutil.rmtree
+
+    def fail_harbor_artifact_cleanup(path: str | Path, *args: Any, **kwargs: Any) -> None:
+        if Path(path).name.startswith("_harbor-"):
+            raise OSError(f"busy: {path}")
+        real_rmtree(path, *args, **kwargs)
+
     monkeypatch.setattr(
         artifact_retention.shutil,
         "rmtree",
-        lambda path: (_ for _ in ()).throw(OSError(f"busy: {path}")),
+        fail_harbor_artifact_cleanup,
     )
 
     result = runner.run_harbor_eval(
@@ -1055,6 +1140,9 @@ def test_runner_reports_known_plan_without_claiming_failed_preflight_ready(
     from skillevaluator.tier3.harbor import runner
 
     reporter = _RecordingReporter()
+    skill = tmp_path / "demo"
+    (skill / "evals").mkdir(parents=True)
+    (skill / "evals" / "evals.json").write_text("[]\n", encoding="utf-8")
     monkeypatch.setattr(
         runner,
         "resolve_llm_provider",
@@ -1070,7 +1158,7 @@ def test_runner_reports_known_plan_without_claiming_failed_preflight_ready(
     )
     monkeypatch.setattr(runner, "_check_prerequisites", lambda **_kwargs: ["Docker is unavailable"])
 
-    result = runner.run_harbor_eval(tmp_path / "demo", ["codex"], progress_reporter=reporter)
+    result = runner.run_harbor_eval(skill, ["codex"], progress_reporter=reporter)
 
     assert result == {"error": ["Docker is unavailable"]}
     known_plan = reporter.plans[-1]
@@ -1090,6 +1178,9 @@ def test_runner_does_not_mark_invalid_configuration_ready(
     from skillevaluator.tier3.harbor import runner
 
     reporter = _RecordingReporter()
+    skill = tmp_path / "demo"
+    (skill / "evals").mkdir(parents=True)
+    (skill / "evals" / "evals.json").write_text("[]\n", encoding="utf-8")
     monkeypatch.setattr(
         runner,
         "resolve_llm_provider",
@@ -1101,7 +1192,7 @@ def test_runner_does_not_mark_invalid_configuration_ready(
         lambda _path: ({"harbor": {"n_attempts": 0}}, None),
     )
 
-    result = runner.run_harbor_eval(tmp_path / "demo", ["codex"], progress_reporter=reporter)
+    result = runner.run_harbor_eval(skill, ["codex"], progress_reporter=reporter)
 
     assert result == {"error": ["n_attempts must be >= 1"]}
     transitions = [(event.stage, event.state) for event in reporter.events]
@@ -1430,7 +1521,8 @@ def test_command_does_not_relabel_runtime_failure_as_configuration_failure(
     from skillevaluator.tier3 import commands
 
     skill = tmp_path / "demo"
-    skill.mkdir()
+    (skill / "evals").mkdir(parents=True)
+    (skill / "evals" / "evals.json").write_text("[]\n", encoding="utf-8")
     reporter = _RecordingReporter()
     monkeypatch.setattr(commands, "resolve_llm_provider", lambda: SimpleNamespace(provider="openai"))
 
@@ -1602,7 +1694,8 @@ def test_command_runner_terminalizes_inherited_configuration_stage(
     from skillevaluator.tier3.harbor import runner
 
     skill = tmp_path / "demo"
-    skill.mkdir()
+    (skill / "evals").mkdir(parents=True)
+    (skill / "evals" / "evals.json").write_text("[]\n", encoding="utf-8")
     reporter = _RecordingReporter()
     monkeypatch.setattr(commands, "resolve_llm_provider", lambda: SimpleNamespace(provider="openai"))
 

--- a/tests/test_tier3_public_runtime.py
+++ b/tests/test_tier3_public_runtime.py
@@ -18,7 +18,7 @@ from skillevaluator.cli import cli
 from skillevaluator.provider_config import ProviderConfig
 from skillevaluator.tier3 import commands as tier3_commands
 from skillevaluator.tier3.evals_config import EvalsConfigError, load_evals_config
-from skillevaluator.tier3.harbor.adapter import _write_task_toml
+from skillevaluator.tier3.harbor.adapter import _EVALUATOR_MANAGED_RUNTIME_ENV, _write_task_toml
 from skillevaluator.tier3.harbor.runner import (
     _model_for_agent,
     _nvidia_build_agent_import_path,
@@ -366,7 +366,10 @@ def test_generated_task_keeps_evaluator_provider_variables_out_of_agent_environm
         "NVIDIA_API_KEY": "${NVIDIA_API_KEY}",
         "SKILL_EVAL_LLM_PROVIDER": "${SKILL_EVAL_LLM_PROVIDER}",
     }
-    assert task["environment"]["env"] == {"SERVICE_API_TOKEN": "${SERVICE_API_TOKEN}"}
+    assert task["environment"]["env"] == {
+        **_EVALUATOR_MANAGED_RUNTIME_ENV,
+        "SERVICE_API_TOKEN": "${SERVICE_API_TOKEN}",
+    }
 
 
 def test_nvidia_build_provider_mapping_does_not_supply_an_openai_agent_credential() -> None:

--- a/tests/tier3/test_generate_dataset_results.py
+++ b/tests/tier3/test_generate_dataset_results.py
@@ -21,10 +21,15 @@ def test_discover_trajectories_uses_env_results_root(tmp_path, monkeypatch):
     skill = tmp_path / "my-skill"
     skill.mkdir()
     results_root = tmp_path / "external-results"
-    trial = results_root / "my-skill" / "latest" / "claude-code" / "with-skill" / "trials" / "case-001"
+    skill_results = results_root / "my-skill"
+    run_id = "20260709_120000"
+    run_dir = skill_results / run_id
+    trial = run_dir / "claude-code" / "with-skill" / "trials" / "case-001"
     trial.mkdir(parents=True)
     trajectory = {"steps": [{"type": "assistant", "content": "done"}]}
     trial.joinpath("trajectory.json").write_text(json.dumps(trajectory), encoding="utf-8")
+    (run_dir / "result.json").write_text(json.dumps({"run_id": run_id}), encoding="utf-8")
+    (skill_results / "latest").symlink_to(run_id)
 
     monkeypatch.setenv("SKILLEVALUATOR_RESULTS_DIR", str(results_root))
 
@@ -36,10 +41,15 @@ def test_discover_trajectories_results_dir_overrides_env(tmp_path, monkeypatch):
     skill.mkdir()
     env_root = tmp_path / "env-results"
     cli_root = tmp_path / "cli-results"
-    trial = cli_root / "my-skill" / "latest" / "claude-code" / "with-skill" / "trials" / "case-001"
+    skill_results = cli_root / "my-skill"
+    run_id = "20260709_120000"
+    run_dir = skill_results / run_id
+    trial = run_dir / "claude-code" / "with-skill" / "trials" / "case-001"
     trial.mkdir(parents=True)
     trajectory = {"steps": [{"type": "assistant", "content": "done"}]}
     trial.joinpath("trajectory.json").write_text(json.dumps(trajectory), encoding="utf-8")
+    (run_dir / "result.json").write_text(json.dumps({"run_id": run_id}), encoding="utf-8")
+    (skill_results / "latest").symlink_to(run_id)
 
     monkeypatch.setenv("SKILLEVALUATOR_RESULTS_DIR", str(env_root))
 

--- a/tests/tier3/test_generate_dataset_results.py
+++ b/tests/tier3/test_generate_dataset_results.py
@@ -28,6 +28,7 @@ def test_discover_trajectories_uses_env_results_root(tmp_path, monkeypatch):
     trial.mkdir(parents=True)
     trajectory = {"steps": [{"type": "assistant", "content": "done"}]}
     trial.joinpath("trajectory.json").write_text(json.dumps(trajectory), encoding="utf-8")
+    (run_dir / "run_config.json").write_text("{}", encoding="utf-8")
     (run_dir / "result.json").write_text(json.dumps({"run_id": run_id}), encoding="utf-8")
     (skill_results / "latest").symlink_to(run_id)
 
@@ -48,6 +49,7 @@ def test_discover_trajectories_results_dir_overrides_env(tmp_path, monkeypatch):
     trial.mkdir(parents=True)
     trajectory = {"steps": [{"type": "assistant", "content": "done"}]}
     trial.joinpath("trajectory.json").write_text(json.dumps(trajectory), encoding="utf-8")
+    (run_dir / "run_config.json").write_text("{}", encoding="utf-8")
     (run_dir / "result.json").write_text(json.dumps({"run_id": run_id}), encoding="utf-8")
     (skill_results / "latest").symlink_to(run_id)
 

--- a/tests/utils/test_secure_fs_selected_reads.py
+++ b/tests/utils/test_secure_fs_selected_reads.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Focused contracts for descriptor-anchored evaluator artifact reads."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from skillevaluator.utils import secure_fs
+from skillevaluator.utils.secure_fs import SecurePathError, SecureRoot
+
+
+def test_secure_root_binds_declared_root_to_expected_snapshot(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    expected = root.lstat()
+    root.rename(tmp_path / "original-root")
+    root.mkdir()
+
+    with pytest.raises(SecurePathError, match=r"changed|snapshot|identity"), SecureRoot(root, expected=expected):
+        pass
+
+
+def test_windows_selected_file_handle_denies_concurrent_write_and_delete(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    selected = tmp_path / "summary.json"
+    selected.write_text("{}", encoding="utf-8")
+    root = SecureRoot(tmp_path)
+    root._windows_root_handles = [100]
+    captured: dict[str, int | str] = {}
+    opened_flags: list[int] = []
+
+    def open_relative(parent_handle: int, name: str, **kwargs: int) -> int:
+        captured.update({"parent_handle": parent_handle, "name": name, **kwargs})
+        return 200
+
+    monkeypatch.setattr(secure_fs, "_windows_open_relative_handle", open_relative)
+    monkeypatch.setattr(secure_fs, "_validate_windows_read_file_handle", lambda *_args: None)
+    monkeypatch.setattr(secure_fs.os, "fstat", lambda _descriptor: selected.lstat())
+    monkeypatch.setattr(secure_fs.os, "O_BINARY", 0x8000, raising=False)
+    monkeypatch.setitem(
+        sys.modules,
+        "msvcrt",
+        SimpleNamespace(open_osfhandle=lambda _handle, flags: opened_flags.append(flags) or 300),
+    )
+
+    assert root._open_windows(Path("summary.json"), None) == 300
+    assert captured["share"] == 0x1  # FILE_SHARE_READ only
+    assert int(opened_flags[0]) & 0x8000  # O_BINARY
+
+
+@pytest.mark.skipif(os.name != "nt", reason="requires native Windows sharing semantics")
+def test_windows_selected_file_is_immutable_until_reader_handle_closes(tmp_path: Path) -> None:
+    root = tmp_path / "skill"
+    root.mkdir()
+    selected = root / "summary.json"
+    selected.write_text("original", encoding="utf-8")
+
+    with SecureRoot(root) as secure_root:
+        descriptor = secure_root._open_windows(Path("summary.json"), selected.lstat())
+        try:
+            with pytest.raises(OSError):
+                selected.write_text("changed", encoding="utf-8")
+            with pytest.raises(OSError):
+                selected.unlink()
+        finally:
+            os.close(descriptor)
+
+    selected.write_text("changed", encoding="utf-8")
+    selected.unlink()
+    assert not selected.exists()


### PR DESCRIPTION
## Summary

- make a present Tier 3 eval-entry `files` field authoritative, so each task receives only its declared files or directories
- preserve backward compatibility: omitting `files` still stages the complete shared `evals/files/` corpus, while explicit `[]`, `null`, blank, or whitespace-only values stage no task input
- prevent evaluator-owned `evals/`, ground truth, unrelated fixtures, stale results, and target-skill payloads from leaking through target/reference/workspace skills, copied repository context, generated/native/custom-Docker/local projections, or agent discovery aliases
- bind private evaluator snapshots to the selected fixture, grader, sidecar, and native-task contents; reject source mutation during staging
- use transactional no-follow copying, path-bound authenticated output provenance, strict current-result discovery, historical-result compatibility checks, and structured cleanup for partial or ENOSPC failures
- preserve exact file bytes and portable mode semantics on Windows while retaining link/reparse, identity, size, and digest validation
- document the compatibility and migration boundary and update the changelog

Closes #29.

## Behavioral contract

- Declared inputs retain safe paths relative to `evals/`; traversal, links/reparse points, hardlinks, mount escapes, source mutation, and evaluator-control material are rejected.
- Baseline arms cannot see the target skill or evaluator-private data through supported projection paths. With-skill arms receive a sanitized runtime skill and only the selected task input.
- Generated tasks, native Harbor tasks, local mode, custom Docker/Compose, copied repositories, retained outputs, `view`, `compare`, retries, and concurrent attempts share the same isolation and provenance rules.
- Current suffixed runs require an authenticated path-bound marker and strict run/result/agent identity. Authentic historical unsuffixed runs remain readable only when their stable configuration and summaries satisfy the complete historical schema.
- Existing signed outputs are transactionally restored when replacement publication fails.

## Verification

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] Added or updated focused regression coverage
- [x] Updated documentation for user-visible changes
- [x] Ran the complete local suite during review: `3551 passed, 12 skipped, 4 deselected`
- [x] Ran the final affected isolation/provenance/results matrix: `565 passed, 5 skipped`
- [x] Ran the real Docker cancellation/timeout integration: `2 passed`
- [x] Built wheel and sdist; passed strict metadata, OSS source/archive boundary, isolated `tier3,llm` install, imports/resources/CLI/progress, and Docker-backed doctor smoke checks
- [x] Passed CI-aligned Ruff lint, changed-file format, workflow YAML, and diff checks
- [x] Passed repository CI on Python 3.12 and 3.13, macOS, native Windows, RHEL 8, packaging, DCO, dependency review, Gitleaks, and CodeQL: [final run](https://github.com/NVIDIA/SkillEvaluator/actions/runs/31138362671)
- [x] Independently reviewed the final security, Windows, transactional-publication, option-interaction, and regression changes with no remaining code findings
- [x] Did not add credentials, private datasets, proprietary benchmark content, or internal-only service references

## Release Impact

- [ ] No user-visible release note needed
- [x] Updated `CHANGELOG.md`

## Remaining live-proof boundary

A credentialed real model/grader evaluation was not run from this checkout. The change is covered by complete repository CI, native Windows execution, real Docker cancellation/timeout integration, and focused generated/native/custom-Docker/local projection tests, but not by a paid end-to-end agent-and-grader run.
