### PR TITLE
Ignore short env values in secure Docker redaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ All notable changes to SkillEvaluator are documented in this file.
 
 ### Security
 
+- Secure Docker exec redaction now ignores environment values shorter than eight
+  characters, matching the exact secret length floor used elsewhere. Short
+  flags such as `CLAUDE_CODE_DISABLE_POLICY_SKILLS=1` no longer rewrite digits
+  in `docker exec` output, which had broken NVIDIA Build bridge loopback
+  origins during Tier 3 preflight.
 - Isolated NVIDIA Build bridge credentials from vendor CLI processes using a
   transient, root-managed, container-only key handoff with cleanup on failure.
 - Removed NVIDIA Build secrets from Harbor and Docker exec arguments using a

--- a/src/skillevaluator/tier3/harbor/secure_docker_environment.py
+++ b/src/skillevaluator/tier3/harbor/secure_docker_environment.py
@@ -35,6 +35,9 @@ SECURE_DOCKER_ENV_IMPORT_PATH = (
 _ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _NVIDIA_BUILD_FILE_SENTINEL = "skillevaluator-file-backed-nvidia-key"
 _NVIDIA_BUILD_KEY_FILE_ENV = "SKILLEVALUATOR_NVIDIA_API_KEY_FILE"
+# Match llm_judge / local_environment: short env values like "1" must not
+# become substring secrets or loopback origins such as 127.0.0.1 break.
+_MIN_EXACT_SECRET_LENGTH = 8
 _COMPOSE_TERMINATE_SECONDS = 5.0
 _COMPOSE_KILL_SECONDS = 5.0
 _COMPOSE_CANCEL_SECONDS = 0.1
@@ -89,7 +92,11 @@ def _redact(text: str | None, secret_values: set[str]) -> str | None:
     if text is None:
         return None
     redacted = text
-    for value in sorted((value for value in secret_values if value), key=len, reverse=True):
+    for value in sorted(
+        (value for value in secret_values if value and len(value) >= _MIN_EXACT_SECRET_LENGTH),
+        key=len,
+        reverse=True,
+    ):
         redacted = redacted.replace(value, "[REDACTED]")
     return redacted
 
@@ -282,7 +289,11 @@ class SkillEvaluatorDockerEnvironment(DockerEnvironment):
 
         process_environment = self._compose_env_vars(include_os_env=True)
         process_environment.update(env_overrides or {})
-        secret_values = {value for value in (env_overrides or {}).values() if value}
+        secret_values = {
+            value
+            for value in (env_overrides or {}).values()
+            if value and len(value) >= _MIN_EXACT_SECRET_LENGTH
+        }
         creation = asyncio.create_task(
             asyncio.create_subprocess_exec(
                 *full_command,
@@ -456,7 +467,9 @@ class SkillEvaluatorSecureDockerEnvironment(SkillEvaluatorDockerEnvironment):
                 cwd=cwd,
                 timeout_sec=timeout_sec,
                 user=user,
-                secret_values={value for value in merged.values() if value},
+                secret_values={
+                    value for value in merged.values() if value and len(value) >= _MIN_EXACT_SECRET_LENGTH
+                },
             )
         except BaseException as exc:
             primary_error = exc

--- a/tests/test_harbor_secure_docker_environment.py
+++ b/tests/test_harbor_secure_docker_environment.py
@@ -217,6 +217,57 @@ def test_compose_check_false_redacts_success_output(
     assert result.stderr == "stderr [REDACTED]"
 
 
+def test_redact_ignores_short_env_values_that_would_corrupt_loopback_origins() -> None:
+    from skillevaluator.tier3.harbor.secure_docker_environment import _redact
+
+    origin = "http://127.0.0.1:41927\n"
+    assert _redact(origin, {"1"}) == origin
+    assert _redact(origin, {"1", "41927"}) == origin
+    assert _redact("token=abcdefgh", {"abcdefgh"}) == "token=[REDACTED]"
+
+
+def test_compose_redacts_long_secrets_without_rewriting_short_env_flags(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    environment = object.__new__(SkillEvaluatorDockerEnvironment)
+    environment.session_id = "secure-short-secret-test"
+    environment.environment_name = "secure-short-secret-test"
+    environment.environment_dir = tmp_path
+    environment._resources_compose_path = None
+    environment._mounts_compose_path = None
+    environment._use_prebuilt = True
+    environment._is_windows_container = False
+    environment.extra_docker_compose_paths = []
+    environment._network_policy = SimpleNamespace(network_mode="public")
+    environment._compose_env_vars = MethodType(lambda _self, **_kwargs: {"PATH": "/usr/bin"}, environment)
+    long_secret = "abcdefgh"
+
+    class Process:
+        returncode = 0
+
+        async def communicate(self) -> tuple[bytes, bytes]:
+            return b"http://127.0.0.1:41927\n", f"stderr {long_secret}".encode()
+
+    async def create_subprocess(*_args: object, **_kwargs: object) -> Process:
+        return Process()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", create_subprocess)
+    result = asyncio.run(
+        environment._run_docker_compose_command(
+            ["exec", "-e", "CLAUDE_CODE_DISABLE_POLICY_SKILLS", "-e", "DATABASE_URL", "main", "true"],
+            check=False,
+            env_overrides={
+                "CLAUDE_CODE_DISABLE_POLICY_SKILLS": "1",
+                "DATABASE_URL": long_secret,
+            },
+        )
+    )
+
+    assert result.stdout == "http://127.0.0.1:41927\n"
+    assert result.stderr == "stderr [REDACTED]"
+
+
 def test_compose_cancellation_reaps_process_tree_even_when_repeated(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

Tier 3 secure Docker exec redaction treated every non empty environment value as a secret. Policy flags such as CLAUDE_CODE_DISABLE_POLICY_SKILLS set to 1 then rewrote every digit 1 in command output, which corrupted NVIDIA Build bridge loopback origins during preflight.

This change applies the existing eight character exact secret length floor in `_redact` and when collecting secret values, matching `llm_judge` and local environment redaction. Short flags no longer destroy bridge health check origins. Longer credential values remain redacted.

Fixes #50

## Verification

1. Added focused regression tests for short env flags versus real credentials
2. Ran the secure Docker redaction tests with `uv run pytest`
3. Ran `ruff check` on the changed source and test files
4. Updated CHANGELOG.md under Security