### PR TITLE
fix(tier3): parse SKILL.md frontmatter as YAML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ All notable changes to SkillEvaluator are documented in this file.
 
 ### Fixed
 
+- Tier 3 eval-dataset generation now parses `SKILL.md` frontmatter as YAML.
+  The previous line-based scan captured block-scalar indicators verbatim, so a
+  `description: >-` became the literal string `>-` in every generated prompt,
+  and multi-line quoted scalars were silently truncated to their first line.
+
 - GitHub Actions pull request reports now link source targets to the checked-out
   repository revision instead of the synthetic `<number>/merge` ref, preventing
   broken or cross-repository links.

--- a/src/skillevaluator/tier3/generate_dataset.py
+++ b/src/skillevaluator/tier3/generate_dataset.py
@@ -51,7 +51,10 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
+import yaml
+
 from skillevaluator.evaluation.results import DatasetGenerationError, DatasetGenerationResult
+from skillevaluator.validators.frontmatter_parser import FRONTMATTER_PATTERN
 
 _INTERACTIVE_RE = re.compile(
     r"interactive|opens?\s+a?\s*browser|waits?\s+for\s+(the\s+)?user|device.code\s+flow",
@@ -104,14 +107,20 @@ def _parse_skill(skill_path: Path, prompt_file: str | None = None) -> dict[str, 
     description = ""
     scripts: list[str] = []
 
-    # Parse frontmatter
-    fm_match = re.match(r"^---\s*\n(.*?)\n---", content, re.DOTALL)
+    # Parse frontmatter as YAML. A line-based scan would capture block-scalar
+    # indicators (``>-``, ``|``) verbatim and truncate multi-line quoted scalars,
+    # so both fields go through the same loader Tier 2 uses.
+    fm_match = FRONTMATTER_PATTERN.match(content)
     if fm_match:
-        for line in fm_match.group(1).split("\n"):
-            if line.startswith("name:"):
-                name = line.split(":", 1)[1].strip().strip("'\"")
-            elif line.startswith("description:"):
-                description = line.split(":", 1)[1].strip().strip("'\"")
+        try:
+            frontmatter = yaml.safe_load(fm_match.group(1))
+        except yaml.YAMLError:
+            frontmatter = None
+        if isinstance(frontmatter, dict):
+            if frontmatter.get("name"):
+                name = str(frontmatter["name"]).strip()
+            if frontmatter.get("description"):
+                description = str(frontmatter["description"]).strip()
 
     # Find scripts
     scripts_dir = skill_path / "scripts"

--- a/tests/tier3/test_generate_dataset_results.py
+++ b/tests/tier3/test_generate_dataset_results.py
@@ -263,3 +263,38 @@ def test_agent_collect_stages_agentskills_dataset(tmp_path, monkeypatch):
     assert data["skill_name"] == "my-skill"
     assert data["evals"][0]["prompt"] == "Use my-skill."
     assert data["evals"][0]["expected_output"] == "The agent uses the skill."
+
+
+def _parse(tmp_path, frontmatter: str):
+    skill = tmp_path / "my-skill"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text(f"---\n{frontmatter}\n---\n\n# body\n", encoding="utf-8")
+    return generate_dataset._parse_skill(skill)
+
+
+def test_parse_skill_folds_block_scalar_description(tmp_path):
+    """``description: >-`` must fold, not be captured as the literal indicator."""
+    parsed = _parse(
+        tmp_path,
+        "name: my-skill\ndescription: >-\n  Writing standards and a checklist.\n  Use when revising docs.",
+    )
+    assert parsed["description"] == "Writing standards and a checklist. Use when revising docs."
+    assert parsed["name"] == "my-skill"
+
+
+def test_parse_skill_keeps_literal_block_scalar_newlines(tmp_path):
+    parsed = _parse(tmp_path, "name: my-skill\ndescription: |-\n  first line\n  second line")
+    assert parsed["description"] == "first line\nsecond line"
+
+
+def test_parse_skill_does_not_truncate_multiline_quoted_description(tmp_path):
+    """A quoted scalar spanning lines was silently cut at the first line."""
+    parsed = _parse(tmp_path, 'name: my-skill\ndescription: "first part\n  second part"')
+    assert parsed["description"] == "first part second part"
+
+
+def test_parse_skill_falls_back_to_defaults_on_malformed_frontmatter(tmp_path):
+    """Unparseable YAML must degrade to the directory name and an empty description."""
+    parsed = _parse(tmp_path, "name: [unclosed\ndescription: broken")
+    assert parsed["name"] == "my-skill"
+    assert parsed["description"] == ""


### PR DESCRIPTION
## Summary

Fixes #66.

`_parse_skill` scanned `SKILL.md` frontmatter line by line, so any field whose
value continued past the first physical line was captured wrong. Continuation
lines are indented, so `line.startswith("description:")` never matched them and
only the indicator line was kept:

- `description: >-` yielded the literal string `>-`, which propagated into the
  console summary and into every prompt generated by the template path
- `|`, `|-`, and `>` behaved the same way
- multi-line quoted scalars were silently truncated to their first line, with no
  visible sentinel
- `name` was parsed by the same loop and had the same failure modes

This parses the frontmatter with `FRONTMATTER_PATTERN` plus `yaml.safe_load`,
matching how Tier 2 reads the same files in `embedding/extractor.py:256-263`.

Malformed YAML degrades to the existing defaults — directory name, empty
description — rather than raising, so skills without usable frontmatter behave
as they do today. `parse_frontmatter()` itself is not used here: it re-reads the
file and returns a `ValidationResult`, which does not fit those fallbacks.

`pyyaml` is already a core dependency (`pyproject.toml:45`), and `tier3` already
imports it in `evals_config`, `commands`, and `dataset_utils`.

User-visible effect: generated eval prompts and the `Description:` summary line
carry the real description instead of a YAML indicator or a truncated fragment.

## Verification

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] Added or updated focused tests
- [ ] Updated documentation for user-visible changes
- [x] Ran `make lint`
- [x] Ran `make test`
- [x] Ran `make build`
- [x] Did not add credentials, private datasets, or proprietary benchmark content

Added four `_parse_skill` tests: folded scalar, literal scalar, multi-line quoted
scalar, and malformed YAML falling back to defaults. All four fail on `main` and
pass with this change. Existing fixtures in
`tests/tier3/test_generate_dataset_results.py` use single-line frontmatter only,
so none asserted the previous behavior and none needed updating.

`make test` on this branch: 4854 passed, 18 skipped. Three failures in
`tests/test_tier3_public_runtime.py::test_anthropic_*` are present on `main` in
my environment as well and are unrelated — the installed `anthropic` SDK expects
an `httpx2.Client` while `httpx.Client` is passed.

No documentation change: this restores the documented frontmatter contract
rather than altering it.

## Release Impact

- [ ] No user-visible release note needed
- [x] Updated `CHANGELOG.md`
