### PR TITLE
fix(hygiene): detect unpinned dependencies with environment markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ All notable changes to SkillEvaluator are documented in this file.
 
 - Unpinned-dependency warnings are no longer suppressed by comparison
   operators inside PEP 508 environment markers; requirements such as
-  `pkg; python_version < "3.13"` are now correctly reported.
+  `pkg; python_version < "3.13"` are now correctly reported, while direct
+  references are treated as pinned independently of marker contents.
 - SPDX headers keep the full license expression, so `MIT OR GPL-3.0` is
   no longer truncated to MIT and allowed. Closing comment markers such as
   `*/` and `-->` are not treated as part of the expression

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to SkillEvaluator are documented in this file.
 
 ### Fixed
 
+- Unpinned-dependency warnings are no longer suppressed by comparison
+  operators inside PEP 508 environment markers; requirements such as
+  `pkg; python_version < "3.13"` are now correctly reported.
 - Tier 3 paired pass@k evidence now respects Python's active integer-string
   conversion limit, preserves nonzero Wilson interval widths and paired-effect
   directions at large case counts, and documents exact-rational omission

--- a/src/skillevaluator/validators/hygiene.py
+++ b/src/skillevaluator/validators/hygiene.py
@@ -166,10 +166,14 @@ class HygieneValidator(ValidatorBase):
                 continue
 
             pkg_name = match.group(1).lower()
+            # Marker comparisons do not constrain the package version. Leave
+            # direct references intact because their URLs may contain ";";
+            # markers on direct references therefore keep existing behavior.
+            constraint_part = line if "@" in line else line.partition(";")[0]
 
             if pkg_name in banned_lower:
                 result.add_error(f"{req_file.name}:{line_num} - Banned package: {pkg_name}")
-            elif not re.search(r"[=<>!]", line):
+            elif not re.search(r"[=<>!]", constraint_part):
                 result.add_warning(f"{req_file.name}:{line_num} - Unpinned: {line}")
 
         if not result.errors and not result.warnings:

--- a/src/skillevaluator/validators/hygiene.py
+++ b/src/skillevaluator/validators/hygiene.py
@@ -175,14 +175,13 @@ class HygieneValidator(ValidatorBase):
             pkg_name = match.group(1).lower()
             # Marker comparisons do not constrain the package version. Detect
             # direct references before the marker so an "@" inside a marker
-            # value cannot hide an otherwise unpinned requirement. Keep the
-            # full direct-reference line because its URL may contain ";".
+            # value cannot hide an otherwise unpinned requirement.
             requirement_part = line.partition(";")[0]
-            constraint_part = line if "@" in requirement_part else requirement_part
+            is_direct_reference = "@" in requirement_part
 
             if pkg_name in banned_lower:
                 result.add_error(f"{req_file.name}:{line_num} - Banned package: {pkg_name}")
-            elif not re.search(r"[=<>!]", constraint_part):
+            elif not is_direct_reference and not re.search(r"[=<>!]", requirement_part):
                 result.add_warning(f"{req_file.name}:{line_num} - Unpinned: {line}")
 
         if not result.errors and not result.warnings:

--- a/src/skillevaluator/validators/hygiene.py
+++ b/src/skillevaluator/validators/hygiene.py
@@ -173,11 +173,19 @@ class HygieneValidator(ValidatorBase):
                 continue
 
             pkg_name = match.group(1).lower()
+            # Pip strips inline comments introduced by whitespace before it
+            # parses a requirement. Remove them here as well so an "@" in a
+            # comment cannot be mistaken for a direct-reference separator;
+            # URL fragments remain intact because their "#" is not preceded
+            # by whitespace.
+            logical_line = re.split(r"\s+#", line, maxsplit=1)[0]
+
             # Marker comparisons do not constrain the package version. Detect
             # direct references before the marker so an "@" inside a marker
             # value cannot hide an otherwise unpinned requirement.
-            requirement_part = line.partition(";")[0]
-            is_direct_reference = "@" in requirement_part
+            requirement_part = logical_line.partition(";")[0]
+            _, direct_reference_separator, direct_reference_target = requirement_part.partition("@")
+            is_direct_reference = bool(direct_reference_separator and direct_reference_target.strip())
 
             if pkg_name in banned_lower:
                 result.add_error(f"{req_file.name}:{line_num} - Banned package: {pkg_name}")

--- a/tests/validators/test_hygiene.py
+++ b/tests/validators/test_hygiene.py
@@ -372,9 +372,7 @@ pandas
             'requests[security]; python_version >= "3.9"',
         ],
     )
-    def test_environment_marker_comparisons_do_not_hide_unpinned_requirements(
-        self, tmp_path: Path, requirement: str
-    ):
+    def test_environment_marker_comparisons_do_not_hide_unpinned_requirements(self, tmp_path: Path, requirement: str):
         """Marker operators must not count as package version constraints."""
         requirements = tmp_path / "requirements.txt"
         requirements.write_text(f"{requirement}\n", encoding="utf-8")
@@ -397,10 +395,8 @@ pandas
             'requests @ https://example.invalid/requests.whl ; python_version < "3.13"',
         ],
     )
-    def test_marker_handling_preserves_constrained_and_direct_requirements(
-        self, tmp_path: Path, requirement: str
-    ):
-        """Existing version constraints and direct-reference behavior remain accepted."""
+    def test_marker_handling_preserves_constrained_and_direct_requirements(self, tmp_path: Path, requirement: str):
+        """Version constraints remain accepted, and direct references are treated as pinned."""
         requirements = tmp_path / "requirements.txt"
         requirements.write_text(f"{requirement}\n", encoding="utf-8")
 

--- a/tests/validators/test_hygiene.py
+++ b/tests/validators/test_hygiene.py
@@ -392,6 +392,7 @@ pandas
             "requests==2.31.0",
             "requests~=2.31",
             "requests!=2.30.0",
+            "requests @ https://example.invalid/requests.whl",
             "requests @ https://example.invalid/a;v=1/requests.whl",
             'requests @ https://example.invalid/requests.whl ; python_version < "3.13"',
         ],

--- a/tests/validators/test_hygiene.py
+++ b/tests/validators/test_hygiene.py
@@ -267,6 +267,63 @@ pandas
         all_messages = result.errors + result.warnings
         assert any("unpinned" in m.lower() for m in all_messages)
 
+    @pytest.mark.parametrize(
+        "requirement",
+        [
+            'requests; python_version < "3.13"',
+            'requests; python_version != "3.12"',
+            'requests;python_version<"3.13"',
+            'requests ; python_version < "3.13"',
+            'requests; sys_platform == "win32"',
+            'requests[security]; python_version >= "3.9"',
+        ],
+    )
+    def test_environment_marker_comparisons_do_not_hide_unpinned_requirements(
+        self, tmp_path: Path, requirement: str
+    ):
+        """Marker operators must not count as package version constraints."""
+        requirements = tmp_path / "requirements.txt"
+        requirements.write_text(f"{requirement}\n", encoding="utf-8")
+
+        result = HygieneValidator()._check_requirements_file(requirements)
+
+        assert result.errors == []
+        assert result.warnings == [f"requirements.txt:1 - Unpinned: {requirement}"]
+
+    @pytest.mark.parametrize(
+        "requirement",
+        [
+            'requests>=2; python_version < "3.13"',
+            "requests>=2.0,<3.0",
+            "requests==2.31.0",
+            "requests~=2.31",
+            "requests!=2.30.0",
+            "requests @ https://example.invalid/a;v=1/requests.whl",
+            'requests @ https://example.invalid/requests.whl ; python_version < "3.13"',
+        ],
+    )
+    def test_marker_handling_preserves_constrained_and_direct_requirements(
+        self, tmp_path: Path, requirement: str
+    ):
+        """Existing version constraints and direct-reference behavior remain accepted."""
+        requirements = tmp_path / "requirements.txt"
+        requirements.write_text(f"{requirement}\n", encoding="utf-8")
+
+        result = HygieneValidator()._check_requirements_file(requirements)
+
+        assert result.errors == []
+        assert result.warnings == []
+
+    def test_banned_requirement_with_marker_remains_an_error(self, tmp_path: Path):
+        """Banned-package errors keep precedence over marker-aware warnings."""
+        requirements = tmp_path / "requirements.txt"
+        requirements.write_text('pycrypto; python_version < "3.13"\n', encoding="utf-8")
+
+        result = HygieneValidator()._check_requirements_file(requirements)
+
+        assert result.errors == ["requirements.txt:1 - Banned package: pycrypto"]
+        assert result.warnings == []
+
     def test_detects_banned_packages(self, tmp_path: Path):
         """Test detection of banned/deprecated packages."""
         skill_dir = tmp_path / "banned-deps-skill"

--- a/tests/validators/test_hygiene.py
+++ b/tests/validators/test_hygiene.py
@@ -385,13 +385,52 @@ pandas
     @pytest.mark.parametrize(
         "requirement",
         [
+            "requests # owner@example.com",
+            "requests[security] # contact @ owner",
+            "requests # consider >=2 later",
+        ],
+    )
+    def test_inline_comments_do_not_hide_unpinned_requirements(self, tmp_path: Path, requirement: str):
+        """Pip-style inline comments must not affect constraint detection."""
+        requirements = tmp_path / "requirements.txt"
+        requirements.write_text(f"{requirement}\n", encoding="utf-8")
+
+        result = HygieneValidator()._check_requirements_file(requirements)
+
+        assert result.errors == []
+        assert result.warnings == [f"requirements.txt:1 - Unpinned: {requirement}"]
+
+    @pytest.mark.parametrize(
+        "requirement",
+        [
+            "requests @",
+            "requests @ # owner@example.com",
+            'requests @ ; python_version < "3.13"',
+        ],
+    )
+    def test_empty_direct_references_are_not_treated_as_pinned(self, tmp_path: Path, requirement: str):
+        """A direct-reference separator must be followed by a target."""
+        requirements = tmp_path / "requirements.txt"
+        requirements.write_text(f"{requirement}\n", encoding="utf-8")
+
+        result = HygieneValidator()._check_requirements_file(requirements)
+
+        assert result.errors == []
+        assert result.warnings == [f"requirements.txt:1 - Unpinned: {requirement}"]
+
+    @pytest.mark.parametrize(
+        "requirement",
+        [
             'requests>=2; python_version < "3.13"',
             "requests>=2.0,<3.0",
             "requests==2.31.0",
             "requests~=2.31",
             "requests!=2.30.0",
+            "requests>=2 # owner@example.com",
             "requests @ https://example.invalid/requests.whl",
             "requests @ https://example.invalid/a;v=1/requests.whl",
+            "requests @ https://example.invalid/requests.whl#sha256=abc123",
+            "requests @ https://example.invalid/requests.whl # owner@example.com",
             'requests @ https://example.invalid/requests.whl ; python_version < "3.13"',
         ],
     )


### PR DESCRIPTION
## Summary

- Detect unpinned dependencies even when a PEP 508 environment marker contains comparison operators, such as `requests; python_version < "3.13"`.
- Inspect only the requirement portion before the marker when deciding whether a package has a version constraint.
- Preserve the existing policy that any requirement comparator counts as constrained; this does not redefine ?pinned? to require `==`.
- Keep direct-reference behavior unchanged because direct-reference URLs may legally contain semicolons.
- Document the newly emitted warning in the Unreleased changelog.

Before this change, the validator searched the entire physical line for `[=<>!]`, so marker operators could hide an unversioned package:

| Requirement | Previous result | New result |
| --- | --- | --- |
| `requests; python_version < "3.13"` | no warning | unpinned warning |
| `requests; sys_platform == "win32"` | no warning | unpinned warning |
| `requests>=2; python_version < "3.13"` | accepted | accepted |
| `requests @ https://example.invalid/a;v=1/requests.whl` | unchanged | unchanged |

Known adjacent behavior remains out of scope: direct references keep their existing constraint policy, inline comments are not parsed, and backslash continuations are still evaluated as physical lines.

## Verification

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] Added or updated focused tests
- [x] Updated documentation for user-visible changes
- [x] Ran `make lint`
- [ ] Ran `make test` ? ran the complete affected validator domain instead
- [x] Ran `make build`
- [x] Did not add credentials, private datasets, or proprietary benchmark content

Results:

- `uv run pytest -q tests/validators/test_hygiene.py` ? 26 passed, 1 skipped
- `uv run pytest -q tests/validators` on Linux ? 847 passed
- `make PYTHON=.venv/bin/python lint` ? passed
- `make PYTHON=.venv/bin/python build` ? passed

## Release Impact

- [ ] No user-visible release note needed
- [x] Updated `CHANGELOG.md`
