### PR TITLE
fix: do not let frontmatter MIT hide a GPL LICENSE file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ All notable changes to SkillEvaluator are documented in this file.
 
 - License detection no longer treats a frontmatter `license` identifier as
   authoritative when a LICENSE file declares a different license. Claiming
-  MIT while shipping GPL-3.0 now fails closed
+  MIT while shipping GPL-3.0 now fails closed. Every LICENSE/COPYING file is
+  reconciled, an unidentified license file is not treated as absent, and a
+  blocking conflict no longer publishes `license_status=allowed`
   ([#85](https://github.com/NVIDIA/SkillEvaluator/issues/85)).
 - Tier 3 paired pass@k evidence now respects Python's active integer-string
   conversion limit, preserves nonzero Wilson interval widths and paired-effect

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to SkillEvaluator are documented in this file.
 
 ### Fixed
 
+- License detection no longer treats a frontmatter `license` identifier as
+  authoritative when a LICENSE file declares a different license. Claiming
+  MIT while shipping GPL-3.0 now fails closed
+  ([#85](https://github.com/NVIDIA/SkillEvaluator/issues/85)).
 - Tier 3 paired pass@k evidence now respects Python's active integer-string
   conversion limit, preserves nonzero Wilson interval widths and paired-effect
   directions at large case counts, and documents exact-rational omission

--- a/src/skillevaluator/validators/license.py
+++ b/src/skillevaluator/validators/license.py
@@ -37,6 +37,8 @@ _THE_PREFIX_PATTERN = re.compile(r"^(the-)?")
 
 # File reference indicators in license field values
 _FILE_REFERENCE_KEYWORDS = frozenset(["see ", "refer to ", "license.txt", "license.md", "copying"])
+_LICENSE_DECLARATION_STEMS = frozenset({"license", "licence", "copying"})
+_TERMINAL_LICENSE_STATUSES = frozenset({"conflict", "unrecognized"})
 
 
 @dataclass(slots=True)
@@ -48,6 +50,19 @@ class LicenseDetection:
     confidence: str
     file_path: str | None = None
     details: str | None = None
+
+
+def _is_license_declaration_filename(name: str) -> bool:
+    """Return True for LICENSE/COPYING-style names, not NOTICE files."""
+    return Path(name).stem.lower() in _LICENSE_DECLARATION_STEMS
+
+
+@dataclass(slots=True)
+class _LicenseFileScan:
+    """All detections and unidentified declaration files under an asset."""
+
+    detections: list[LicenseDetection]
+    unrecognized_declaration_files: list[str]
 
 
 class LicenseValidator(ValidatorBase):
@@ -126,6 +141,8 @@ class LicenseValidator(ValidatorBase):
         result = ValidationResult()
         detection = self._detect_license(asset_path, result)
 
+        if result.metadata.get("license_status") in _TERMINAL_LICENSE_STATUSES:
+            return result
         if detection is None:
             self._handle_no_license(result)
         else:
@@ -143,22 +160,25 @@ class LicenseValidator(ValidatorBase):
 
     def _detect_license(self, asset_path: Path, result: ValidationResult) -> LicenseDetection | None:
         """Attempt to detect license using multi-tier approach."""
-        # Tier 1: Frontmatter declaration
+        scan = self._collect_license_files(asset_path)
+
         if detection := self._check_frontmatter(asset_path):
             result.add_message(f"Tier 1: Found license declaration in {detection.source}")
             if detection.license_id and self._is_file_reference(detection.license_id):
                 result.add_message(f"  License field references file: '{detection.license_id}'")
-                if file_detection := self._check_license_file(asset_path):
-                    return file_detection
+                chosen = self._choose_from_license_files(scan, result)
+                if chosen is not None or result.metadata.get("license_status") in _TERMINAL_LICENSE_STATUSES:
+                    return chosen
             else:
-                return self._resolve_frontmatter_and_file(detection, asset_path, result)
+                return self._resolve_frontmatter_and_files(detection, scan, result)
 
-        # Tier 2: LICENSE file
-        if detection := self._check_license_file(asset_path):
-            result.add_message(f"Tier 2: Detected {detection.license_id} from {detection.file_path}")
-            return detection
+        chosen = self._choose_from_license_files(scan, result)
+        if result.metadata.get("license_status") in _TERMINAL_LICENSE_STATUSES:
+            return chosen
+        if chosen is not None:
+            result.add_message(f"Tier 2: Detected {chosen.license_id} from {chosen.file_path}")
+            return chosen
 
-        # Tier 3: SPDX headers in source files
         if detection := self._scan_source_headers(asset_path):
             result.add_message(f"Tier 3: Found SPDX header '{detection.license_id}' in {detection.file_path}")
             return detection
@@ -198,124 +218,236 @@ class LicenseValidator(ValidatorBase):
         lower = license_value.lower()
         return any(ref in lower for ref in _FILE_REFERENCE_KEYWORDS)
 
-    def _resolve_frontmatter_and_file(
-        self,
-        frontmatter: LicenseDetection,
-        asset_path: Path,
-        result: ValidationResult,
-    ) -> LicenseDetection:
-        """Reconcile a concrete frontmatter license with a LICENSE file, if present.
-
-        Matching IDs keep the frontmatter result. A blocked ID on either side
-        is returned so validation fails closed. Distinct allowed IDs emit a
-        mismatch finding instead of silently preferring frontmatter.
-        """
-        file_detection = self._check_license_file(asset_path)
-        if file_detection is None or not frontmatter.license_id or not file_detection.license_id:
-            return frontmatter
-
-        fm_norm = self._normalize_license_id(frontmatter.license_id)
-        file_norm = self._normalize_license_id(file_detection.license_id)
-        if fm_norm == file_norm:
-            return frontmatter
-
-        return self._resolve_license_conflict(frontmatter, file_detection, fm_norm, file_norm, result)
-
-    def _resolve_license_conflict(
-        self,
-        frontmatter: LicenseDetection,
-        file_detection: LicenseDetection,
-        fm_norm: str,
-        file_norm: str,
-        result: ValidationResult,
-    ) -> LicenseDetection:
-        """Choose which detection to validate when frontmatter and LICENSE disagree."""
-        result.add_message(
-            f"Frontmatter license '{frontmatter.license_id}' differs from "
-            f"{file_detection.file_path} license '{file_detection.license_id}'"
-        )
-        if file_norm in self._normalized_blocklist:
-            result.add_message(f"Tier 2: Detected {file_detection.license_id} from {file_detection.file_path}")
-            return file_detection
-        if fm_norm in self._normalized_blocklist:
-            return frontmatter
-        if fm_norm in self._normalized_allowlist and file_norm in self._normalized_allowlist:
-            self._add_license_mismatch_finding(result, frontmatter, file_detection)
-        return frontmatter
-
-    @staticmethod
-    def _add_license_mismatch_finding(
-        result: ValidationResult,
-        frontmatter: LicenseDetection,
-        file_detection: LicenseDetection,
-    ) -> None:
-        """Fail closed when two allowed licenses disagree."""
-        result.add_structured_finding(
-            Finding(
-                category="LICENSE",
-                severity="HIGH",
-                check_name="frontmatter_license_mismatch",
-                message=(
-                    f"Frontmatter license '{frontmatter.license_id}' conflicts with "
-                    f"{file_detection.file_path} license '{file_detection.license_id}'"
-                ),
-                file_path=file_detection.file_path or frontmatter.file_path or "unknown",
-                suggestion=(
-                    "Make the SKILL.md license field match the LICENSE file, or remove one of the declarations."
-                ),
-            ),
-            is_error=True,
-        )
-
-    def _check_license_file(self, asset_path: Path) -> LicenseDetection | None:
-        """Tier 2: Parse LICENSE files and match against known patterns."""
+    def _collect_license_files(self, asset_path: Path) -> _LicenseFileScan:
+        """Read every conventional license filename and collect all matches."""
+        detections: list[LicenseDetection] = []
+        unrecognized: list[str] = []
         for license_name in LICENSE_FILE_NAMES:
             license_path = asset_path / license_name
-            if not license_path.exists():
+            if not license_path.is_file():
                 continue
-
             try:
                 content = license_path.read_text(encoding="utf-8", errors="ignore")
-
-                if detected := self._identify_license_from_content(content):
-                    return LicenseDetection(
-                        license_id=detected["license_id"],
+            except Exception as exc:
+                logger.debug("Could not read %s: %s", license_path, exc)
+                if _is_license_declaration_filename(license_name):
+                    unrecognized.append(license_name)
+                continue
+            matches = self._identify_all_licenses_from_content(content)
+            if matches:
+                detections.extend(
+                    LicenseDetection(
+                        license_id=match["license_id"],
                         source="license_file",
-                        confidence=detected["confidence"],
+                        confidence=match["confidence"],
                         file_path=license_name,
                     )
-
-                if indicator := self._find_proprietary_indicator(content):
-                    return LicenseDetection(
+                    for match in matches
+                )
+                continue
+            if indicator := self._find_proprietary_indicator(content):
+                detections.append(
+                    LicenseDetection(
                         license_id="Proprietary",
                         source="license_file",
                         confidence="high",
                         file_path=license_name,
                         details=f"Found proprietary indicator: '{indicator}'",
                     )
-            except Exception as e:
-                logger.debug("Could not read %s: %s", license_path, e)
+                )
+                continue
+            if _is_license_declaration_filename(license_name):
+                unrecognized.append(license_name)
+        return _LicenseFileScan(detections, unrecognized)
 
-        return None
-
-    def _identify_license_from_content(self, content: str) -> dict | None:
-        """Match LICENSE content against known patterns."""
+    def _identify_all_licenses_from_content(self, content: str) -> list[dict]:
+        """Return every configured license pattern that matches the file text."""
         content_upper = content.upper()
-
+        matches: list[dict] = []
         for license_id, pattern_config in self.config.get("license_patterns", {}).items():
             required = pattern_config.get("required", [])
             exclude = pattern_config.get("exclude", [])
-
             if not self._all_patterns_match(required, content, content_upper):
                 continue
             if self._any_pattern_matches(exclude, content_upper):
                 continue
+            matches.append(
+                {
+                    "license_id": license_id,
+                    "confidence": pattern_config.get("confidence", "medium"),
+                }
+            )
+        return matches
 
-            return {
-                "license_id": license_id,
-                "confidence": pattern_config.get("confidence", "medium"),
+    def _identify_license_from_content(self, content: str) -> dict | None:
+        """Match LICENSE content against known patterns."""
+        matches = self._identify_all_licenses_from_content(content)
+        return matches[0] if matches else None
+
+    def _license_bucket(self, license_id: str | None) -> str:
+        """Classify a license id as allowed, blocked, or unknown."""
+        if not license_id:
+            return "unknown"
+        normalized = self._normalize_license_id(license_id)
+        if normalized in self._normalized_blocklist:
+            return "blocked"
+        if normalized in self._normalized_allowlist:
+            return "allowed"
+        return "unknown"
+
+    def _record_unrecognized_license_file(
+        self,
+        result: ValidationResult,
+        filenames: list[str],
+        frontmatter: LicenseDetection | None = None,
+    ) -> None:
+        """Fail closed when a LICENSE/COPYING file exists but cannot be identified."""
+        joined = ", ".join(filenames)
+        declared = f" Frontmatter declares '{frontmatter.license_id}'." if frontmatter and frontmatter.license_id else ""
+        result.add_structured_finding(
+            Finding(
+                category="LICENSE",
+                severity="HIGH",
+                check_name="unrecognized_license_file",
+                message=(
+                    f"License file '{joined}' is present but could not be identified.{declared} "
+                    "Manual review is required."
+                ),
+                file_path=filenames[0],
+                suggestion=(
+                    "Identify the license in the file, add a detection pattern, or remove the file."
+                ),
+            ),
+            is_error=True,
+        )
+        result.metadata.update(
+            {
+                "license": frontmatter.license_id if frontmatter else None,
+                "license_status": "unrecognized",
+                "license_source": "license_file",
             }
+        )
 
+    def _choose_from_license_files(
+        self,
+        scan: _LicenseFileScan,
+        result: ValidationResult,
+    ) -> LicenseDetection | None:
+        """Pick a file detection, failing closed on blocked or conflicting ids."""
+        if scan.unrecognized_declaration_files:
+            self._record_unrecognized_license_file(result, scan.unrecognized_declaration_files)
+            return None
+        if not scan.detections:
+            return None
+        blocked = [item for item in scan.detections if self._license_bucket(item.license_id) == "blocked"]
+        if blocked:
+            return blocked[0]
+        unique: dict[str, LicenseDetection] = {}
+        for item in scan.detections:
+            if not item.license_id:
+                continue
+            unique.setdefault(self._normalize_license_id(item.license_id), item)
+        if len(unique) == 1:
+            return next(iter(unique.values()))
+        first, second = list(unique.values())[:2]
+        self._add_license_mismatch_finding(result, first, second, check_name="license_file_mismatch")
+        return None
+
+    def _resolve_frontmatter_and_files(
+        self,
+        frontmatter: LicenseDetection,
+        scan: _LicenseFileScan,
+        result: ValidationResult,
+    ) -> LicenseDetection | None:
+        """Reconcile a concrete frontmatter license with every license file."""
+        if scan.unrecognized_declaration_files:
+            self._record_unrecognized_license_file(result, scan.unrecognized_declaration_files, frontmatter)
+            return None
+        if not scan.detections:
+            return frontmatter
+
+        blocked_files = [item for item in scan.detections if self._license_bucket(item.license_id) == "blocked"]
+        if blocked_files:
+            chosen = blocked_files[0]
+            result.add_message(
+                f"Frontmatter license '{frontmatter.license_id}' differs from "
+                f"{chosen.file_path} license '{chosen.license_id}'"
+            )
+            result.add_message(f"Tier 2: Detected {chosen.license_id} from {chosen.file_path}")
+            return chosen
+        if self._license_bucket(frontmatter.license_id) == "blocked":
+            return frontmatter
+
+        file_by_id: dict[str, LicenseDetection] = {}
+        for item in scan.detections:
+            if item.license_id:
+                file_by_id.setdefault(self._normalize_license_id(item.license_id), item)
+        fm_norm = self._normalize_license_id(frontmatter.license_id or "")
+        if set(file_by_id) == {fm_norm}:
+            return frontmatter
+
+        other = next((item for key, item in file_by_id.items() if key != fm_norm), None)
+        if (
+            other is not None
+            and self._license_bucket(frontmatter.license_id) == "allowed"
+            and self._license_bucket(other.license_id) == "allowed"
+        ):
+            result.add_message(
+                f"Frontmatter license '{frontmatter.license_id}' differs from "
+                f"{other.file_path} license '{other.license_id}'"
+            )
+            self._add_license_mismatch_finding(result, frontmatter, other)
+            return None
+        if other is not None and self._license_bucket(other.license_id) == "unknown":
+            return other
+        return frontmatter
+
+    def _add_license_mismatch_finding(
+        self,
+        result: ValidationResult,
+        first: LicenseDetection,
+        second: LicenseDetection,
+        check_name: str = "frontmatter_license_mismatch",
+    ) -> None:
+        """Fail closed when two allowed licenses disagree, without marking allowed."""
+        result.add_structured_finding(
+            Finding(
+                category="LICENSE",
+                severity="HIGH",
+                check_name=check_name,
+                message=(
+                    f"License '{first.license_id}' conflicts with "
+                    f"{second.file_path} license '{second.license_id}'"
+                ),
+                file_path=second.file_path or first.file_path or "unknown",
+                suggestion=(
+                    "Make every license declaration agree, or remove the conflicting file."
+                ),
+            ),
+            is_error=True,
+        )
+        result.metadata.update(
+            {
+                "license": f"{first.license_id} vs {second.license_id}",
+                "license_status": "conflict",
+                "license_source": "frontmatter+license_file" if first.source.startswith("frontmatter") else "license_file",
+            }
+        )
+
+    def _check_license_file(self, asset_path: Path) -> LicenseDetection | None:
+        """Tier 2 helper: first blocked file detection, else the sole identified id."""
+        scan = self._collect_license_files(asset_path)
+        if scan.unrecognized_declaration_files or not scan.detections:
+            return None
+        blocked = [item for item in scan.detections if self._license_bucket(item.license_id) == "blocked"]
+        if blocked:
+            return blocked[0]
+        unique: dict[str, LicenseDetection] = {}
+        for item in scan.detections:
+            if item.license_id:
+                unique.setdefault(self._normalize_license_id(item.license_id), item)
+        if len(unique) == 1:
+            return next(iter(unique.values()))
         return None
 
     @staticmethod

--- a/src/skillevaluator/validators/license.py
+++ b/src/skillevaluator/validators/license.py
@@ -151,7 +151,7 @@ class LicenseValidator(ValidatorBase):
                 if file_detection := self._check_license_file(asset_path):
                     return file_detection
             else:
-                return detection
+                return self._resolve_frontmatter_and_file(detection, asset_path, result)
 
         # Tier 2: LICENSE file
         if detection := self._check_license_file(asset_path):
@@ -197,6 +197,75 @@ class LicenseValidator(ValidatorBase):
         """Check if license value references a file."""
         lower = license_value.lower()
         return any(ref in lower for ref in _FILE_REFERENCE_KEYWORDS)
+
+    def _resolve_frontmatter_and_file(
+        self,
+        frontmatter: LicenseDetection,
+        asset_path: Path,
+        result: ValidationResult,
+    ) -> LicenseDetection:
+        """Reconcile a concrete frontmatter license with a LICENSE file, if present.
+
+        Matching IDs keep the frontmatter result. A blocked ID on either side
+        is returned so validation fails closed. Distinct allowed IDs emit a
+        mismatch finding instead of silently preferring frontmatter.
+        """
+        file_detection = self._check_license_file(asset_path)
+        if file_detection is None or not frontmatter.license_id or not file_detection.license_id:
+            return frontmatter
+
+        fm_norm = self._normalize_license_id(frontmatter.license_id)
+        file_norm = self._normalize_license_id(file_detection.license_id)
+        if fm_norm == file_norm:
+            return frontmatter
+
+        return self._resolve_license_conflict(frontmatter, file_detection, fm_norm, file_norm, result)
+
+    def _resolve_license_conflict(
+        self,
+        frontmatter: LicenseDetection,
+        file_detection: LicenseDetection,
+        fm_norm: str,
+        file_norm: str,
+        result: ValidationResult,
+    ) -> LicenseDetection:
+        """Choose which detection to validate when frontmatter and LICENSE disagree."""
+        result.add_message(
+            f"Frontmatter license '{frontmatter.license_id}' differs from "
+            f"{file_detection.file_path} license '{file_detection.license_id}'"
+        )
+        if file_norm in self._normalized_blocklist:
+            result.add_message(f"Tier 2: Detected {file_detection.license_id} from {file_detection.file_path}")
+            return file_detection
+        if fm_norm in self._normalized_blocklist:
+            return frontmatter
+        if fm_norm in self._normalized_allowlist and file_norm in self._normalized_allowlist:
+            self._add_license_mismatch_finding(result, frontmatter, file_detection)
+        return frontmatter
+
+    @staticmethod
+    def _add_license_mismatch_finding(
+        result: ValidationResult,
+        frontmatter: LicenseDetection,
+        file_detection: LicenseDetection,
+    ) -> None:
+        """Fail closed when two allowed licenses disagree."""
+        result.add_structured_finding(
+            Finding(
+                category="LICENSE",
+                severity="HIGH",
+                check_name="frontmatter_license_mismatch",
+                message=(
+                    f"Frontmatter license '{frontmatter.license_id}' conflicts with "
+                    f"{file_detection.file_path} license '{file_detection.license_id}'"
+                ),
+                file_path=file_detection.file_path or frontmatter.file_path or "unknown",
+                suggestion=(
+                    "Make the SKILL.md license field match the LICENSE file, or remove one of the declarations."
+                ),
+            ),
+            is_error=True,
+        )
 
     def _check_license_file(self, asset_path: Path) -> LicenseDetection | None:
         """Tier 2: Parse LICENSE files and match against known patterns."""

--- a/src/skillevaluator/validators/license.py
+++ b/src/skillevaluator/validators/license.py
@@ -224,7 +224,7 @@ class LicenseValidator(ValidatorBase):
         unrecognized: list[str] = []
         for license_name in LICENSE_FILE_NAMES:
             license_path = asset_path / license_name
-            if not license_path.is_file():
+            if not license_path.is_file() or not _is_license_declaration_filename(license_name):
                 continue
             try:
                 content = license_path.read_text(encoding="utf-8", errors="ignore")

--- a/tests/validators/test_license.py
+++ b/tests/validators/test_license.py
@@ -473,6 +473,22 @@ Copyright (C) 1991, 1999 Free Software Foundation, Inc.
         assert result.metadata.get("license_status") == "unrecognized"
         assert result.metadata.get("license_status") != "allowed"
 
+    def test_notice_apache_attribution_does_not_conflict_with_mit(self, tmp_path: Path):
+        """NOTICE stays informational; Apache text there must not mismatch MIT LICENSE."""
+        skill_dir = create_skill_with_declared_license_and_file(
+            tmp_path,
+            "mit-with-apache-notice",
+            "MIT",
+            MIT_LICENSE_TEXT,
+        )
+        (skill_dir / "NOTICE").write_text(APACHE_2_LICENSE_TEXT)
+
+        result = LicenseValidator(strict_mode=True).validate(skill_dir)
+
+        assert result.passed
+        assert all(f.check_name != "frontmatter_license_mismatch" for f in result.findings)
+        assert result.metadata.get("license_status") == "allowed"
+
     def test_strict_dual_license_expression_with_unknown_component_fails(self, tmp_path: Path):
         """Strict mode should fail when any expression component is unknown."""
         skill_dir = create_skill_with_declared_license_and_file(

--- a/tests/validators/test_license.py
+++ b/tests/validators/test_license.py
@@ -9,6 +9,41 @@ import pytest
 
 from skillevaluator.validators.license import LicenseDetection, LicenseValidator
 
+GPL_V3_LICENSE_TEXT = """
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+"""
+
+APACHE_2_LICENSE_TEXT = """
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+"""
+
+MIT_LICENSE_TEXT = """MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+"""
+
 # =============================================================================
 # FIXTURES
 # =============================================================================
@@ -63,19 +98,7 @@ license: MIT
 # MIT Licensed Skill
 """)
 
-    # Create MIT LICENSE file
-    (skill_dir / "LICENSE").write_text("""MIT License
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-""")
+    (skill_dir / "LICENSE").write_text(MIT_LICENSE_TEXT)
 
     return skill_dir
 
@@ -94,15 +117,7 @@ description: A skill with GPL license
 # GPL Licensed Skill
 """)
 
-    # Create GPL v3 LICENSE file
-    (skill_dir / "LICENSE").write_text("""
-                    GNU GENERAL PUBLIC LICENSE
-                       Version 3, 29 June 2007
-
- Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
- Everyone is permitted to copy and distribute verbatim copies
- of this license document, but changing it is not allowed.
-""")
+    (skill_dir / "LICENSE").write_text(GPL_V3_LICENSE_TEXT)
 
     return skill_dir
 
@@ -320,7 +335,84 @@ class TestFrontmatterDetection:
         result = LicenseValidator().validate(skill_with_mit_license)
 
         assert result.passed
+        assert result.metadata.get("license_status") == "allowed"
         assert all(f.check_name != "frontmatter_license_mismatch" for f in result.findings)
+
+    def test_mit_frontmatter_does_not_hide_gpl_license_file(self, tmp_path: Path):
+        """MIT in frontmatter must not hide a GPL LICENSE file (#85)."""
+        skill_dir = create_skill_with_declared_license_and_file(
+            tmp_path,
+            "mit-claims-gpl-body",
+            "MIT",
+            GPL_V3_LICENSE_TEXT,
+        )
+
+        result = LicenseValidator().validate(skill_dir)
+
+        assert not result.passed
+        error_text = " ".join(result.errors).lower()
+        assert any(token in error_text for token in ("gpl", "copyleft", "blocked", "conflict", "mismatch"))
+        assert not any("License: MIT (ALLOWED" in message for message in result.messages)
+        assert result.metadata.get("license_status") != "allowed"
+
+    def test_mit_frontmatter_without_license_file_is_allowed(self, tmp_path: Path):
+        """Frontmatter-only MIT remains allowed when no LICENSE file exists."""
+        skill_dir = tmp_path / "mit-frontmatter-only"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("""---
+name: mit-frontmatter-only
+description: MIT in frontmatter with no LICENSE file
+license: MIT
+---
+
+# MIT Frontmatter Only
+""")
+
+        result = LicenseValidator().validate(skill_dir)
+
+        assert result.passed
+        assert result.metadata.get("license") == "MIT"
+        assert result.metadata.get("license_status") == "allowed"
+
+    def test_gpl_license_file_without_frontmatter_is_blocked(self, skill_with_gpl_license: Path):
+        """LICENSE-only GPL remains blocked when frontmatter has no license field."""
+        result = LicenseValidator().validate(skill_with_gpl_license)
+
+        assert not result.passed
+        assert any(f.check_name == "blocked_license" for f in result.findings)
+        error_text = " ".join(result.errors).lower()
+        assert "gpl" in error_text or "copyleft" in error_text
+
+    def test_gpl_frontmatter_is_not_hidden_by_mit_license_file(self, tmp_path: Path):
+        """Blocked frontmatter must still fail even if the LICENSE file is allowed."""
+        skill_dir = create_skill_with_declared_license_and_file(
+            tmp_path,
+            "gpl-claims-mit-body",
+            "GPL-3.0",
+            MIT_LICENSE_TEXT,
+        )
+
+        result = LicenseValidator().validate(skill_dir)
+
+        assert not result.passed
+        assert any(f.check_name == "blocked_license" for f in result.findings)
+        assert result.metadata.get("license_status") != "allowed"
+
+    def test_conflicting_allowed_licenses_fail_closed(self, tmp_path: Path):
+        """MIT frontmatter vs Apache LICENSE must not silently pick either side."""
+        skill_dir = create_skill_with_declared_license_and_file(
+            tmp_path,
+            "mit-vs-apache-body",
+            "MIT",
+            APACHE_2_LICENSE_TEXT,
+        )
+
+        result = LicenseValidator().validate(skill_dir)
+
+        assert not result.passed
+        error_text = " ".join(result.errors).lower()
+        assert any(token in error_text for token in ("conflict", "mismatch", "differ"))
+        assert any(f.check_name == "frontmatter_license_mismatch" for f in result.findings)
 
     def test_strict_dual_license_expression_with_unknown_component_fails(self, tmp_path: Path):
         """Strict mode should fail when any expression component is unknown."""

--- a/tests/validators/test_license.py
+++ b/tests/validators/test_license.py
@@ -413,6 +413,65 @@ license: MIT
         error_text = " ".join(result.errors).lower()
         assert any(token in error_text for token in ("conflict", "mismatch", "differ"))
         assert any(f.check_name == "frontmatter_license_mismatch" for f in result.findings)
+        assert result.metadata.get("license_status") == "conflict"
+        assert not any("ALLOWED - permissive" in message for message in result.messages)
+
+    def test_copying_gpl_is_not_hidden_by_mit_license_file(self, tmp_path: Path):
+        """MIT LICENSE plus GPL COPYING must fail closed even with MIT frontmatter."""
+        skill_dir = create_skill_with_declared_license_and_file(
+            tmp_path,
+            "mit-license-gpl-copying",
+            "MIT",
+            MIT_LICENSE_TEXT,
+        )
+        (skill_dir / "COPYING").write_text(GPL_V3_LICENSE_TEXT)
+
+        result = LicenseValidator(strict_mode=True).validate(skill_dir)
+
+        assert not result.passed
+        assert any(f.check_name == "blocked_license" for f in result.findings)
+        assert result.metadata.get("license_status") == "blocked"
+        assert not any("License: MIT (ALLOWED" in message for message in result.messages)
+
+    def test_single_file_mit_and_gpl_signatures_fail_closed(self, tmp_path: Path):
+        """One LICENSE file matching both MIT and GPL patterns must not report MIT allowed."""
+        skill_dir = tmp_path / "dual-signature-license"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("""---
+name: dual-signature-license
+description: LICENSE file contains both MIT and GPL signatures
+license: MIT
+---
+
+# Dual signature
+""")
+        (skill_dir / "LICENSE").write_text(MIT_LICENSE_TEXT + "\n" + GPL_V3_LICENSE_TEXT)
+
+        result = LicenseValidator(strict_mode=True).validate(skill_dir)
+
+        assert not result.passed
+        assert any(f.check_name == "blocked_license" for f in result.findings)
+        assert result.metadata.get("license_status") == "blocked"
+
+    def test_unrecognized_lgpl21_license_file_fails_closed(self, tmp_path: Path):
+        """A present LICENSE file without a configured signature cannot be treated as absent."""
+        skill_dir = create_skill_with_declared_license_and_file(
+            tmp_path,
+            "mit-frontmatter-lgpl21-file",
+            "MIT",
+            """GNU LESSER GENERAL PUBLIC LICENSE
+Version 2.1, February 1999
+
+Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+""",
+        )
+
+        result = LicenseValidator(strict_mode=True).validate(skill_dir)
+
+        assert not result.passed
+        assert any(f.check_name == "unrecognized_license_file" for f in result.findings)
+        assert result.metadata.get("license_status") == "unrecognized"
+        assert result.metadata.get("license_status") != "allowed"
 
     def test_strict_dual_license_expression_with_unknown_component_fails(self, tmp_path: Path):
         """Strict mode should fail when any expression component is unknown."""


### PR DESCRIPTION
## Summary

If SKILL.md says `license: MIT`, the license check never read the LICENSE file. A skill could claim MIT, ship GPL-3.0 in LICENSE, and still pass. Take the frontmatter field out and the same file is blocked.

I compare frontmatter against the LICENSE file when both exist. A copyleft file fails closed. Matching MIT still passes. Fixes #85.

## Verification

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] Added or updated focused tests
- [x] Updated documentation for user-visible changes
- [x] Ran `make lint`
- [x] Ran `make test`
- [x] Ran `make build`
- [x] Did not add credentials, private datasets, or proprietary benchmark content

## Release Impact

- [x] Updated `CHANGELOG.md`

MIT frontmatter plus a GPL LICENSE file is blocked. MIT with no LICENSE file still passes. MIT plus an MIT LICENSE file still passes.