### PR TITLE
fix: skip gitleaks test dirs, not substring names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to SkillEvaluator are documented in this file.
 
 ### Fixed
 
+- Gitleaks path allowlist now skips test/example/fixture/mock directories
+  instead of any path containing those substrings, so files like `latest.py`
+  are scanned.
 - Tier 3 paired pass@k evidence now respects Python's active integer-string
   conversion limit, preserves nonzero Wilson interval widths and paired-effect
   directions at large case counts, and documents exact-rational omission

--- a/src/skillevaluator/validators/secrets.py
+++ b/src/skillevaluator/validators/secrets.py
@@ -85,7 +85,7 @@ tags = ["nvidia", "api-key"]
         )
 
     def _validate_single_skill(self, skill_path: Path) -> ValidationResult:
-        """Run Gitleaks scan on a single skill directory."""
+        """Run Gitleaks scan on a single skill directory or file."""
         result = ValidationResult()
 
         if not Tools.gitleaks.is_available:
@@ -95,13 +95,26 @@ tags = ["nvidia", "api-key"]
             result.mark_scan_incomplete("gitleaks")
             return result
 
+        scan_root = skill_path.resolve()
+        if self.scan_git_history:
+            source = str(scan_root)
+            cwd = None
+        else:
+            # Keep no-git finding paths relative to the requested scan root so
+            # allowlists cannot match unrelated absolute ancestors. Direct
+            # files run from their parent, with "./" protecting option-like
+            # filenames while preserving Gitleaks' native ignore semantics.
+            scan_is_dir = scan_root.is_dir()
+            source = "." if scan_is_dir else f"./{scan_root.name}"
+            cwd = scan_root if scan_is_dir else scan_root.parent
+
         config_path = self._create_gitleaks_config()
         try:
             tool_result = Tools.gitleaks.run(
                 [
                     "detect",
                     "--source",
-                    str(skill_path.resolve()),
+                    source,
                     "--report-format",
                     "json",
                     "--report-path",
@@ -112,6 +125,7 @@ tags = ["nvidia", "api-key"]
                     str(config_path),
                     *([] if self.scan_git_history else ["--no-git"]),
                 ],
+                cwd=cwd,
                 timeout=120,
             )
 

--- a/src/skillevaluator/validators/secrets.py
+++ b/src/skillevaluator/validators/secrets.py
@@ -163,6 +163,10 @@ tags = ["nvidia", "api-key"]
         Tier 1 artifact dirs (evals/, results/, versions/, ...) hold Tier 3
         output snapshots that routinely carry harvested test credentials;
         gitleaks has to skip them via config since it takes no exclude flag.
+
+        Test/example/fixture/mock skips are directory path components, not
+        substrings. ``(.*)?test(.*)?`` would also skip ``latest`` and
+        ``attestation``.
         """
         artifact_paths = "\n".join(f"    '''(^|/){re.escape(name)}(/|$)'''," for name in sorted(SCAN_EXCLUDED_DIRS))
         config = f"""
@@ -172,10 +176,7 @@ useDefault = true
 [allowlist]
 description = "SkillEvaluator allowlist"
 paths = [
-    '''(.*)?test(.*)?''',
-    '''(.*)?example(.*)?''',
-    '''(.*)?fixture(.*)?''',
-    '''(.*)?mock(.*)?''',
+    '''(^|/)(tests?|examples?|fixtures?|mocks?)(/|$)''',
 {artifact_paths}
 ]
 regexes = [

--- a/tests/validators/test_artifact_dir_exclusion.py
+++ b/tests/validators/test_artifact_dir_exclusion.py
@@ -202,6 +202,35 @@ class TestGitleaksArtifactExclusion:
             assert pattern in paths, f"gitleaks allowlist missing artifact dir {name!r}"
 
 
+class TestGitleaksTestPathAllowlist:
+    def test_config_skips_test_directories_not_substring_names(self):
+        config_path = SecretsValidator()._create_gitleaks_config()
+        try:
+            config = tomllib.loads(config_path.read_text())
+        finally:
+            config_path.unlink(missing_ok=True)
+
+        paths = config["allowlist"]["paths"]
+        assert r"(^|/)(tests?|examples?|fixtures?|mocks?)(/|$)" in paths
+        assert r"(.*)?test(.*)?" not in paths
+
+        compiled = [re.compile(p) for p in paths]
+
+        def skipped(relpath: str) -> bool:
+            return any(pat.search(relpath) for pat in compiled)
+
+        assert skipped("tests/helper.py")
+        assert skipped("test/helper.py")
+        assert skipped("examples/sample.json")
+        assert skipped("fixtures/data.json")
+        assert skipped("mocks/client.py")
+        assert not skipped("scripts/latest.py")
+        assert not skipped("attestation.py")
+        assert not skipped("skills/data-latest/prod.py")
+        assert not skipped("scripts/prod.py")
+        assert not skipped("contest/score.py")
+
+
 # =============================================================================
 # SKILLSPECTOR ISSUES UNDER ARTIFACT DIRS ARE DROPPED
 # =============================================================================

--- a/tests/validators/test_scanner_path_resolution.py
+++ b/tests/validators/test_scanner_path_resolution.py
@@ -1,12 +1,14 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Scanner argv must receive resolved absolute paths.
+"""Scanner invocations must not expose relative paths as option tokens.
 
 A skill directory named like an option token (e.g. ``--exclude=*``) that
 reaches a scanner argv as a bare relative positional is parsed by the
-scanner as an option, silently excluding the skill from analysis. Every
-external scanner call site must therefore pass ``skill_path.resolve()``.
+scanner as an option, silently excluding the skill from analysis. Most
+scanners therefore receive ``skill_path.resolve()``. Gitleaks no-git scans
+instead use paths relative to the requested scan root so allowlists cannot
+match unrelated absolute ancestors.
 """
 
 import json
@@ -15,12 +17,26 @@ from unittest.mock import patch
 
 import pytest
 
+from skillevaluator.constants import SCAN_EXCLUDED_DIRS
 from skillevaluator.utils.tool_runner import ToolResult, Tools
 from skillevaluator.validators.code_risk import CodeRiskValidator
 from skillevaluator.validators.secrets import SecretsValidator
 from skillevaluator.validators.security import SecurityValidator
 
 MALICIOUS_DIR_NAME = "--exclude=all"
+GITLEAKS_ALLOWLIST_DIR_NAMES = sorted(
+    {
+        "test",
+        "tests",
+        "example",
+        "examples",
+        "fixture",
+        "fixtures",
+        "mock",
+        "mocks",
+        *SCAN_EXCLUDED_DIRS,
+    }
+)
 
 CLEAN_RESULT = ToolResult(success=True, stdout=json.dumps({"results": []}), stderr="", exit_code=0)
 
@@ -69,13 +85,62 @@ class TestSemgrepPathResolution:
 class TestGitleaksPathResolution:
     @patch.object(Tools.gitleaks, "_path", "/usr/bin/gitleaks")
     @patch.object(Tools.gitleaks, "run")
-    def test_gitleaks_argv_uses_resolved_path(self, mock_run, malicious_skill_path):
+    def test_gitleaks_no_git_uses_dot_source_from_resolved_skill_dir(self, mock_run, malicious_skill_path):
         mock_run.return_value = CLEAN_RESULT
 
         SecretsValidator()._validate_single_skill(malicious_skill_path)
 
         args = mock_run.call_args.args[0]
+        assert args[args.index("--source") + 1] == "."
+        assert "--no-git" in args
+        assert "--gitleaks-ignore-path" not in args
+        assert mock_run.call_args.kwargs["cwd"] == malicious_skill_path.resolve()
+
+    @pytest.mark.parametrize("ancestor_name", GITLEAKS_ALLOWLIST_DIR_NAMES)
+    @patch.object(Tools.gitleaks, "_path", "/usr/bin/gitleaks")
+    @patch.object(Tools.gitleaks, "run")
+    def test_gitleaks_no_git_does_not_expose_allowlisted_ancestors(
+        self, mock_run, tmp_path, ancestor_name
+    ):
+        mock_run.return_value = CLEAN_RESULT
+        skill_path = tmp_path / ancestor_name / "production-skill"
+        skill_path.mkdir(parents=True)
+
+        SecretsValidator()._validate_single_skill(skill_path)
+
+        args = mock_run.call_args.args[0]
+        assert args[args.index("--source") + 1] == "."
+        assert mock_run.call_args.kwargs["cwd"] == skill_path.resolve()
+
+    @pytest.mark.parametrize("ancestor_name", GITLEAKS_ALLOWLIST_DIR_NAMES)
+    @patch.object(Tools.gitleaks, "_path", "/usr/bin/gitleaks")
+    @patch.object(Tools.gitleaks, "run")
+    def test_gitleaks_no_git_direct_file_uses_safe_relative_source(
+        self, mock_run, tmp_path, ancestor_name
+    ):
+        mock_run.return_value = CLEAN_RESULT
+        target = tmp_path / ancestor_name / "--exclude=all.mdc"
+        target.parent.mkdir(parents=True)
+        target.write_text("rule content\n")
+
+        SecretsValidator()._validate_single_skill(target)
+
+        args = mock_run.call_args.args[0]
+        assert args[args.index("--source") + 1] == f"./{target.name}"
+        assert "--gitleaks-ignore-path" not in args
+        assert mock_run.call_args.kwargs["cwd"] == target.parent.resolve()
+
+    @patch.object(Tools.gitleaks, "_path", "/usr/bin/gitleaks")
+    @patch.object(Tools.gitleaks, "run")
+    def test_gitleaks_git_history_keeps_resolved_source(self, mock_run, malicious_skill_path):
+        mock_run.return_value = CLEAN_RESULT
+
+        SecretsValidator(scan_git_history=True)._validate_single_skill(malicious_skill_path)
+
+        args = mock_run.call_args.args[0]
         _assert_resolved(args[args.index("--source") + 1], malicious_skill_path)
+        assert "--no-git" not in args
+        assert mock_run.call_args.kwargs.get("cwd") is None
 
 
 class TestSkillspectorPathResolution:


### PR DESCRIPTION
## Summary

The default Gitleaks allowlist treated `test` as a substring, so `scripts/latest.py` and `attestation.py` were never scanned. Same shape for `example`, `fixture`, and `mock`.

The skip is now a directory path component (`tests/`, `test/`, `examples/`, ...). Production files whose names happen to contain those letters still go through secrets. Fixes #92.

## Verification

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] Added or updated focused tests
- [x] Updated documentation for user-visible changes
- [x] Ran `make lint`
- [x] Ran `make test`
- [x] Ran `make build`
- [x] Did not add credentials, private datasets, or proprietary benchmark content

## Release Impact

- [x] Updated `CHANGELOG.md`