### PR TITLE
fix(tier3): avoid transcript runtime false positives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to SkillEvaluator are documented in this file.
 
 ### Fixed
 
+- Tier 3 Harbor collection no longer scans an agent's unstructured transcript
+  for runtime-error phrases when the recorded exception belongs to the
+  verifier, health check, or task. Correct answers that discuss errors such as
+  `401 Unauthorized` are no longer misreported as agent runtime failures.
 - Tier 3 paired pass@k evidence now respects Python's active integer-string
   conversion limit, preserves nonzero Wilson interval widths and paired-effect
   directions at large case counts, and documents exact-rational omission

--- a/src/skillevaluator/tier3/harbor/collector.py
+++ b/src/skillevaluator/tier3/harbor/collector.py
@@ -561,7 +561,10 @@ def _agent_runtime_failure_reason(trial_dir: Path) -> str:
     exception_type, exception_reason = _trial_exception_details(trial_dir)
     agent_reason = _agent_log_runtime_failure_reason(
         trial_dir,
-        include_text_logs=bool(exception_reason),
+        include_text_logs=(
+            exception_type in _AGENT_RUNTIME_EXCEPTION_TYPES
+            or exception_type in _UNCONDITIONAL_AGENT_RUNTIME_EXCEPTION_TYPES
+        ),
     )
     if agent_reason:
         return agent_reason

--- a/tests/test_harbor_collector_runtime_failures.py
+++ b/tests/test_harbor_collector_runtime_failures.py
@@ -9,7 +9,10 @@ import json
 from pathlib import Path
 
 from skillevaluator.evaluation.tier3_report import render_agent_eval_html_report
-from skillevaluator.tier3.harbor.collector import collect_harbor_results
+from skillevaluator.tier3.harbor.collector import (
+    _agent_runtime_failure_reason,
+    collect_harbor_results,
+)
 from skillevaluator.tier3.harbor.metrics import DEFAULT_METRIC_SET
 
 
@@ -126,6 +129,30 @@ def test_agent_timeout_invalidates_reward_and_is_reported_as_trial_failure(tmp_p
     assert opencode["trial_failures"]["with_skill"] == [
         {"trial": "case-001__attempt", "reason": "AgentTimeoutError: Agent timed out after 600 seconds"}
     ]
+
+
+def test_verifier_exception_does_not_scan_plain_agent_transcript(tmp_path: Path) -> None:
+    """Correct agent prose must not turn a verifier failure into an agent failure."""
+    trial_dir = tmp_path / "case-001__attempt"
+    agent_dir = trial_dir / "agent"
+    agent_dir.mkdir(parents=True)
+    (trial_dir / "result.json").write_text(
+        json.dumps(
+            {
+                "exception_info": {
+                    "exception_type": "VerifierError",
+                    "exception_message": "verifier exited nonzero",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    (agent_dir / "opencode.txt").write_text(
+        "Troubleshooting: an invalid credential can produce 401 Unauthorized.\n",
+        encoding="utf-8",
+    )
+
+    assert _agent_runtime_failure_reason(trial_dir) == ""
 
 
 def test_errored_job_stats_suppress_rewards_without_trial_exception(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Fixes #82.

Tier 3 Harbor collection previously enabled an unstructured whole-transcript
scan whenever any trial exception existed. That allowed verifier, health-check,
or task failures to turn ordinary agent prose such as `401 Unauthorized` into
an incorrectly attributed agent runtime failure.

This change limits the plaintext transcript fallback to exception types that
the collector already classifies as agent-runtime failures. Structured agent
error records and tokenless-trajectory detection remain active for all trials,
and the existing timeout handling is preserved.

A focused regression test covers a verifier exception paired with a correct
agent transcript that discusses an authentication error. The changelog now
documents the corrected diagnostic behavior.

## Verification

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] Added or updated focused tests
- [x] Updated documentation for user-visible changes
- [x] Ran `make lint`
- [x] Ran `make test`
- [x] Ran `make build`
- [x] Did not add credentials, private datasets, or proprietary benchmark content

Focused tests: `21 passed`.

The full Linux test run completed with 5,067 passed, 51 skipped, and 57
environment/baseline failures. Representative failures reproduced unchanged
after reversing this patch on the exact upstream base: the remote host exposes
an unmanaged `/usr/bin/codex`, has port 18080 occupied, and uses a Python 3.12
HTMLParser API incompatible with the current validator implementation.

## Release Impact

- [ ] No user-visible release note needed
- [x] Updated `CHANGELOG.md`
