### PR TITLE
fix: flag Windows PII usernames that start with s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to SkillEvaluator are documented in this file.
 
 ### Fixed
 
+- Windows personal-path PII now flags `C:\Users\...` usernames that start with
+  `s` (for example `steve`), matching the intended whitespace class rather than
+  excluding the letter `s` ([#87](https://github.com/NVIDIA/SkillEvaluator/issues/87)).
+
 - Tier 3 paired pass@k evidence now respects Python's active integer-string
   conversion limit, preserves nonzero Wilson interval widths and paired-effect
   directions at large case counts, and documents exact-rational omission

--- a/src/skillevaluator/config/pii_patterns.yaml
+++ b/src/skillevaluator/config/pii_patterns.yaml
@@ -33,7 +33,7 @@ personal_paths:
       - "DELETE /users"
       - "api/users"
 
-  - pattern: 'C:\\Users\\[^\\s]+'
+  - pattern: "C:\\\\Users\\\\[^\\\\\\s]+"
     severity: high
     description: Personal Windows user path
     suggestion: "Use generic path like C:\\path\\to\\file or %USERPROFILE% variable"

--- a/tests/validators/test_security.py
+++ b/tests/validators/test_security.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 
 import pytest
 
+from skillevaluator.config import load_pii_patterns
 from skillevaluator.reporting import CLIReporter, HTMLReporter, JSONReporter, MarkdownReporter
 from skillevaluator.utils.tool_runner import ToolResult, Tools
 from skillevaluator.validators.base import Finding, Severity, ValidationResult
@@ -134,6 +135,55 @@ Install from: /Users/johndoe/projects/secret/
 
         all_findings = result.errors + result.warnings
         assert any("path" in f.lower() for f in all_findings), f"Expected path detection. Findings: {all_findings}"
+
+    def test_detects_windows_personal_path_for_alice(self, tmp_path: Path):
+        """Windows C:\\Users\\alice paths are still flagged."""
+        skill_dir = tmp_path / "win-alice-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("""---
+name: win-alice-skill
+description: A skill with a Windows personal path for testing detection
+---
+
+# Path Test
+
+See C:\\Users\\alice\\Documents\\notes.txt
+""")
+        result = SecurityValidator().validate_pii_only(skill_dir)
+        all_findings = result.errors + result.warnings
+        assert any("alice" in f and "C:\\Users\\" in f for f in all_findings), (
+            f"Expected Windows path detection for alice. Findings: {all_findings}"
+        )
+
+    def test_detects_windows_personal_path_for_steve(self, tmp_path: Path):
+        """Windows C:\\Users\\steve paths are flagged (usernames starting with s)."""
+        skill_dir = tmp_path / "win-steve-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("""---
+name: win-steve-skill
+description: A skill with a Windows personal path for testing detection
+---
+
+# Path Test
+
+See C:\\Users\\steve\\Documents\\notes.txt
+""")
+        result = SecurityValidator().validate_pii_only(skill_dir)
+        all_findings = result.errors + result.warnings
+        assert any("steve" in f and "C:\\Users\\" in f for f in all_findings), (
+            f"Expected Windows path detection for steve. Findings: {all_findings}"
+        )
+
+    def test_windows_personal_path_pattern_matches_usernames_starting_with_s(self):
+        """Loaded Windows personal-path regex uses a whitespace class, not letter s."""
+        pattern = load_pii_patterns()["personal_paths"][1]["pattern"]
+        assert r"[^\\\s]" in pattern or r"[^\s]" in pattern
+        regex = re.compile(pattern, re.IGNORECASE)
+        assert regex.search(r"C:\Users\steve\Documents\notes.txt")
+        assert regex.search(r"C:\Users\alice\Documents\notes.txt")
+        assert regex.search(r"C:\Users\sam\file.txt")
+        assert regex.search(r"C:\Users\session\file.txt")
+        assert not regex.search(r"C:\Temp\file.txt")
 
     def test_api_route_not_flagged_as_personal_path(self, tmp_path: Path):
         """Test that REST API routes like /users/:id are not flagged as personal macOS paths."""


### PR DESCRIPTION
## Summary

The Windows personal-path PII rule was single-quoted YAML, so `\\s` stayed backslash plus the letter s. Usernames starting with s (steve, sam, session) never matched. Alice still did.

I quoted the pattern the same way as the macOS rule so the class is "not backslash, not whitespace". Fixes #87.

## Verification

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] Added or updated focused tests
- [x] Updated documentation for user-visible changes
- [x] Ran `make lint`
- [x] Ran `make test`
- [x] Ran `make build`
- [x] Did not add credentials, private datasets, or proprietary benchmark content

## Release Impact

- [x] Updated `CHANGELOG.md`

Focused tests cover alice (still flagged) and steve (the miss). I also asserted the loaded regex matches sam/session and does not match `C:\Temp\...`.

`make lint` is clean. The PII test files pass (243). Full `make test` on this machine hits a pre-existing Python 3.12.2 `HTMLParser.set_cdata_mode(escapable=...)` failure in `test_markdown.py` / `test_quality_score.py`. That fails on main with no local changes too. Not part of this PR.