### PR TITLE
chore(release): prepare v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to SkillEvaluator are documented in this file.
 
 ## Unreleased
 
+## 0.2.1 - 2026-08-24
+
 ### Added
 
 - Added a public benchmark publication gate, regression coverage, and a
@@ -14,6 +16,12 @@ All notable changes to SkillEvaluator are documented in this file.
 - Unified Tier 3 scoring around the canonical five dimensions, persisted an
   immutable dataset-truth snapshot with provenance metadata, and redesigned
   `BENCHMARK.md` as a decision-first publication card.
+- Updated public OpenAI / Anthropic / Bedrock chat defaults to pinned frontier
+  models (`gpt-5.6-sol`, `claude-opus-5`, `us.anthropic.claude-opus-5`),
+  centralized in `provider_config`, and documented `gpt-5.4-mini` as the
+  lower-cost OpenAI `SKILL_EVAL_LLM_MODEL` alternative. Raised
+  dimension/insights judge token budgets to 4096 and widened the gpt-5\*
+  temperature guard to bare model IDs.
 
 ### Fixed
 
@@ -25,39 +33,6 @@ All notable changes to SkillEvaluator are documented in this file.
 - GitHub Actions pull request reports now link source targets to the checked-out
   repository revision instead of the synthetic `<number>/merge` ref, preventing
   broken or cross-repository links.
-
-## 0.2.0 - 2026-08-18
-
-### Security
-
-- Secure Docker exec redaction now ignores environment values shorter than eight
-  characters, matching the exact secret length floor used elsewhere. Short
-  flags such as `CLAUDE_CODE_DISABLE_POLICY_SKILLS=1` no longer rewrite digits
-  in `docker exec` output, which had broken NVIDIA Build bridge loopback
-  origins during Tier 3 preflight.
-
-### Changed
-
-- Updated public OpenAI / Anthropic / Bedrock chat defaults to pinned frontier
-  models (`gpt-5.6-sol`, `claude-opus-5`, `us.anthropic.claude-opus-5`),
-  centralized in `provider_config`, and documented `gpt-5.4-mini` as the
-  lower-cost OpenAI `SKILL_EVAL_LLM_MODEL` alternative. Raised
-  dimension/insights judge token budgets to 4096 and widened the gpt-5\*
-  temperature guard to bare model IDs.
-- Added explicit `--block-on-dedup` / `--no-block-on-dedup` and
-  `--block-on-agent-eval` / `--no-block-on-agent-eval` controls with
-  backward-compatible defaults, Tier 3 source preflight, and consistent gating
-  metadata across CLI, JSON, Markdown, and HTML reports.
-- Reduced pull-request runner use for changes confined to `docs/**` and
-  `fern/**`: DCO, Gitleaks, and pinned Fern validation still run, while mixed
-  and non-docs changes retain the complete Linux, macOS, Windows, packaging,
-  and security matrix. Superseded pull-request CI and security runs are
-  cancelled so they do not consume runners after a newer commit is pushed.
-  Path classification executes from the pull request base revision so a
-  change cannot weaken its own CI routing.
-
-### Fixed
-
 - Tier 3 LLM insights now receive explicit labels and bounded expected-behavior
   context for `expected_skill: null` negative controls, and the judge is
   instructed not to flag unrelated successes without invocation or
@@ -84,6 +59,37 @@ All notable changes to SkillEvaluator are documented in this file.
   intent, README guidance, or exclusivity from prose;
   use `rubric-eval` for semantic documentation judgments and Tier 3 for
   observed agent behavior.
+
+## 0.2.0 - 2026-08-18
+
+### Security
+
+- Secure Docker exec redaction now ignores environment values shorter than eight
+  characters, matching the exact secret length floor used elsewhere. Short
+  flags such as `CLAUDE_CODE_DISABLE_POLICY_SKILLS=1` no longer rewrite digits
+  in `docker exec` output, which had broken NVIDIA Build bridge loopback
+  origins during Tier 3 preflight.
+
+### Changed
+
+- Added explicit `--block-on-dedup` / `--no-block-on-dedup` and
+  `--block-on-agent-eval` / `--no-block-on-agent-eval` controls with
+  backward-compatible defaults, Tier 3 source preflight, and consistent gating
+  metadata across CLI, JSON, Markdown, and HTML reports.
+- Reduced pull-request runner use for changes confined to `docs/**` and
+  `fern/**`: DCO, Gitleaks, and pinned Fern validation still run, while mixed
+  and non-docs changes retain the complete Linux, macOS, Windows, packaging,
+  and security matrix. Superseded pull-request CI and security runs are
+  cancelled so they do not consume runners after a newer commit is pushed.
+  Path classification executes from the pull request base revision so a
+  change cannot weaken its own CI routing.
+
+### Fixed
+
+- Quality scoring now uses boundary-aware and context-aware matching for XML tags,
+  reserved names, MCP guidance, README references, time references, exclusivity
+  language, instruction action verbs, and nested Markdown links, avoiding
+  incidental-word score changes.
 - Tier 3 generated tasks now stage only an entry's declared `files`, preventing
   undeclared fixtures from the shared `evals/files/` directory from appearing
   in that task's `/workspace/input/`, while preserving copy-all behavior for

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: "If you use SkillEvaluator in academic or technical work, please cite this software."
 title: "SkillEvaluator"
 type: software
-version: "0.2.0"
+version: "0.2.1"
 authors:
   - name: "NVIDIA Corporation"
 license: Apache-2.0

--- a/docs/developer-guide.mdx
+++ b/docs/developer-guide.mdx
@@ -143,7 +143,7 @@ cff-version: 1.2.0
 message: "If you use SkillEvaluator in academic or technical work, please cite this software."
 title: "SkillEvaluator"
 type: software
-version: "0.2.0"
+version: "0.2.1"
 authors:
   - name: "NVIDIA Corporation"
 license: Apache-2.0

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -22,7 +22,7 @@ Get your first evaluation result in about two minutes, with no API key. This pag
   skillevaluator --version
   ```
 
-  You should see `skillevaluator, version 0.2.0` (or newer).
+  You should see `skillevaluator, version 0.2.1` (or newer).
 
   <Tip>
   If the shell can't find `skillevaluator`, run `uv tool update-shell` and open a new terminal — uv installs tools to `~/.local/bin`, which may not be on your PATH yet.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires = ["setuptools >= 77", "wheel"]
 
 [project]
 name = "skillevaluator"
-version = "0.2.0"
+version = "0.2.1"
 description = "Multi-tier framework for evaluating AI agent skills with quality gates, semantic overlap detection, synthetic evaluation dataset generation, and live agent evaluation."
 authors = [{ name = "NVIDIA Corporation" }]
 readme = "README.md"

--- a/src/skillevaluator/__init__.py
+++ b/src/skillevaluator/__init__.py
@@ -10,6 +10,6 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("skillevaluator")
 except PackageNotFoundError:
-    __version__ = "0.2.0"
+    __version__ = "0.2.1"
 
 __all__ = ["__version__"]

--- a/uv.lock
+++ b/uv.lock
@@ -1967,7 +1967,7 @@ wheels = [
 
 [[package]]
 name = "skillevaluator"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- bump SkillEvaluator version metadata from `0.2.0` to `0.2.1`
- cut the `0.2.1` changelog section for all changes merged since the v0.2.0 preparation PR while preserving the historical v0.2.0 notes
- update the citation metadata, developer guide example, and quickstart version output

## Impact

Prepares the repository for a future v0.2.1 tag and GitHub Release. This PR changes release metadata and documentation only; it does not introduce additional runtime behavior beyond reporting the new package version.

## Validation

- `uv lock --check`
- `ruff check .`
- `fern check` (0 errors)
- `pytest -q` — 4,857 passed, 18 skipped, 4 deselected
- `pytest -q tests/test_oss_packaging.py` — 37 passed
- built the wheel and sdist in an isolated temporary directory
- OSS-boundary scan passed for the source tree, wheel, and sdist
- `twine==6.2.0 check --strict` passed for both distributions
- wheel and sdist metadata, an isolated wheel import, and the installed CLI all report `0.2.1`
