### PR TITLE
fix(tier3): score Harbor single-step null results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ All notable changes to SkillEvaluator are documented in this file.
 
 ### Fixed
 
+- Tier 3 Harbor collection now accepts the `step_results: null` sentinel
+  emitted for successful single-step trials while retaining fail-closed
+  validation for malformed non-null multi-step result containers.
+
 - Tier 3 eval-dataset generation now parses `SKILL.md` frontmatter as YAML.
   The previous line-based scan captured block-scalar indicators verbatim, so a
   `description: >-` became the literal string `>-` in every generated prompt,

--- a/src/skillevaluator/tier3/harbor/collector.py
+++ b/src/skillevaluator/tier3/harbor/collector.py
@@ -1452,7 +1452,18 @@ def _standard_reward_metrics(
     return DEFAULT_METRICS if "security" in metric_names else LEGACY_METRICS
 
 
-def _constituent_default_reward_failure(result: dict[str, Any]) -> str:
+def _physical_steps_layout_present(trial_root: Path) -> bool:
+    """Return whether a trial has any physical steps entry, failing closed on I/O errors."""
+    try:
+        (trial_root / "steps").lstat()
+    except FileNotFoundError:
+        return False
+    except OSError:
+        return True
+    return True
+
+
+def _constituent_default_reward_failure(result: dict[str, Any], trial_root: Path | None = None) -> str:
     """Return a safe failure when a standard step reward cannot support its aggregate."""
     root_verifier = result.get("verifier_result")
     root_rewards = root_verifier.get("rewards") if isinstance(root_verifier, dict) else None
@@ -1471,7 +1482,16 @@ def _constituent_default_reward_failure(result: dict[str, Any]) -> str:
         return "Authoritative verifier reward is failed; it was not scored"
 
     step_results = result.get("step_results")
-    if "step_results" in result and not isinstance(step_results, list):
+    # Harbor serializes ``None`` for a successful single-step trial. A physical
+    # steps layout makes that sentinel ambiguous, so retain fail-closed handling.
+    if (
+        step_results is None
+        and "step_results" in result
+        and trial_root is not None
+        and _physical_steps_layout_present(trial_root)
+    ):
+        return "Authoritative verifier result has malformed constituent steps; it was not scored"
+    if step_results is not None and not isinstance(step_results, list):
         return "Authoritative verifier result has malformed constituent steps; it was not scored"
     if not isinstance(step_results, list):
         return ""
@@ -1535,9 +1555,13 @@ def _constituent_default_reward_failure(result: dict[str, Any]) -> str:
     return ""
 
 
-def _merge_constituent_default_reward_failure(data: dict[str, Any], result: dict[str, Any]) -> None:
+def _merge_constituent_default_reward_failure(
+    data: dict[str, Any],
+    result: dict[str, Any],
+    trial_root: Path | None = None,
+) -> None:
     """Make an aggregate unscoreable when one of its standard constituents is invalid."""
-    reason = _constituent_default_reward_failure(result)
+    reason = _constituent_default_reward_failure(result, trial_root)
     if not reason:
         return
     data["evaluation_status"] = "failed"
@@ -1569,7 +1593,7 @@ def _extract_rewards(job_dir: Path) -> list[dict[str, Any]]:
         data = _reward_from_harbor_result(result)
         if not data:
             continue
-        _merge_constituent_default_reward_failure(data, result)
+        _merge_constituent_default_reward_failure(data, result, trial_dir)
         _merge_trial_evaluation_failures(data, trial_dir)
         trial_name = str(result.get("trial_name") or trial_dir.name)
         data["_trial_name"] = trial_name
@@ -1613,7 +1637,7 @@ def _extract_rewards(job_dir: Path) -> list[dict[str, Any]]:
                 if result_file.exists():
                     result = _read_json(result_file)
                     if isinstance(result, dict):
-                        _merge_constituent_default_reward_failure(data, result)
+                        _merge_constituent_default_reward_failure(data, result, trial_dir)
                         data["_started_at"] = result.get("started_at")
                         if not data.get("entry_id"):
                             entry_id = _entry_id_from_harbor_result(result)
@@ -1642,7 +1666,7 @@ def _extract_rewards(job_dir: Path) -> list[dict[str, Any]]:
         data = _reward_from_harbor_result(result)
         if not data:
             continue
-        _merge_constituent_default_reward_failure(data, result)
+        _merge_constituent_default_reward_failure(data, result, trial_dir)
         _merge_trial_evaluation_failures(data, trial_dir)
         trial_name = str(result.get("trial_name") or trial_dir.name)
         data["_trial_name"] = trial_name
@@ -2297,6 +2321,10 @@ def _authoritative_step_names(trial_root: Path) -> tuple[bool, list[str] | None]
             return True, None
         return False, None
     step_results = result.get("step_results")
+    if step_results is None:
+        # Single-step Harbor trials serialize an explicit null. A physical
+        # steps layout still makes that shape ambiguous, so keep it fail-closed.
+        return (True, None) if steps_layout_present else (False, None)
     if not isinstance(step_results, list) or not step_results:
         return True, None
 

--- a/tests/test_harbor_negative_control_evidence.py
+++ b/tests/test_harbor_negative_control_evidence.py
@@ -122,12 +122,23 @@ def test_collect_persists_target_invocation_for_both_single_step_variants(tmp_pa
     jobs_dir = tmp_path / "jobs"
     for variant, observed_skill in (("with", "demo"), ("without", "unrelated")):
         trial_name = f"case-{variant}_attempt001"
-        _write_trial(
+        trial_dir = _write_trial(
             jobs_dir,
             variant=variant,
             trial_name=trial_name,
             reward=dict(STANDARD_REWARD),
             trajectory=_trajectory(skill=observed_skill),
+        )
+        (trial_dir / "result.json").write_text(
+            json.dumps(
+                {
+                    "trial_name": trial_name,
+                    "task_name": f"case-{variant}",
+                    "verifier_result": {"rewards": dict(STANDARD_REWARD)},
+                    "step_results": None,
+                }
+            ),
+            encoding="utf-8",
         )
         _write_job_result(jobs_dir / f"demo-opencode-{variant}", [trial_name])
 
@@ -145,7 +156,7 @@ def test_collect_persists_target_invocation_for_both_single_step_variants(tmp_pa
     assert result["agents"]["opencode"]["without_skill"]["skill_execution"] == 0.4
     for variant, trial_name in (("with-skill", "case-with_attempt001"), ("without-skill", "case-without_attempt001")):
         trial_dir = tmp_path / "results" / "opencode" / variant / "trials" / trial_name
-        assert {path.name for path in trial_dir.iterdir()} == {"reward.json", "trajectory.json"}
+        assert {path.name for path in trial_dir.iterdir()} == {"result.json", "reward.json", "trajectory.json"}
 
 
 def test_collect_redacts_successful_standard_reward_without_diagnostic_truncation(tmp_path: Path) -> None:
@@ -309,8 +320,8 @@ def test_collect_derives_authoritative_multistep_invocation_for_both_variants(
 
 @pytest.mark.parametrize(
     "trial_result",
-    [None, "{not-json", "{}"],
-    ids=("missing-result", "malformed-result", "no-step-results"),
+    [None, "{not-json", "{}", '{"step_results": null}'],
+    ids=("missing-result", "malformed-result", "no-step-results", "null-with-steps-layout"),
 )
 def test_collect_does_not_certify_root_non_invocation_when_step_layout_is_ambiguous(
     tmp_path: Path,
@@ -337,6 +348,41 @@ def test_collect_does_not_certify_root_non_invocation_when_step_layout_is_ambigu
     persisted = _persisted_reward(tmp_path, "with", trial_name)
     assert "skill_invoked" not in persisted
     assert "invocation_evidence_source" not in persisted
+
+
+def test_collect_rejects_null_step_results_with_a_physical_steps_layout(tmp_path: Path) -> None:
+    jobs_dir = tmp_path / "jobs"
+    trial_name = "null-with-steps_attempt001"
+    trial_dir = _write_trial(
+        jobs_dir,
+        variant="with",
+        trial_name=trial_name,
+        reward=dict(STANDARD_REWARD),
+        trajectory=_trajectory(skill="demo"),
+    )
+    step_agent_dir = trial_dir / "steps" / "unexpected" / "agent"
+    step_agent_dir.mkdir(parents=True)
+    (step_agent_dir / "trajectory.json").write_text(json.dumps(_trajectory(skill="demo")), encoding="utf-8")
+    (trial_dir / "result.json").write_text(
+        json.dumps(
+            {
+                "trial_name": trial_name,
+                "task_name": "null-with-steps",
+                "verifier_result": {"rewards": dict(STANDARD_REWARD)},
+                "step_results": None,
+            }
+        ),
+        encoding="utf-8",
+    )
+    _write_job_result(jobs_dir / "demo-opencode-with", [trial_name])
+
+    result = _collect(tmp_path)
+
+    condition = result["agents"]["opencode"]["conditions"]["with_skill"]
+    assert result["execution_status"] == "failed"
+    assert condition["execution_status"] == "failed"
+    assert condition["scored_attempts"] == 0
+    assert "constituent" in " ".join(condition["execution_errors"]).casefold()
 
 
 def test_collect_replaces_spoofed_standard_evidence_and_leaves_unreadable_unknown(tmp_path: Path) -> None:

--- a/tests/test_issue55_collector_truth.py
+++ b/tests/test_issue55_collector_truth.py
@@ -552,6 +552,35 @@ def test_authoritative_default_aggregate_rejects_malformed_step_entry(
     assert "constituent" in " ".join(result["execution_errors"]).casefold()
 
 
+def test_single_step_harbor_null_step_results_keeps_custom_reward_scoreable(tmp_path: Path) -> None:
+    job_dir = tmp_path / "jobs" / "demo-opencode-with"
+    trial_name = "case-001__attempt"
+    trial_dir = job_dir / trial_name
+    reward = {"overall": 0.75, "domain_quality": 0.9}
+    (trial_dir / "result.json").parent.mkdir(parents=True)
+    (trial_dir / "result.json").write_text(
+        json.dumps(
+            {
+                "trial_name": trial_name,
+                "task_name": "nvidia/case-001",
+                "verifier_result": {"rewards": reward},
+                "step_results": None,
+            }
+        ),
+        encoding="utf-8",
+    )
+    _write_reward(job_dir, trial_name, reward)
+    _write_complete_job_result(job_dir, [trial_name])
+
+    result = _collect(tmp_path, skip_baseline=True, case_ids=["case-001"])
+
+    agent = result["agents"]["opencode"]
+    assert result["execution_status"] == "succeeded"
+    assert agent["conditions"]["with_skill"]["scored_attempts"] == 1
+    assert agent["custom_with_skill"] == {"domain_quality": 0.9}
+    assert agent["pass_at_k"]["with_skill"]["rate"] == 1.0
+
+
 @pytest.mark.parametrize("invalid_steps", [{}, "malformed-steps"], ids=("mapping", "string"))
 def test_authoritative_default_aggregate_rejects_malformed_step_results_container(
     tmp_path: Path,


### PR DESCRIPTION
## Summary

- Accept the `step_results: null` sentinel emitted by Harbor for successful single-step trials.
- Preserve trusted root-trajectory invocation evidence for valid single-step A/B results.
- Keep malformed non-null containers and `null` results with an unexpected physical `steps/` layout fail-closed.
- Add scoring, A/B trajectory-evidence, and ambiguous-layout regressions plus a changelog entry.
- Do not change the pinned Harbor version.

Closes #65.

PR #67 documents the same root cause but currently conflicts with `main`. This PR applies the correction cleanly to current `main` and extends the regression coverage to trusted A/B trajectory evidence. Credit to @genkey6 for the original diagnosis and implementation. PR #63 should rebase after this lands before its provider-backed Harbor verification.

## Verification

- Test-first regression failed on `main` because the condition was reported failed instead of succeeded.
- Affected collector and negative-control suites: `195 passed, 4 skipped`.
- `make PYTHON=.venv/bin/python lint`: passed.
- `make PYTHON=.venv/bin/python build`: wheel and sdist built successfully.
- `git diff --check`: passed.
- Independent code review: no actionable findings after two fail-closed edge cases were added.
- Real NVIDIA Build + OpenCode + Docker Harbor A/B smoke: completed in 276 seconds. Both retained raw trials contained explicit `step_results: null`, `exception_info: null`, and object verifier rewards; both with-skill and without-skill conditions succeeded with `1/1` scored attempts and no execution errors. The retained real jobs were replayed through the final collector revision successfully.

Full-suite disclosure: two serial runs exercised all tests. One ended with `4,858 passed` plus the existing 2-second FIFO subprocess timeout; the other ended with `4,857 passed` plus that timeout and one bridge-worker timing assertion. Both timing-sensitive failures passed together immediately afterward (`2 passed in 7.09s`). The final affected surface was rerun after the trajectory/layout hardening and is green as reported above.

## Checklist

- [x] Added focused regressions
- [x] Updated `CHANGELOG.md`
- [x] Ran lint
- [x] Ran build
- [x] Ran a real provider-backed Harbor smoke
- [x] Did not add credentials, private datasets, or proprietary content
