### PR TITLE
fix(ci): scope Gitleaks to checked-out history

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -60,14 +60,27 @@ jobs:
           test "$(git rev-parse --is-shallow-repository)" = "false"
           git rev-parse --verify "HEAD^{commit}" >/dev/null
       - name: Scan Git history
-        # Mirror the v8.30.0 Git log defaults except --all -> HEAD; re-derive
-        # these options when bumping the image. This excludes unrelated refs.
-        run: >-
-          docker run --rm
-          --volume "$PWD:/repo:ro"
-          ghcr.io/gitleaks/gitleaks:v8.30.0@sha256:691af3c7c5a48b16f187ce3446d5f194838f91238f27270ed36eef6359a574d9
-          git --no-banner --redact --verbose
-          --log-opts="--full-history --diff-filter=tuxdb HEAD --" /repo
+        # Pull requests and main pushes scan only history reachable from the
+        # checked-out commit. Audits keep --all so unmerged refs and tags stay
+        # covered. Re-derive these v8.30.0 options when bumping the image.
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "$GITHUB_EVENT_NAME" in
+            pull_request|push)
+              log_opts="--full-history --diff-filter=tuxdb HEAD --"
+              ;;
+            # Unknown future events deliberately receive the wider audit.
+            *)
+              log_opts="--full-history --all --diff-filter=tuxdb --"
+              ;;
+          esac
+
+          docker run --rm \
+            --volume "$PWD:/repo:ro" \
+            ghcr.io/gitleaks/gitleaks:v8.30.0@sha256:691af3c7c5a48b16f187ce3446d5f194838f91238f27270ed36eef6359a574d9 \
+            git --no-banner --redact --verbose \
+            --log-opts="$log_opts" /repo
 
   dependency-review:
     name: Dependency review

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -57,13 +57,17 @@ jobs:
       - name: Verify full Git checkout
         run: |
           test -d .git
-          test "$(git rev-list --count HEAD)" -gt 0
+          test "$(git rev-parse --is-shallow-repository)" = "false"
+          git rev-parse --verify "HEAD^{commit}" >/dev/null
       - name: Scan Git history
+        # Mirror the v8.30.0 Git log defaults except --all -> HEAD; re-derive
+        # these options when bumping the image. This excludes unrelated refs.
         run: >-
           docker run --rm
           --volume "$PWD:/repo:ro"
           ghcr.io/gitleaks/gitleaks:v8.30.0@sha256:691af3c7c5a48b16f187ce3446d5f194838f91238f27270ed36eef6359a574d9
-          git --no-banner --redact --verbose /repo
+          git --no-banner --redact --verbose
+          --log-opts="--full-history --diff-filter=tuxdb HEAD --" /repo
 
   dependency-review:
     name: Dependency review

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -174,6 +174,27 @@ def test_security_keeps_gitleaks_always_on_and_skips_only_nonessential_jobs() ->
     assert "vars.ENABLE_GITHUB_ADVANCED_SECURITY == 'true'" in codeql_if
 
 
+def test_gitleaks_scans_full_history_reachable_from_checked_out_head() -> None:
+    job = _load("security.yml")["jobs"]["gitleaks"]
+    checkout = next(
+        step for step in job["steps"] if step.get("uses", "").startswith("actions/checkout@")
+    )
+    verify = next(step for step in job["steps"] if step.get("name") == "Verify full Git checkout")
+    scan = next(step for step in job["steps"] if step.get("name") == "Scan Git history")
+
+    assert str(checkout["with"]["fetch-depth"]) == "0"
+    assert 'test "$(git rev-parse --is-shallow-repository)" = "false"' in verify["run"]
+    assert 'git rev-parse --verify "HEAD^{commit}"' in verify["run"]
+    assert (
+        "gitleaks:v8.30.0@sha256:691af3c7c5a48b16f187ce3446d5f194838f91238f27270ed36eef6359a574d9"
+        in scan["run"]
+    )
+    log_opts = re.search(r'--log-opts="([^"]+)"', scan["run"])
+    assert log_opts is not None
+    assert log_opts.group(1) == "--full-history --diff-filter=tuxdb HEAD --"
+    assert "--all" not in log_opts.group(1).split()
+
+
 def test_dco_stays_unconditional_and_has_no_path_filter() -> None:
     dco = _load("dco.yml")
 

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -174,7 +174,7 @@ def test_security_keeps_gitleaks_always_on_and_skips_only_nonessential_jobs() ->
     assert "vars.ENABLE_GITHUB_ADVANCED_SECURITY == 'true'" in codeql_if
 
 
-def test_gitleaks_scans_full_history_reachable_from_checked_out_head() -> None:
+def test_gitleaks_uses_event_specific_full_history_scopes() -> None:
     job = _load("security.yml")["jobs"]["gitleaks"]
     checkout = next(
         step for step in job["steps"] if step.get("uses", "").startswith("actions/checkout@")
@@ -189,10 +189,20 @@ def test_gitleaks_scans_full_history_reachable_from_checked_out_head() -> None:
         "gitleaks:v8.30.0@sha256:691af3c7c5a48b16f187ce3446d5f194838f91238f27270ed36eef6359a574d9"
         in scan["run"]
     )
-    log_opts = re.search(r'--log-opts="([^"]+)"', scan["run"])
-    assert log_opts is not None
-    assert log_opts.group(1) == "--full-history --diff-filter=tuxdb HEAD --"
-    assert "--all" not in log_opts.group(1).split()
+    scan_run = scan["run"]
+    head_opts = "--full-history --diff-filter=tuxdb HEAD --"
+    audit_opts = "--full-history --all --diff-filter=tuxdb --"
+    assignments = re.findall(r'log_opts="([^"]+)"', scan_run)
+
+    assert assignments == [head_opts, audit_opts]
+    assert scan["shell"] == "bash"
+    assert "set -euo pipefail" in scan_run
+    assert 'case "$GITHUB_EVENT_NAME" in' in scan_run
+    assert re.search(
+        rf'pull_request\|push\)\s+log_opts="{re.escape(head_opts)}"\s+;;', scan_run
+    )
+    assert re.search(rf'\*\)\s+log_opts="{re.escape(audit_opts)}"\s+;;', scan_run)
+    assert '--log-opts="$log_opts"' in scan_run
 
 
 def test_dco_stays_unconditional_and_has_no_path_filter() -> None:
@@ -208,6 +218,7 @@ def test_non_pr_workflow_triggers_are_preserved() -> None:
     security = _load("security.yml")
 
     assert ci["on"]["push"] == {"branches": ["main"]}
+    assert set(security["on"]) == {"pull_request", "push", "schedule", "workflow_dispatch"}
     assert security["on"]["push"] == {"branches": ["main"]}
     assert security["on"]["schedule"] == [{"cron": "23 7 * * 1"}]
     assert "workflow_dispatch" in security["on"]


### PR DESCRIPTION
## Summary

Closes #105.

- Scope required Gitleaks scans for pull requests and pushes to commits reachable from the checked-out `HEAD`, instead of every unrelated ref fetched into the repository.
- Retain repository-wide `--all` audits for scheduled and manually dispatched runs; unknown future event types also default to the wider audit.
- Preserve Gitleaks v8.30.0's existing `--full-history` and `--diff-filter=tuxdb` behavior, terminate revision parsing with `--`, and keep the pinned image digest unchanged.
- Fail closed before scanning if checkout history is shallow or `HEAD` is not a valid commit. This matters because v8.30.0 can log an invalid-revision error while still returning exit code 0.
- Add workflow regression coverage for both exact scan scopes, their event mapping, shell quoting, checkout depth, trigger set, and the pinned Gitleaks image.

For pull requests, GitHub's checked-out merge ref includes base ancestry and all PR commits. Pushes to `main` scan the full `main` ancestry. Scheduled and manual runs retain the pre-PR repository-wide audit across fetched branches and tags.

## Verification

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] Added or updated focused tests
- [ ] Updated documentation for user-visible changes — not applicable; this is CI-only
- [x] Ran `make lint`
- [ ] Ran `make test` — see full-suite environment result below
- [x] Ran `make build`
- [x] Did not add credentials, private datasets, or proprietary benchmark content

Focused and static verification:

- `uv run pytest -q tests/test_ci_workflows.py` — 11 passed
- `make PYTHON=.venv/bin/python lint` — passed
- `make PYTHON=.venv/bin/python build` — passed
- Linux full suite — 5122 passed, 51 skipped, 4 deselected; two host-only failures because `/usr/bin/codex` was installed and port 18080 was already occupied. Neither failing test intersects this diff.

Pinned-image behavioral verification:

- Real full clone with 20 branch/tag refs: `HEAD` scope scanned 65 commits, exited 0, and found no leaks; `--all` scanned 179 commits and detected the existing fixtures on other refs, confirming that scheduled/manual audit coverage is retained.
- Synthetic finding on an unrelated branch: HEAD scope exits 0 while all-ref scope exits 1.
- Synthetic finding on current history: HEAD scope exits 1.
- Synthetic finding in an older current-branch commit, removed before `HEAD`: HEAD scope still exits 1.
- A root path named `HEAD` remains unambiguous because the revision list ends with `--`.

## Release Impact

- [x] No user-visible release note needed
- [ ] Updated `CHANGELOG.md`