### PR TITLE
fix(tier3): score single-step trials with null step_results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ All notable changes to SkillEvaluator are documented in this file.
 
 ### Fixed
 
+- Tier 3 now scores single-step trials again. Harbor serializes
+  `TrialResult.step_results` without `exclude_none`, so every single-step trial
+  writes an explicit `"step_results": null`, which the collector rejected as a
+  malformed constituent-step container and reported as an unscoreable reward.
+  Wrong container types are still rejected.
+
 - GitHub Actions pull request reports now link source targets to the checked-out
   repository revision instead of the synthetic `<number>/merge` ref, preventing
   broken or cross-repository links.

--- a/src/skillevaluator/tier3/harbor/collector.py
+++ b/src/skillevaluator/tier3/harbor/collector.py
@@ -1471,7 +1471,10 @@ def _constituent_default_reward_failure(result: dict[str, Any]) -> str:
         return "Authoritative verifier reward is failed; it was not scored"
 
     step_results = result.get("step_results")
-    if "step_results" in result and not isinstance(step_results, list):
+    # Harbor's TrialResult declares ``step_results`` as ``list[StepResult] | None`` and
+    # serializes it without ``exclude_none``, so every single-step trial writes an explicit
+    # ``null``. Treat that the same as an absent key; only a wrong container type is malformed.
+    if step_results is not None and not isinstance(step_results, list):
         return "Authoritative verifier result has malformed constituent steps; it was not scored"
     if not isinstance(step_results, list):
         return ""

--- a/tests/test_issue55_collector_truth.py
+++ b/tests/test_issue55_collector_truth.py
@@ -575,6 +575,30 @@ def test_authoritative_default_aggregate_rejects_malformed_step_results_containe
     assert "authoritative" in " ".join(result["execution_errors"]).casefold()
 
 
+def test_single_step_null_step_results_is_scored(tmp_path: Path) -> None:
+    """Harbor single-step trials serialize ``"step_results": null``; that must still score.
+
+    ``TrialResult.step_results`` is ``list[StepResult] | None`` and Harbor dumps it without
+    ``exclude_none``, so the key is always present with a null value for single-step trials --
+    the shape every generated eval case produces.
+    """
+    job_dir = tmp_path / "jobs" / "demo-opencode-with"
+    trial_dir = _write_authoritative_multistep_result(
+        job_dir,
+        "case-001__attempt",
+        aggregate=_default_reward("case-001", 1.0),
+        step_rewards=[_default_reward("case-001", 1.0)],
+    )
+    payload = json.loads((trial_dir / "result.json").read_text(encoding="utf-8"))
+    payload["step_results"] = None
+    (trial_dir / "result.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    result = _collect(tmp_path, skip_baseline=True, case_ids=["case-001"])
+
+    assert result["execution_status"] == "succeeded"
+    assert result["agents"]["opencode"]["conditions"]["with_skill"]["scored_attempts"] == 1
+
+
 def test_v2_root_aggregate_does_not_reclassify_constituent_missing_security_as_legacy(tmp_path: Path) -> None:
     job_dir = tmp_path / "jobs" / "demo-opencode-with"
     undeclared_five_metric_step = dict.fromkeys(LEGACY_METRICS, 1.0)


### PR DESCRIPTION
## Summary

Fixes #65.

Harbor's `TrialResult` declares `step_results: list[StepResult] | None = None`
(`harbor/models/trial/result.py:88`) and `Trial._finalize` serializes it with
`model_dump_json` and no `exclude_none` (`harbor/trial/trial.py:328`), so every
single-step trial writes an explicit `"step_results": null`. That is the shape
every eval case generated by `create-eval-dataset` produces, under the harbor
0.13.2 this project pins.

The collector guard tolerated an absent key but rejected the explicit null as a
malformed constituent-step container, so a trial whose verifier had written a
perfectly valid reward was marked unscoreable — and because any coverage
shortfall withholds the arm aggregate, a whole arm rendered `NO SCORE`.

This treats null the same as an absent key. Wrong container types (`{}`, a
string) are still rejected, and multi-step trials are unaffected because
`MultiStepTrial` always initializes `step_results` to a list. The
`"step_results" in result` clause is dropped as redundant: `.get()` already
returns `None` for a missing key.

User-visible effect: Tier 3 runs of generated datasets score again instead of
reporting `NO SCORE` for every metric.

## Verification

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] Added or updated focused tests
- [ ] Updated documentation for user-visible changes
- [x] Ran `make lint`
- [x] Ran `make test`
- [x] Ran `make build`
- [x] Did not add credentials, private datasets, or proprietary benchmark content

Added `test_single_step_null_step_results_is_scored`. Existing fixtures build
`result.json` by hand, either omitting the key or setting a list, so the shape
real Harbor writes was never exercised. The new test fails on `main` and passes
with this change; the neighbouring `{}` / string rejection cases still pass.

`make test` on this branch: 4851 passed, 18 skipped. Three failures in
`tests/test_tier3_public_runtime.py::test_anthropic_*` are present on `main` in
my environment as well and are unrelated — they come from the installed
`anthropic` SDK expecting an `httpx2.Client` while `httpx.Client` is passed.

No documentation change: the guard is internal and no documented behavior
description changes.

## Release Impact

- [ ] No user-visible release note needed
- [x] Updated `CHANGELOG.md`
