### PR TITLE
fix: keep --llm-verify file reads inside the skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to SkillEvaluator are documented in this file.
 
 ### Fixed
 
+- `--llm-verify` now refuses to send file context from paths outside the
+  skill root, including `..`, absolute paths, and outbound file symlinks.
 - Tier 3 paired pass@k evidence now respects Python's active integer-string
   conversion limit, preserves nonzero Wilson interval widths and paired-effect
   directions at large case counts, and documents exact-rational omission

--- a/src/skillevaluator/inference/finding_verifier.py
+++ b/src/skillevaluator/inference/finding_verifier.py
@@ -75,6 +75,26 @@ class FindingVerifier(LLMClient):
 
     # -- Prompt construction ----------------------------------------------
 
+    @staticmethod
+    def _can_safely_open_under_skill(skill_path: Path, file_path: str) -> bool:
+        """Return whether *file_path* resolves to a regular file inside the skill."""
+        if not file_path:
+            return True
+        skill_root = skill_path.resolve()
+        for candidate in (skill_path / file_path, Path(file_path)):
+            if FindingVerifier._resolved_inside_skill(candidate, skill_root) is not None:
+                return True
+        return False
+
+    @staticmethod
+    def _redacted_prompt_fields() -> tuple[str, str, str]:
+        """Message, line content, and line number placeholders for unsafe files."""
+        return (
+            "(redacted: file outside skill boundary)",
+            "(redacted)",
+            "?",
+        )
+
     def _build_prompt(self, findings: list[Finding], skill_path: Path) -> str:
         """Build a user prompt grouping findings by file with surrounding code context."""
         groups: dict[str, list[tuple[int, Finding]]] = {}
@@ -90,14 +110,19 @@ class FindingVerifier(LLMClient):
 
             for idx, finding in indexed_findings:
                 sev = finding.severity.value if hasattr(finding.severity, "value") else str(finding.severity)
+                if self._can_safely_open_under_skill(skill_path, finding.file_path or ""):
+                    message = finding.message
+                    line_content = finding.line_content or "(no content)"
+                    line_number = str(finding.line_number or "?")
+                else:
+                    message, line_content, line_number = self._redacted_prompt_fields()
                 parts.append(
                     f"\nFinding #{idx}:\n"
                     f"  Category: {finding.category}\n"
                     f"  Severity: {sev}\n"
                     f"  Check: {finding.check_name}\n"
-                    f"  Message: {finding.message}\n"
-                    f"  Line {finding.line_number or '?'}: "
-                    f"{finding.line_content or '(no content)'}\n"
+                    f"  Message: {message}\n"
+                    f"  Line {line_number}: {line_content}\n"
                     f"  Suggestion: {finding.suggestion or 'N/A'}"
                 )
 

--- a/src/skillevaluator/inference/finding_verifier.py
+++ b/src/skillevaluator/inference/finding_verifier.py
@@ -107,12 +107,29 @@ class FindingVerifier(LLMClient):
         return "\n".join(parts)
 
     @staticmethod
+    def _resolved_inside_skill(path: Path, skill_root: Path) -> Path | None:
+        """Return *path* resolved only if it is a file inside *skill_root*."""
+        try:
+            resolved = path.resolve()
+            if not resolved.is_file() or not resolved.is_relative_to(skill_root):
+                return None
+            return resolved
+        except (OSError, ValueError, RuntimeError):
+            return None
+
+    @staticmethod
     def _read_file_context(skill_path: Path, file_path: str) -> str | None:
-        """Read up to 100 lines from a file for LLM context."""
+        """Read up to 100 lines from a file under the skill root for LLM context."""
+        if not file_path:
+            return None
+        skill_root = skill_path.resolve()
         candidates = [skill_path / file_path, Path(file_path)]
         for path in candidates:
+            resolved = FindingVerifier._resolved_inside_skill(path, skill_root)
+            if resolved is None:
+                continue
             try:
-                lines = path.read_text(encoding="utf-8", errors="ignore").split("\n")[:100]
+                lines = resolved.read_text(encoding="utf-8", errors="ignore").split("\n")[:100]
                 return "\n".join(lines)
             except (OSError, ValueError):
                 continue

--- a/tests/inference/test_finding_verifier.py
+++ b/tests/inference/test_finding_verifier.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Containment checks for FindingVerifier file-context reads."""
+
+from pathlib import Path
+
+from skillevaluator.inference.finding_verifier import FindingVerifier
+
+
+def _skill_with_outside(tmp_path: Path) -> tuple[Path, Path]:
+    outside = tmp_path / "outside.txt"
+    outside.write_text("hello-from-outside\n", encoding="utf-8")
+    skill = tmp_path / "skill"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text(
+        "---\nname: fv\ndescription: Containment check.\n---\n# inside\n",
+        encoding="utf-8",
+    )
+    return skill, outside
+
+
+def test_read_file_context_allows_in_skill_relative_path(tmp_path):
+    skill, _ = _skill_with_outside(tmp_path)
+    context = FindingVerifier._read_file_context(skill, "SKILL.md")
+    assert context is not None
+    assert "inside" in context
+    assert "hello-from-outside" not in context
+
+
+def test_read_file_context_rejects_parent_relative_path(tmp_path):
+    skill, _ = _skill_with_outside(tmp_path)
+    assert FindingVerifier._read_file_context(skill, "../outside.txt") is None
+
+
+def test_read_file_context_rejects_absolute_path_outside_skill(tmp_path):
+    skill, outside = _skill_with_outside(tmp_path)
+    assert FindingVerifier._read_file_context(skill, str(outside)) is None
+
+
+def test_read_file_context_rejects_symlink_pointing_outside_skill(tmp_path):
+    skill, outside = _skill_with_outside(tmp_path)
+    link = skill / "notes.md"
+    link.symlink_to(outside)
+    assert FindingVerifier._read_file_context(skill, "notes.md") is None

--- a/tests/inference/test_finding_verifier.py
+++ b/tests/inference/test_finding_verifier.py
@@ -43,3 +43,25 @@ def test_read_file_context_rejects_symlink_pointing_outside_skill(tmp_path):
     link = skill / "notes.md"
     link.symlink_to(outside)
     assert FindingVerifier._read_file_context(skill, "notes.md") is None
+
+
+def test_build_prompt_redacts_symlink_finding_payload(tmp_path):
+    from skillevaluator.models import Finding, Severity
+
+    skill, outside = _skill_with_outside(tmp_path)
+    outside.write_text("secret-pii-data@example.com\n", encoding="utf-8")
+    link = skill / "notes.md"
+    link.symlink_to(outside)
+
+    finding = Finding(
+        category="PII",
+        severity=Severity.HIGH,
+        check_name="email",
+        message="Found email secret-pii-data@example.com",
+        file_path="notes.md",
+        line_number=1,
+        line_content="secret-pii-data@example.com",
+    )
+    prompt = FindingVerifier()._build_prompt([finding], skill)
+    assert "secret-pii-data" not in prompt
+    assert "(redacted: file outside skill boundary)" in prompt


### PR DESCRIPTION
## Summary

`--llm-verify` was reading whatever path a finding pointed at and pasting the first 100 lines into the LLM prompt. `../outside.txt`, an absolute path, and a symlink that left the skill all worked.

The helper now resolves the path and only reads regular files that stay under the skill root. Fixes #94.

## Verification

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] Added or updated focused tests
- [x] Updated documentation for user-visible changes
- [x] Ran `make lint`
- [x] Ran `make test`
- [x] Ran `make build`
- [x] Did not add credentials, private datasets, or proprietary benchmark content

## Release Impact

- [x] Updated `CHANGELOG.md`