### PR TITLE
chore(release): prepare v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,24 +4,7 @@ All notable changes to SkillEvaluator are documented in this file.
 
 ## Unreleased
 
-### Added
-
-- CI DCO check that fails pull requests whose commits lack a `Signed-off-by`
-  trailer, matching the sign-off requirement in `CONTRIBUTING.md`.
-- Initial public release candidate.
-- Enabled optional semantic-version validation in the default Tier 1 pipeline,
-  including a public `--previous-version` monotonic-bump bound.
-
-- Added NVIDIA Build live-agent paths: direct OpenCode support plus Docker
-  compatibility bridges for Codex and experimental Claude Code, including
-  multi-turn tool-call continuation.
-- Fern documentation site configured for `docs.nvidia.com/skills/skillevaluator`,
-  building the `docs/` guides (installation, configuration, and the three
-  evaluation tiers) as MDX pages.
-- Expanded the documentation site to fifteen pages — quickstart, eval
-  datasets, agents and sandboxes, custom graders, reports, CI integration,
-  CLI reference, and environment variables — under a task-oriented
-  navigation, with every command verified against the current CLI.
+## 0.2.0 - 2026-08-18
 
 ### Security
 
@@ -30,19 +13,6 @@ All notable changes to SkillEvaluator are documented in this file.
   flags such as `CLAUDE_CODE_DISABLE_POLICY_SKILLS=1` no longer rewrite digits
   in `docker exec` output, which had broken NVIDIA Build bridge loopback
   origins during Tier 3 preflight.
-- Isolated NVIDIA Build bridge credentials from vendor CLI processes using a
-  transient, root-managed, container-only key handoff with cleanup on failure.
-- Removed NVIDIA Build secrets from Harbor and Docker exec arguments using a
-  host-only key file, a non-secret subprocess sentinel, and per-exec container
-  handoffs; provider-secret aliases in `runtime_env` are rejected.
-- Hardened compatibility-bridge startup with a dynamic loopback port and
-  authenticated, process-bound readiness instead of a fixed health endpoint.
-- Tightened local macOS Seatbelt policy so nested workspaces can traverse home
-  directory metadata without gaining directory-listing or sibling-file access.
-- Removed implicit host-side pytest execution from default Tier 1
-  code-integrity validation. Test evidence is now collected with contained,
-  filename-only discovery that does not import or execute target-controlled
-  Python code.
 
 ### Changed
 
@@ -57,36 +27,6 @@ All notable changes to SkillEvaluator are documented in this file.
   cancelled so they do not consume runners after a newer commit is pushed.
   Path classification executes from the pull request base revision so a
   change cannot weaken its own CI routing.
-- Simplified the repository README into a concise documentation landing page,
-  retained a compact keyless `validate` quickstart, LLM-provider setup, and a
-  one-command `validate --full` path through all three tiers, broadened the
-  project description to agent artifacts starting with agent skills, and moved
-  detailed guidance to `docs.nvidia.com/skills/skillevaluator`.
-- Added Tier 3 cost-planning guidance, including trial-volume multipliers,
-  cost-saving flags, and the cost and isolation tradeoffs of local mode.
-- Standardized the product name as `SkillEvaluator` across documentation,
-  repository metadata, CLI output, and generated report artifacts.
-- Removed the optional OpenTelemetry integration, the
-  `skillevaluator[telemetry]` extra, and the `skillevaluator.telemetry` Python
-  module from the public distribution. Imports of that module now fail rather
-  than providing the former telemetry and safety helpers. Redaction and
-  child-process environment filtering remain available from
-  `skillevaluator.utils.redaction` and
-  `skillevaluator.utils.process_environment`; direct Protobuf and OpenTelemetry
-  dependencies are no longer installed.
-- Changed the public OpenAI default to `gpt-5.4-mini` and the NVIDIA Build
-  default to `nvidia/nemotron-3-nano-30b-a3b`; OpenCode, Codex, and experimental
-  Claude Code now resolve that Build default without redundant model flags.
-- Tier 3 now streams staging, arm submission, completion, failure, collection,
-  and report-writing progress instead of appearing idle during Harbor startup.
-- Tier 3 now reports structured agent/provider failures such as NVIDIA Build
-  capacity exhaustion instead of scoring a no-trajectory fallback or emitting
-  a generated Harbor task-name mismatch.
-- Replaced provisional `test_coverage`, `tests`, and `coverage_percent` output
-  with one `test_discovery` detail. Reports now include `test_count`, supported
-  filename patterns, `execution_performed=false`, and
-  `coverage_measured=false`; projects must run tests and measure coverage in a
-  trusted environment or explicit sandbox.
 
 ### Fixed
 
@@ -123,6 +63,84 @@ All notable changes to SkillEvaluator are documented in this file.
   schema. Pre-status scored summaries remain consumable, coherent status-era
   failures remain visible without contributing scores, and marked current
   partial runs continue to fail closed.
+- Tier 2 scans now validate but do not follow the exact contained
+  `CLAUDE.md -> AGENTS.md` compatibility alias, scanning the exactly named,
+  independently discovered, single-link regular target once while continuing
+  to reject hard-linked selected files, linked manifests, directories, and all
+  other file redirects.
+
+## 0.1.0 - 2026-08-05
+
+### Added
+
+- CI DCO check that fails pull requests whose commits lack a `Signed-off-by`
+  trailer, matching the sign-off requirement in `CONTRIBUTING.md`.
+- Initial public release candidate.
+- Enabled optional semantic-version validation in the default Tier 1 pipeline,
+  including a public `--previous-version` monotonic-bump bound.
+
+- Added NVIDIA Build live-agent paths: direct OpenCode support plus Docker
+  compatibility bridges for Codex and experimental Claude Code, including
+  multi-turn tool-call continuation.
+- Fern documentation site configured for `docs.nvidia.com/skills/skillevaluator`,
+  building the `docs/` guides (installation, configuration, and the three
+  evaluation tiers) as MDX pages.
+- Expanded the documentation site to fifteen pages — quickstart, eval
+  datasets, agents and sandboxes, custom graders, reports, CI integration,
+  CLI reference, and environment variables — under a task-oriented
+  navigation, with every command verified against the current CLI.
+
+### Security
+
+- Isolated NVIDIA Build bridge credentials from vendor CLI processes using a
+  transient, root-managed, container-only key handoff with cleanup on failure.
+- Removed NVIDIA Build secrets from Harbor and Docker exec arguments using a
+  host-only key file, a non-secret subprocess sentinel, and per-exec container
+  handoffs; provider-secret aliases in `runtime_env` are rejected.
+- Hardened compatibility-bridge startup with a dynamic loopback port and
+  authenticated, process-bound readiness instead of a fixed health endpoint.
+- Tightened local macOS Seatbelt policy so nested workspaces can traverse home
+  directory metadata without gaining directory-listing or sibling-file access.
+- Removed implicit host-side pytest execution from default Tier 1
+  code-integrity validation. Test evidence is now collected with contained,
+  filename-only discovery that does not import or execute target-controlled
+  Python code.
+
+### Changed
+
+- Simplified the repository README into a concise documentation landing page,
+  retained a compact keyless `validate` quickstart, LLM-provider setup, and a
+  one-command `validate --full` path through all three tiers, broadened the
+  project description to agent artifacts starting with agent skills, and moved
+  detailed guidance to `docs.nvidia.com/skills/skillevaluator`.
+- Added Tier 3 cost-planning guidance, including trial-volume multipliers,
+  cost-saving flags, and the cost and isolation tradeoffs of local mode.
+- Standardized the product name as `SkillEvaluator` across documentation,
+  repository metadata, CLI output, and generated report artifacts.
+- Removed the optional OpenTelemetry integration, the
+  `skillevaluator[telemetry]` extra, and the `skillevaluator.telemetry` Python
+  module from the public distribution. Imports of that module now fail rather
+  than providing the former telemetry and safety helpers. Redaction and
+  child-process environment filtering remain available from
+  `skillevaluator.utils.redaction` and
+  `skillevaluator.utils.process_environment`; direct Protobuf and OpenTelemetry
+  dependencies are no longer installed.
+- Changed the public OpenAI default to `gpt-5.4-mini` and the NVIDIA Build
+  default to `nvidia/nemotron-3-nano-30b-a3b`; OpenCode, Codex, and experimental
+  Claude Code now resolve that Build default without redundant model flags.
+- Tier 3 now streams staging, arm submission, completion, failure, collection,
+  and report-writing progress instead of appearing idle during Harbor startup.
+- Tier 3 now reports structured agent/provider failures such as NVIDIA Build
+  capacity exhaustion instead of scoring a no-trajectory fallback or emitting
+  a generated Harbor task-name mismatch.
+- Replaced provisional `test_coverage`, `tests`, and `coverage_percent` output
+  with one `test_discovery` detail. Reports now include `test_count`, supported
+  filename patterns, `execution_performed=false`, and
+  `coverage_measured=false`; projects must run tests and measure coverage in a
+  trusted environment or explicit sandbox.
+
+### Fixed
+
 - Public benchmark cards now omit policy profiles, redact absolute host paths,
   and normalize imported internal or retired metadata before publication.
 - Previous-version validation now rejects catalog-wide scalar reuse and removal
@@ -143,8 +161,3 @@ All notable changes to SkillEvaluator are documented in this file.
 - Tier 2 content collection now prunes configured evaluation and version
   artifact directories before enforcing the discovered-path limit, so excluded
   generated results cannot cause false path-count failures.
-- Tier 2 scans now validate but do not follow the exact contained
-  `CLAUDE.md -> AGENTS.md` compatibility alias, scanning the exactly named,
-  independently discovered, single-link regular target once while continuing
-  to reject hard-linked selected files, linked manifests, directories, and all
-  other file redirects.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: "If you use SkillEvaluator in academic or technical work, please cite this software."
 title: "SkillEvaluator"
 type: software
-version: "0.1.0"
+version: "0.2.0"
 authors:
   - name: "NVIDIA Corporation"
 license: Apache-2.0

--- a/docs/developer-guide.mdx
+++ b/docs/developer-guide.mdx
@@ -143,7 +143,7 @@ cff-version: 1.2.0
 message: "If you use SkillEvaluator in academic or technical work, please cite this software."
 title: "SkillEvaluator"
 type: software
-version: "0.1.0"
+version: "0.2.0"
 authors:
   - name: "NVIDIA Corporation"
 license: Apache-2.0

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -22,7 +22,7 @@ Get your first evaluation result in about two minutes, with no API key. This pag
   skillevaluator --version
   ```
 
-  You should see `skillevaluator, version 0.1.0` (or newer).
+  You should see `skillevaluator, version 0.2.0` (or newer).
 
   <Tip>
   If the shell can't find `skillevaluator`, run `uv tool update-shell` and open a new terminal — uv installs tools to `~/.local/bin`, which may not be on your PATH yet.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires = ["setuptools >= 77", "wheel"]
 
 [project]
 name = "skillevaluator"
-version = "0.1.0"
+version = "0.2.0"
 description = "Multi-tier framework for evaluating AI agent skills with quality gates, semantic overlap detection, synthetic evaluation dataset generation, and live agent evaluation."
 authors = [{ name = "NVIDIA Corporation" }]
 readme = "README.md"

--- a/src/skillevaluator/__init__.py
+++ b/src/skillevaluator/__init__.py
@@ -10,6 +10,6 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("skillevaluator")
 except PackageNotFoundError:
-    __version__ = "0.1.0"
+    __version__ = "0.2.0"
 
 __all__ = ["__version__"]

--- a/uv.lock
+++ b/uv.lock
@@ -1967,7 +1967,7 @@ wheels = [
 
 [[package]]
 name = "skillevaluator"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- bump SkillEvaluator package, lockfile, citation, and fallback version metadata from 0.1.0 to 0.2.0
- cut the 2026-08-18 v0.2.0 changelog from changes merged since v0.1.0
- backfill the v0.1.0 changelog heading and update version examples in the documentation

## Impact

Prepares the repository for the v0.2.0 tag and GitHub Release. This release adds explicit Tier 2/Tier 3 gating controls, improves docs-only CI routing, hardens Tier 3 evaluator/fixture isolation, fixes boundary-aware quality scoring, and corrects Secure Docker exec redaction.

## Validation

- `ruff check .`
- `fern check`
- `uv lock --check`
- `pytest -q` — 3,766 passed, 13 skipped, 3 deselected
- `pytest -q tests/test_oss_packaging.py` — 36 passed
- `python -m build`
- OSS-boundary scan over source, wheel, and sdist
- `twine==6.2.0 check --strict dist/*`

All release metadata and built distribution metadata report version 0.2.0.
