### PR TITLE
fix(reporting): use commit SHA for pull request links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ All notable changes to SkillEvaluator are documented in this file.
   immutable dataset-truth snapshot with provenance metadata, and redesigned
   `BENCHMARK.md` as a decision-first publication card.
 
+### Fixed
+
+- GitHub Actions pull request reports now link source targets to the checked-out
+  repository revision instead of the synthetic `<number>/merge` ref, preventing
+  broken or cross-repository links.
+
 ## 0.2.0 - 2026-08-18
 
 ### Security

--- a/src/skillevaluator/utils/helpers.py
+++ b/src/skillevaluator/utils/helpers.py
@@ -101,6 +101,19 @@ def resolve_git_remote_url(local_path: Path) -> str | None:
         # In CI pipelines (detached HEAD), git returns "HEAD" so prefer an
         # explicitly supplied branch name.
         branch = os.environ.get("GITHUB_REF_NAME", "")
+        if re.fullmatch(r"\d+/merge", branch):
+            # A pull request merge ref belongs to the workflow repository, but
+            # local_path may point into a different checkout. Resolve the
+            # revision from the repository that contains local_path.
+            try:
+                branch = subprocess.check_output(
+                    ["git", "rev-parse", "HEAD"],
+                    cwd=repo_root,
+                    stderr=subprocess.DEVNULL,
+                    text=True,
+                ).strip()
+            except subprocess.CalledProcessError:
+                branch = ""
         if not branch:
             try:
                 branch = subprocess.check_output(

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -3,6 +3,7 @@
 
 """Tests for skillevaluator.utils module."""
 
+import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
@@ -164,6 +165,19 @@ def _clean_ci_env(**overrides: str) -> dict[str, str]:
     return env
 
 
+def _init_git_repo(path: Path, remote_url: str) -> str:
+    """Create a repository with one commit and return its HEAD revision."""
+    path.mkdir()
+    subprocess.run(["git", "init", "-q", str(path)], check=True)
+    subprocess.run(["git", "-C", str(path), "config", "user.name", "Test User"], check=True)
+    subprocess.run(["git", "-C", str(path), "config", "user.email", "test@example.com"], check=True)
+    (path / "README.md").write_text("test repository\n")
+    subprocess.run(["git", "-C", str(path), "add", "README.md"], check=True)
+    subprocess.run(["git", "-C", str(path), "commit", "-q", "-m", "Initial commit"], check=True)
+    subprocess.run(["git", "-C", str(path), "remote", "add", "origin", remote_url], check=True)
+    return subprocess.check_output(["git", "-C", str(path), "rev-parse", "HEAD"], text=True).strip()
+
+
 class TestResolveGitRemoteUrl:
     """Tests for the Git remote URL resolver used in HTML report links."""
 
@@ -207,3 +221,38 @@ class TestResolveGitRemoteUrl:
             url = resolve_git_remote_url(sub_dir)
         # Branch wins over the SHA because the scan is same-repo.
         assert url == "https://github.com/g/r/tree/feature/x/src"
+
+    def test_pull_request_merge_ref_uses_local_head_without_valid_github_sha(self, tmp_path: Path):
+        """A missing or malformed workflow SHA cannot replace the checked-out revision."""
+        repo_root = tmp_path / "repo"
+        head = _init_git_repo(repo_root, "git@github.com:g/r.git")
+        sub_dir = repo_root / "src"
+        sub_dir.mkdir()
+
+        for github_sha in (None, "not-a-commit"):
+            env = _clean_ci_env(GITHUB_REF_NAME="58/merge", GITHUB_REPOSITORY="g/r")
+            if github_sha is not None:
+                env["GITHUB_SHA"] = github_sha
+            with patch.dict("os.environ", env, clear=True):
+                url = resolve_git_remote_url(sub_dir)
+
+            assert url == f"https://github.com/g/r/tree/{head}/src"
+
+    def test_pull_request_merge_ref_uses_secondary_checkout_head(self, tmp_path: Path):
+        """Source links use the target checkout even when workflow metadata describes another repository."""
+        repo_root = tmp_path / "secondary"
+        head = _init_git_repo(repo_root, "https://github.com/example/secondary.git")
+        skill_dir = repo_root / "skills" / "demo"
+        skill_dir.mkdir(parents=True)
+        workflow_sha = "a" * 40
+        assert head != workflow_sha
+        env = _clean_ci_env(
+            GITHUB_REF_NAME="58/merge",
+            GITHUB_SHA=workflow_sha,
+            GITHUB_REPOSITORY="NVIDIA/SkillEvaluator",
+        )
+
+        with patch.dict("os.environ", env, clear=True):
+            url = resolve_git_remote_url(skill_dir)
+
+        assert url == f"https://github.com/example/secondary/tree/{head}/skills/demo"


### PR DESCRIPTION
## Summary

GitHub Actions uses values such as `58/merge` for `GITHUB_REF_NAME` during pull request jobs. Those values are not browsable repository branches, so generated report links can return 404.

Use `GITHUB_SHA` for pull request merge refs while keeping ordinary branch links unchanged.

Closes #59

## Verification

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] Added or updated focused tests
- [x] Updated documentation for user-visible changes
- [x] Ran `make lint`
- [x] Ran `make test`
- [x] Ran `make build`
- [x] Did not add credentials, private datasets, or proprietary benchmark content

## Release Impact

- [ ] No user-visible release note needed
- [x] Updated `CHANGELOG.md`
