### PR TITLE
docs: link the NVIDIA Verified Skills docs from SkillEvaluator

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -6,7 +6,7 @@ layout: overview
 
 SkillEvaluator is an open-source, multi-tier framework for evaluating AI agent artifacts, starting with agent skills: deterministic quality gates, semantic overlap detection, synthetic eval dataset generation, and live agent evaluation.
 
-Agent skills are folders of instructions and supporting files that extend AI agents, as defined by the [Agent Skills specification](https://agentskills.io/). SkillEvaluator is part of the [NVIDIA Verified Skills pipeline](https://github.com/NVIDIA/skills). Tier 1 integrates [SkillSpector](https://github.com/NVIDIA/SkillSpector) for specialized security scanning; see [Installation](installation.mdx#system-tools) for the security setup.
+Agent skills are folders of instructions and supporting files that extend AI agents, as defined by the [Agent Skills specification](https://agentskills.io/). SkillEvaluator is part of the [NVIDIA Verified Skills pipeline](https://docs.nvidia.com/skills/), published from the [NVIDIA/skills catalog](https://github.com/NVIDIA/skills). Tier 1 integrates [SkillSpector](https://github.com/NVIDIA/SkillSpector) for specialized security scanning; see [Installation](installation.mdx#system-tools) for the security setup.
 
 <Note>
   SkillEvaluator's support level is **Experimental**: community-supported on a best-effort basis through [GitHub Issues](https://github.com/NVIDIA/SkillEvaluator/issues), with no SLA. See [SUPPORT.md](https://github.com/NVIDIA/SkillEvaluator/blob/main/SUPPORT.md).

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -80,3 +80,5 @@ navigation:
       - page: Contributing
         path: ../docs/developer-guide.mdx
         slug: developer-guide
+      - link: NVIDIA Verified Skills
+        href: https://docs.nvidia.com/skills/


### PR DESCRIPTION
Adds the cross-link back to the Verified Skills documentation in the two places it was missing.

## Changes

**1. Reference nav** (`fern/docs.yml`) — a `NVIDIA Verified Skills` entry under Reference, pointing at https://docs.nvidia.com/skills/. Fern renders it with an external-link marker.

**2. Overview** (`docs/index.mdx`) — the pipeline sentence linked only to GitHub. It now links both:

> SkillEvaluator is part of the [NVIDIA Verified Skills pipeline](https://docs.nvidia.com/skills/), published from the [NVIDIA/skills catalog](https://github.com/NVIDIA/skills).

## Why

This is the return leg of NVIDIA/skills#414, which added a SkillEvaluator section to the Verified Skills sidebar. That link was one-directional — a reader arriving at the Verified Skills docs could find SkillEvaluator, but not the reverse. Now both docs sites point at each other.

## Validation

`fern check` passes with 0 errors. The single warning is the pre-existing unauthenticated redirect-check notice, identical on `main`.

Three lines changed in total. Commit carries a DCO sign-off.