### PR TITLE
Honor SkillSpector analysis completeness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,10 +67,16 @@ All notable changes to SkillEvaluator are documented in this file.
   for runtime-error phrases when the recorded exception belongs to the
   verifier, health check, or task. Correct answers that discuss errors such as
   `401 Unauthorized` are no longer misreported as agent runtime failures.
-- SkillSpector 2.10 incomplete scans now report the authoritative analysis-
-  completeness failure instead of a false recommendation/severity
-  contradiction. Complete reports and older reports without completeness
-  metadata retain their existing validation behavior.
+- SkillSpector reports now use validated version-specific completeness
+  contracts. Valid findings from coherent 2.10+ partial scans remain visible
+  while the result stays incomplete, and fully covered 2.9.6 `--no-llm`
+  reports remain compatible. Contradictory finding or component totals and
+  duplicate component identities fail closed. Versioned findings require
+  producer paths, and complete reports reconcile universal analyzer work with
+  the component inventory. Reports scored before 2.10 finding compaction remain
+  accepted. Shipped bytecode findings, source-scoped executable evidence, and
+  version-specific finding identities remain authoritative without overstating
+  compacted or hidden finding evidence.
 - Tier 3 paired pass@k evidence now respects Python's active integer-string
   conversion limit, preserves nonzero Wilson interval widths and paired-effect
   directions at large case counts, and documents exact-rational omission

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,10 @@ All notable changes to SkillEvaluator are documented in this file.
   for runtime-error phrases when the recorded exception belongs to the
   verifier, health check, or task. Correct answers that discuss errors such as
   `401 Unauthorized` are no longer misreported as agent runtime failures.
+- SkillSpector 2.10 incomplete scans now report the authoritative analysis-
+  completeness failure instead of a false recommendation/severity
+  contradiction. Complete reports and older reports without completeness
+  metadata retain their existing validation behavior.
 - Tier 3 paired pass@k evidence now respects Python's active integer-string
   conversion limit, preserves nonzero Wilson interval widths and paired-effect
   directions at large case counts, and documents exact-rational omission

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,14 +76,16 @@ All notable changes to SkillEvaluator are documented in this file.
   `401 Unauthorized` are no longer misreported as agent runtime failures.
 - SkillSpector reports now use validated version-specific completeness
   contracts. Valid findings from coherent 2.10+ partial scans remain visible
-  while the result stays incomplete, and fully covered 2.9.6 `--no-llm`
+  while the result stays incomplete, and fully covered 2.9.5/2.9.6 `--no-llm`
   reports remain compatible. Contradictory finding or component totals and
   duplicate component identities fail closed. Versioned findings require
   producer paths, and complete reports reconcile universal analyzer work with
   the component inventory. Reports scored before 2.10 finding compaction remain
   accepted. Shipped bytecode findings, source-scoped executable evidence, and
   version-specific finding identities remain authoritative without overstating
-  compacted or hidden finding evidence.
+  compacted or hidden finding evidence. SkillSpector 2.11+ requires bundled
+  execution-surface analyzer evidence; 2.11.1+ uses classification-aware
+  finding IDs while rejecting conflicting reuse of an ID.
 - Tier 3 paired pass@k evidence now respects Python's active integer-string
   conversion limit, preserves nonzero Wilson interval widths and paired-effect
   directions at large case counts, and documents exact-rational omission

--- a/src/skillevaluator/models/result.py
+++ b/src/skillevaluator/models/result.py
@@ -279,7 +279,7 @@ class ValidationResult:
 
     @property
     def incomplete_scans(self) -> list[str]:
-        """External scanners that did not produce trustworthy evidence."""
+        """External scanners that did not produce complete trustworthy evidence."""
         value = self.metadata.get("incomplete_scans")
         if not isinstance(value, list):
             return []
@@ -462,10 +462,11 @@ class ValidationResult:
         self.messages.append(message)
 
     def mark_scan_incomplete(self, tool_name: str) -> None:
-        """Record that an external scanner produced no trustworthy results.
+        """Record that an external scanner did not produce complete trustworthy results.
 
-        Missing, timed-out, crashed, and malformed scanner runs are gate
-        failures. Reporters distinguish them from completed scans with policy
+        Partial, missing, timed-out, crashed, and malformed scanner runs are
+        gate failures. Trustworthy partial findings remain available, while
+        reporters distinguish these runs from completed scans with policy
         findings by using the canonical ``incomplete`` status.
         """
         scans = self.metadata.setdefault("incomplete_scans", [])

--- a/src/skillevaluator/validators/security.py
+++ b/src/skillevaluator/validators/security.py
@@ -764,6 +764,70 @@ class SecurityValidator(ValidatorBase):
             result.add_error("skillspector JSON field 'success' must be a boolean; security scan did not complete")
             return False
 
+        execution_successful = data.get("execution_successful")
+        if "execution_successful" in data and not isinstance(execution_successful, bool):
+            result.add_error(
+                "skillspector JSON field 'execution_successful' must be a boolean; "
+                "security scan did not complete"
+            )
+            return False
+        if execution_successful is False:
+            result.add_error("skillspector reported execution_successful=false; security scan did not complete")
+            return False
+
+        analysis_completeness = data.get("analysis_completeness")
+        if "analysis_completeness" in data:
+            if not isinstance(analysis_completeness, dict):
+                result.add_error(
+                    "skillspector JSON field 'analysis_completeness' must be an object; "
+                    "security scan did not complete"
+                )
+                return False
+            is_complete = analysis_completeness.get("is_complete")
+            if not isinstance(is_complete, bool):
+                result.add_error(
+                    "skillspector JSON field 'analysis_completeness.is_complete' must be a boolean; "
+                    "security scan did not complete"
+                )
+                return False
+            completeness_status = analysis_completeness.get("status")
+            if not isinstance(completeness_status, str) or completeness_status not in {
+                "complete",
+                "partial",
+                "failed",
+            }:
+                result.add_error(
+                    "skillspector JSON field 'analysis_completeness.status' is not recognized; "
+                    "security scan did not complete"
+                )
+                return False
+            completeness_execution_successful = analysis_completeness.get("execution_successful")
+            if not isinstance(completeness_execution_successful, bool):
+                result.add_error(
+                    "skillspector JSON field 'analysis_completeness.execution_successful' must be a boolean; "
+                    "security scan did not complete"
+                )
+                return False
+            if (
+                execution_successful is not None
+                and execution_successful is not completeness_execution_successful
+            ):
+                result.add_error(
+                    "skillspector JSON execution_successful fields contradict each other; "
+                    "security scan did not complete"
+                )
+                return False
+            if (
+                not is_complete
+                or completeness_status != "complete"
+                or not completeness_execution_successful
+            ):
+                result.add_error(
+                    "skillspector JSON field 'analysis_completeness' reports incomplete analysis "
+                    f"(status '{completeness_status}'); security scan did not complete"
+                )
+                return False
+
         status = data.get("status")
         if status is not None and not isinstance(status, str):
             result.add_error("skillspector JSON field 'status' must be a string; security scan did not complete")

--- a/src/skillevaluator/validators/security.py
+++ b/src/skillevaluator/validators/security.py
@@ -21,6 +21,7 @@ import re
 import shutil
 import tempfile
 import tokenize
+from collections import Counter
 from collections.abc import Iterable, Mapping
 from pathlib import Path
 
@@ -36,6 +37,7 @@ from skillevaluator.constants import (
     SKILL_MANIFEST_VARIANTS,
 )
 from skillevaluator.logging_config import get_logger
+from skillevaluator.models.skill import SEMVER_RE
 from skillevaluator.provider_config import ProviderConfigurationError, resolve_llm_provider
 from skillevaluator.spdx import is_spdx_only_html_comment
 from skillevaluator.utils.tool_runner import Tools, parse_json_output
@@ -51,6 +53,55 @@ logger = get_logger(__name__)
 
 _AUTHOR_IDENTITY_RE = re.compile(r"^\S[^<>\n]* <(?P<email>[^<>@\s]+@[^<>\s]+)>$")
 _SKILLSPECTOR_POLICY_EXIT_CODES = frozenset({0, 1})
+_SKILLSPECTOR_STATUSLESS_COMPLETENESS_VERSION = (2, 9, 6)
+_SKILLSPECTOR_COMPLETENESS_SCHEMA_VERSION = (2, 10, 0)
+_SKILLSPECTOR_SEMANTIC_ANALYZERS = frozenset(
+    {
+        "semantic_developer_intent",
+        "semantic_quality_policy",
+        "semantic_security_discovery",
+    }
+)
+_SKILLSPECTOR_OPTIONAL_ANALYZERS = _SKILLSPECTOR_SEMANTIC_ANALYZERS | {"meta_analyzer"}
+_SKILLSPECTOR_COMMON_REQUIRED_ANALYZERS = frozenset(
+    {
+        "behavioral_ast",
+        "behavioral_taint_tracking",
+        "mcp_least_privilege",
+        "mcp_rug_pull",
+        "mcp_tool_poisoning",
+        "meta_analyzer",
+        "static_patterns_agent_snooping",
+        "static_patterns_anti_refusal",
+        "static_patterns_data_exfiltration",
+        "static_patterns_deserialization",
+        "static_patterns_excessive_agency",
+        "static_patterns_harmful_content",
+        "static_patterns_memory_poisoning",
+        "static_patterns_output_handling",
+        "static_patterns_privilege_escalation",
+        "static_patterns_prompt_injection",
+        "static_patterns_rogue_agent",
+        "static_patterns_ssrf",
+        "static_patterns_supply_chain",
+        "static_patterns_system_prompt_leakage",
+        "static_patterns_tool_misuse",
+        "static_yara",
+    }
+)
+_SKILLSPECTOR_2_9_6_REQUIRED_ANALYZERS = (
+    _SKILLSPECTOR_COMMON_REQUIRED_ANALYZERS | _SKILLSPECTOR_SEMANTIC_ANALYZERS
+)
+# SkillSpector 2.10+ can omit semantic analyzers when no provider is available.
+_SKILLSPECTOR_2_10_REQUIRED_ANALYZERS = _SKILLSPECTOR_COMMON_REQUIRED_ANALYZERS | {
+    "artifact_integrity"
+}
+_SKILLSPECTOR_COMMON_UNIVERSAL_ANALYZERS = frozenset(
+    analyzer_id
+    for analyzer_id in _SKILLSPECTOR_COMMON_REQUIRED_ANALYZERS
+    if analyzer_id == "static_yara" or analyzer_id.startswith("static_patterns_")
+)
+_SKILLSPECTOR_DISABLED_ANALYZER_LIMITATION = "Analyzer was disabled by the requested configuration."
 _SKILLSPECTOR_RISK_BANDS = ((81, "CRITICAL"), (51, "HIGH"), (21, "MEDIUM"), (0, "LOW"))
 _SKILLSPECTOR_RECOMMENDATION_BY_SEVERITY = {
     "CRITICAL": "DO_NOT_INSTALL",
@@ -59,7 +110,10 @@ _SKILLSPECTOR_RECOMMENDATION_BY_SEVERITY = {
     "LOW": "SAFE",
 }
 _SKILLSPECTOR_SEVERITY_POINTS = {"CRITICAL": 50, "HIGH": 25, "MEDIUM": 10, "LOW": 5, "INFO": 5}
+_SKILLSPECTOR_EXECUTABLE_MULTIPLIER = 1.3
+_SKILLSPECTOR_RISK_SCORE_FLOORS_BY_RULE_ID = {"SC8": 51}
 _SKILLSPECTOR_DIMINISHING_WEIGHTS = (1.0, 0.5, 0.25)
+_SKILLSPECTOR_SCAN_EXCLUDED_DIRS = SCAN_EXCLUDED_DIRS - {"__pycache__"}
 _SKILLSPECTOR_PROVIDER_MAP = {
     "anthropic": "anthropic",
     "bedrock": "bedrock",
@@ -357,13 +411,16 @@ def _skillspector_child_env() -> dict[str, str]:
 
 
 def _tree_contains_artifact_dirs(root: Path) -> bool:
-    """Return True when any :data:`SCAN_EXCLUDED_DIRS` dir exists under root."""
-    return any(any(d in SCAN_EXCLUDED_DIRS for d in dirnames) for _dirpath, dirnames, _filenames in os.walk(root))
+    """Return True when the SkillSpector scan tree needs staging."""
+    return any(
+        any(d in _SKILLSPECTOR_SCAN_EXCLUDED_DIRS for d in dirnames)
+        for _dirpath, dirnames, _filenames in os.walk(root)
+    )
 
 
 def _ignore_artifact_dirs(dirpath: str, names: list[str]) -> set[str]:
     """``shutil.copytree`` ignore hook dropping artifact directories only."""
-    return {n for n in names if n in SCAN_EXCLUDED_DIRS and Path(dirpath, n).is_dir()}
+    return {n for n in names if n in _SKILLSPECTOR_SCAN_EXCLUDED_DIRS and Path(dirpath, n).is_dir()}
 
 
 def _rewrite_path_prefix(value, old: str, new: str):
@@ -384,6 +441,34 @@ def _issue_field(issue: dict):
         return issue.get(key) or default
 
     return get
+
+
+def _skillspector_scoring_source_scope(item: Mapping[str, object]) -> tuple[str, str]:
+    """Return the producer's source identity for score reconciliation."""
+    for key in ("source_identity", "source_url", "source_digest"):
+        value = item.get(key)
+        if isinstance(value, str) and value:
+            return key, value
+    return "", ""
+
+
+def _skillspector_scoring_match_identity(
+    issue: Mapping[str, object],
+    index: int,
+    *,
+    uses_report_identities: bool,
+) -> tuple[str, str | int]:
+    """Return the producer's finding identity used for report compaction."""
+    fingerprint = issue.get("match_fingerprint")
+    if isinstance(fingerprint, str) and fingerprint:
+        return "match_fingerprint", fingerprint
+    if uses_report_identities:
+        finding_id = issue.get("finding_id")
+        if isinstance(finding_id, str) and finding_id:
+            return "finding_id", finding_id
+        return "row", index
+    finding = str(issue.get("finding") or "").strip()[:100]
+    return ("finding", finding) if finding else ("row", index)
 
 
 class SecurityValidator(ValidatorBase):
@@ -597,10 +682,11 @@ class SecurityValidator(ValidatorBase):
         LLM analysis is disabled for static-only analysis.
 
         skillspector has no exclude flag and reads every file it finds, so
-        when the skill carries Tier 1 artifact dirs (``evals/results/``
+        when the skill carries generated output dirs (``evals/results/``
         snapshots can reach hundreds of MB after Tier 3 runs) the scan runs
-        on a temp copy of the skill without those dirs, and reported paths
-        are mapped back onto the original location.
+        on a temp copy without those outputs. Shipped bytecode remains for
+        artifact-integrity analysis, and reported paths map back to the
+        original location.
         """
         result = ValidationResult()
 
@@ -706,7 +792,13 @@ class SecurityValidator(ValidatorBase):
                 result.mark_scan_incomplete(stage_name)
                 return result
 
-        if not self._validate_skillspector_report(data, tool_result.exit_code, use_llm, result):
+        if not self._validate_skillspector_report(
+            data,
+            tool_result.exit_code,
+            use_llm,
+            stage_name,
+            result,
+        ):
             result.mark_scan_incomplete(stage_name)
             return result
 
@@ -740,6 +832,7 @@ class SecurityValidator(ValidatorBase):
         data: dict,
         process_exit_code: int,
         use_llm: bool,
+        stage_name: str,
         result: ValidationResult,
     ) -> bool:
         """Return whether JSON is a trustworthy SkillSpector findings report."""
@@ -764,7 +857,42 @@ class SecurityValidator(ValidatorBase):
             result.add_error("skillspector JSON field 'success' must be a boolean; security scan did not complete")
             return False
 
+        report_metadata = data.get("metadata")
+        version_error: str | None = None
+        skillspector_version: tuple[int, int, int] | None = None
+        if isinstance(report_metadata, dict):
+            raw_version = report_metadata.get("skillspector_version")
+            if not isinstance(raw_version, str) or SEMVER_RE.fullmatch(raw_version) is None:
+                version_error = (
+                    "skillspector JSON field 'metadata.skillspector_version' must be a semantic version; "
+                    "security scan did not complete"
+                )
+            else:
+                major, minor, patch = (int(part) for part in raw_version.split("."))
+                skillspector_version = (major, minor, patch)
+        elif report_metadata is None:
+            version_error = (
+                "skillspector JSON report is missing "
+                "'metadata.skillspector_version'; security scan did not complete"
+            )
+        uses_completeness_schema = (
+            skillspector_version is not None
+            and skillspector_version >= _SKILLSPECTOR_COMPLETENESS_SCHEMA_VERSION
+        )
+        uses_statusless_completeness_schema = (
+            skillspector_version == _SKILLSPECTOR_STATUSLESS_COMPLETENESS_VERSION
+        )
+        uses_versioned_completeness = uses_completeness_schema or uses_statusless_completeness_schema
+        completeness_contract = "2.10+" if uses_completeness_schema else "2.9.6"
+
         execution_successful = data.get("execution_successful")
+        if uses_versioned_completeness and "execution_successful" not in data:
+            result.add_error(
+                f"skillspector {completeness_contract} JSON report is missing required "
+                "'execution_successful' field; "
+                "security scan did not complete"
+            )
+            return False
         if "execution_successful" in data and not isinstance(execution_successful, bool):
             result.add_error(
                 "skillspector JSON field 'execution_successful' must be a boolean; "
@@ -775,7 +903,16 @@ class SecurityValidator(ValidatorBase):
             result.add_error("skillspector reported execution_successful=false; security scan did not complete")
             return False
 
+        findings_after_filtering: int | None = None
+        universal_analyzer_evidence_valid = True
         analysis_completeness = data.get("analysis_completeness")
+        if uses_versioned_completeness and "analysis_completeness" not in data:
+            result.add_error(
+                f"skillspector {completeness_contract} JSON report is missing required "
+                "'analysis_completeness' object; "
+                "security scan did not complete"
+            )
+            return False
         if "analysis_completeness" in data:
             if not isinstance(analysis_completeness, dict):
                 result.add_error(
@@ -783,26 +920,23 @@ class SecurityValidator(ValidatorBase):
                     "security scan did not complete"
                 )
                 return False
-            is_complete = analysis_completeness.get("is_complete")
-            if not isinstance(is_complete, bool):
+            if skillspector_version is not None and not uses_versioned_completeness:
                 result.add_error(
-                    "skillspector JSON field 'analysis_completeness.is_complete' must be a boolean; "
-                    "security scan did not complete"
-                )
-                return False
-            completeness_status = analysis_completeness.get("status")
-            if not isinstance(completeness_status, str) or completeness_status not in {
-                "complete",
-                "partial",
-                "failed",
-            }:
-                result.add_error(
-                    "skillspector JSON field 'analysis_completeness.status' is not recognized; "
+                    "skillspector JSON report uses an unsupported pre-2.10 completeness schema; "
                     "security scan did not complete"
                 )
                 return False
             completeness_execution_successful = analysis_completeness.get("execution_successful")
-            if not isinstance(completeness_execution_successful, bool):
+            if uses_versioned_completeness and "execution_successful" not in analysis_completeness:
+                result.add_error(
+                    "skillspector JSON field 'analysis_completeness.execution_successful' is required; "
+                    "security scan did not complete"
+                )
+                return False
+            if "execution_successful" in analysis_completeness and not isinstance(
+                completeness_execution_successful,
+                bool,
+            ):
                 result.add_error(
                     "skillspector JSON field 'analysis_completeness.execution_successful' must be a boolean; "
                     "security scan did not complete"
@@ -817,41 +951,368 @@ class SecurityValidator(ValidatorBase):
                     "security scan did not complete"
                 )
                 return False
-            if (
-                not is_complete
-                or completeness_status != "complete"
-                or not completeness_execution_successful
-            ):
+            if completeness_execution_successful is False:
                 result.add_error(
-                    "skillspector JSON field 'analysis_completeness' reports incomplete analysis "
-                    f"(status '{completeness_status}'); security scan did not complete"
-                )
-                return False
-            coverage_percent = analysis_completeness.get("coverage_percent")
-            incomplete_file_counts = (
-                analysis_completeness.get("partially_inspected_files"),
-                analysis_completeness.get("entirely_uninspected_files"),
-            )
-            ledger_exceptions = analysis_completeness.get("ledger_exceptions")
-            limitations = analysis_completeness.get("limitations")
-            if (
-                isinstance(coverage_percent, bool)
-                or not isinstance(coverage_percent, (int, float))
-                or coverage_percent != 100
-                or any(
-                    isinstance(count, bool) or not isinstance(count, int) or count != 0
-                    for count in incomplete_file_counts
-                )
-                or not isinstance(ledger_exceptions, list)
-                or bool(ledger_exceptions)
-                or not isinstance(limitations, list)
-                or bool(limitations)
-            ):
-                result.add_error(
-                    "skillspector JSON field 'analysis_completeness' details contradict complete analysis; "
+                    "skillspector JSON field 'analysis_completeness.execution_successful' is false; "
                     "security scan did not complete"
                 )
                 return False
+
+            if uses_versioned_completeness:
+                is_complete = analysis_completeness.get("is_complete")
+                if not isinstance(is_complete, bool):
+                    result.add_error(
+                        "skillspector JSON field 'analysis_completeness.is_complete' must be a boolean; "
+                        "security scan did not complete"
+                    )
+                    return False
+                if uses_completeness_schema:
+                    completeness_status = analysis_completeness.get("status")
+                    if not isinstance(completeness_status, str) or completeness_status not in {
+                        "complete",
+                        "partial",
+                        "failed",
+                    }:
+                        result.add_error(
+                            "skillspector JSON field 'analysis_completeness.status' is not recognized; "
+                            "security scan did not complete"
+                        )
+                        return False
+                    if completeness_status == "failed":
+                        result.add_error(
+                            "skillspector JSON field 'analysis_completeness' reports failed analysis; "
+                            "security scan did not complete"
+                        )
+                        return False
+                elif "status" in analysis_completeness:
+                    result.add_error(
+                        "skillspector 2.9.6 JSON field 'analysis_completeness.status' must be absent; "
+                        "security scan did not complete"
+                    )
+                    return False
+
+                count_fields = (
+                    "total_components",
+                    "scanned_components",
+                    "fully_inspected_files",
+                    "partially_inspected_files",
+                    "entirely_uninspected_files",
+                    "findings_before_filtering",
+                    "findings_after_filtering",
+                )
+                counts: dict[str, int] = {}
+                for field in count_fields:
+                    value = analysis_completeness.get(field)
+                    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+                        result.add_error(
+                            f"skillspector JSON field 'analysis_completeness.{field}' must be a "
+                            "non-negative integer; security scan did not complete"
+                        )
+                        return False
+                    counts[field] = value
+                findings_before_filtering = counts["findings_before_filtering"]
+                findings_after_filtering = counts["findings_after_filtering"]
+                if findings_before_filtering < findings_after_filtering or (
+                    uses_completeness_schema
+                    and (
+                        bool(findings_before_filtering) is not bool(findings_after_filtering)
+                        or (is_complete and findings_before_filtering != findings_after_filtering)
+                    )
+                ):
+                    result.add_error(
+                        "skillspector JSON field 'analysis_completeness' has inconsistent finding counts; "
+                        "security scan did not complete"
+                    )
+                    return False
+
+                coverage_percent = analysis_completeness.get("coverage_percent")
+                if (
+                    isinstance(coverage_percent, bool)
+                    or not isinstance(coverage_percent, (int, float))
+                    or not 0 <= coverage_percent <= 100
+                ):
+                    result.add_error(
+                        "skillspector JSON field 'analysis_completeness.coverage_percent' must be a "
+                        "finite number from 0 to 100; security scan did not complete"
+                    )
+                    return False
+                ledger_exceptions = analysis_completeness.get("ledger_exceptions")
+                limitations = analysis_completeness.get("limitations")
+                if (
+                    not isinstance(ledger_exceptions, list)
+                    or not all(
+                        isinstance(exception, dict) and isinstance(exception.get("fatal"), bool)
+                        for exception in ledger_exceptions
+                    )
+                    or not isinstance(limitations, list)
+                    or not all(isinstance(limitation, str) for limitation in limitations)
+                ):
+                    result.add_error(
+                        "skillspector JSON field 'analysis_completeness' has invalid detail lists; "
+                        "security scan did not complete"
+                    )
+                    return False
+                if any(exception["fatal"] for exception in ledger_exceptions):
+                    result.add_error(
+                        "skillspector JSON field 'analysis_completeness' has a fatal exception despite "
+                        "successful execution; security scan did not complete"
+                    )
+                    return False
+
+                analyzer_statuses = analysis_completeness.get("analyzer_statuses")
+                if not isinstance(analyzer_statuses, list) or not analyzer_statuses:
+                    result.add_error(
+                        "skillspector JSON field 'analysis_completeness.analyzer_statuses' must be a "
+                        "non-empty list; security scan did not complete"
+                    )
+                    return False
+                expected_limitations: list[str] = []
+                observed_analyzer_ids: set[str] = set()
+                analyzer_evidence: dict[str, list[tuple[str, dict[str, int]]]] = {}
+                for index, analyzer_status in enumerate(analyzer_statuses):
+                    if not isinstance(analyzer_status, dict):
+                        result.add_error(
+                            "skillspector JSON field "
+                            f"'analysis_completeness.analyzer_statuses[{index}]' must be an object; "
+                            "security scan did not complete"
+                        )
+                        return False
+                    analyzer_id = analyzer_status.get("analyzer_id")
+                    analyzer_state = analyzer_status.get("status")
+                    if (
+                        not isinstance(analyzer_id, str)
+                        or not analyzer_id
+                        or not isinstance(analyzer_state, str)
+                    ):
+                        result.add_error(
+                            "skillspector JSON field 'analysis_completeness.analyzer_statuses' has "
+                            "invalid analyzer evidence; security scan did not complete"
+                        )
+                        return False
+                    observed_analyzer_ids.add(analyzer_id)
+                    for field in ("reason_code", "message"):
+                        value = analyzer_status.get(field)
+                        if value is not None and not isinstance(value, str):
+                            result.add_error(
+                                "skillspector JSON field 'analysis_completeness.analyzer_statuses' has "
+                                f"a non-string '{field}'; security scan did not complete"
+                            )
+                            return False
+                    outcome_fields = (
+                        ("completed", "partial", "skipped", "failed", "unaccounted")
+                        if uses_completeness_schema
+                        else ("completed", "skipped", "failed", "unaccounted")
+                    )
+                    analyzer_counts: dict[str, int] = {}
+                    for field in ("planned_work", *outcome_fields):
+                        value = analyzer_status.get(field)
+                        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+                            result.add_error(
+                                "skillspector JSON field 'analysis_completeness.analyzer_statuses' has "
+                                f"invalid '{field}' accounting; security scan did not complete"
+                            )
+                            return False
+                        analyzer_counts[field] = value
+                    analyzer_evidence.setdefault(analyzer_id, []).append(
+                        (analyzer_state, analyzer_counts)
+                    )
+                    if analyzer_counts["planned_work"] != sum(
+                        analyzer_counts[field] for field in outcome_fields
+                    ):
+                        result.add_error(
+                            "skillspector JSON field 'analysis_completeness.analyzer_statuses' has "
+                            "inconsistent work accounting; security scan did not complete"
+                        )
+                        return False
+                    if analyzer_counts["unaccounted"]:
+                        result.add_error(
+                            "skillspector JSON field 'analysis_completeness.analyzer_statuses' reports "
+                            "unaccounted work despite successful execution; security scan did not complete"
+                        )
+                        return False
+                    if analyzer_counts["planned_work"]:
+                        expected_analyzer_state = (
+                            "failed"
+                            if analyzer_counts["failed"]
+                            else "degraded"
+                            if any(analyzer_counts.get(field, 0) for field in ("partial", "skipped"))
+                            else "completed"
+                        )
+                        if analyzer_state != expected_analyzer_state:
+                            result.add_error(
+                                "skillspector JSON field 'analysis_completeness.analyzer_statuses' has "
+                                "a status that contradicts its work accounting; security scan did not complete"
+                            )
+                            return False
+                    incomplete_outcomes = outcome_fields[1:]
+                    if (is_complete or uses_statusless_completeness_schema) and any(
+                        analyzer_counts[field] for field in incomplete_outcomes
+                    ):
+                        result.add_error(
+                            "skillspector JSON field 'analysis_completeness.analyzer_statuses' contradicts "
+                            "complete analysis; security scan did not complete"
+                        )
+                        return False
+                    if analyzer_state == "disabled":
+                        if (
+                            use_llm
+                            or analyzer_id not in _SKILLSPECTOR_OPTIONAL_ANALYZERS
+                            or analyzer_status.get("reason_code") != "disabled_by_configuration"
+                        ):
+                            result.add_error(
+                                "skillspector JSON field 'analysis_completeness.analyzer_statuses' "
+                                "reports an unexpected disabled analyzer; security scan did not complete"
+                            )
+                            return False
+                        if uses_statusless_completeness_schema:
+                            expected_limitations.append(_SKILLSPECTOR_DISABLED_ANALYZER_LIMITATION)
+                    elif analyzer_state in {"failed", "degraded", "unavailable"}:
+                        if uses_statusless_completeness_schema or is_complete:
+                            result.add_error(
+                                "skillspector JSON field 'analysis_completeness.analyzer_statuses' reports "
+                                f"incomplete analyzer '{analyzer_id}'; security scan did not complete"
+                            )
+                            return False
+                        message = analyzer_status.get("message")
+                        expected_limitations.append(
+                            message
+                            if isinstance(message, str) and message
+                            else f"Analyzer {analyzer_id} status: {analyzer_state}."
+                        )
+                    elif analyzer_state not in {"completed", "not_applicable"}:
+                        result.add_error(
+                            "skillspector JSON field 'analysis_completeness.analyzer_statuses' reports "
+                            f"unknown analyzer status '{analyzer_state}'; security scan did not complete"
+                        )
+                        return False
+
+                required_analyzer_ids = (
+                    _SKILLSPECTOR_2_9_6_REQUIRED_ANALYZERS
+                    if uses_statusless_completeness_schema
+                    else _SKILLSPECTOR_2_10_REQUIRED_ANALYZERS
+                )
+                if (
+                    uses_completeness_schema
+                    and use_llm
+                    and report_metadata.get("llm_available") is True
+                ):
+                    required_analyzer_ids |= _SKILLSPECTOR_SEMANTIC_ANALYZERS
+                if not required_analyzer_ids.issubset(observed_analyzer_ids):
+                    result.add_error(
+                        "skillspector JSON field 'analysis_completeness.analyzer_statuses' is "
+                        "missing required analyzer evidence; security scan did not complete"
+                    )
+                    return False
+                if (is_complete or uses_statusless_completeness_schema) and counts["total_components"]:
+                    universal_analyzer_ids = _SKILLSPECTOR_COMMON_UNIVERSAL_ANALYZERS | (
+                        {"artifact_integrity"} if uses_completeness_schema else set()
+                    )
+                    universal_analyzer_evidence_valid = all(
+                        all(state == "completed" for state, _item in analyzer_evidence[analyzer_id])
+                        and sum(item["planned_work"] for _state, item in analyzer_evidence[analyzer_id])
+                        == counts["total_components"]
+                        and sum(item["completed"] for _state, item in analyzer_evidence[analyzer_id])
+                        == counts["total_components"]
+                        for analyzer_id in universal_analyzer_ids
+                    )
+                actual_limitation_counts = Counter(limitations)
+                expected_limitation_counts = Counter(expected_limitations)
+                if (
+                    uses_statusless_completeness_schema
+                    and actual_limitation_counts != expected_limitation_counts
+                ) or (
+                    uses_completeness_schema
+                    and bool(expected_limitation_counts - actual_limitation_counts)
+                ):
+                    result.add_error(
+                        "skillspector JSON field 'analysis_completeness.limitations' contradicts "
+                        "analyzer evidence; security scan did not complete"
+                    )
+                    return False
+
+                if uses_completeness_schema and is_complete is not (completeness_status == "complete"):
+                    has_report_stage_truncation = any(
+                        limitation.startswith("Transitive traversal truncated: ")
+                        for limitation in limitations
+                    )
+                    if not (
+                        not is_complete
+                        and completeness_status == "complete"
+                        and has_report_stage_truncation
+                    ):
+                        result.add_error(
+                            "skillspector JSON field 'analysis_completeness' has contradictory status markers; "
+                            "security scan did not complete"
+                        )
+                        return False
+
+                if (
+                    counts["scanned_components"] != counts["fully_inspected_files"]
+                    or counts["total_components"]
+                    != counts["fully_inspected_files"]
+                    + counts["partially_inspected_files"]
+                    + counts["entirely_uninspected_files"]
+                ):
+                    result.add_error(
+                        "skillspector JSON field 'analysis_completeness' has inconsistent counters or coverage; "
+                        "security scan did not complete"
+                    )
+                    return False
+
+                expected_coverage = (
+                    round(counts["fully_inspected_files"] / counts["total_components"] * 100, 1)
+                    if counts["total_components"]
+                    else 100.0
+                )
+                if coverage_percent != expected_coverage:
+                    result.add_error(
+                        "skillspector JSON field 'analysis_completeness' has inconsistent counters or coverage; "
+                        "security scan did not complete"
+                    )
+                    return False
+
+                if uses_statusless_completeness_schema:
+                    if (
+                        counts["partially_inspected_files"] != 0
+                        or counts["entirely_uninspected_files"] != 0
+                        or ledger_exceptions
+                        or coverage_percent != 100
+                        or is_complete is not (not limitations)
+                    ):
+                        result.add_error(
+                            "skillspector 2.9.6 JSON field 'analysis_completeness' does not describe "
+                            "a fully covered scan; security scan did not complete"
+                        )
+                        return False
+                elif is_complete:
+                    if (
+                        counts["partially_inspected_files"] != 0
+                        or counts["entirely_uninspected_files"] != 0
+                        or ledger_exceptions
+                        or limitations
+                    ):
+                        result.add_error(
+                            "skillspector JSON field 'analysis_completeness' details contradict complete analysis; "
+                            "security scan did not complete"
+                        )
+                        return False
+                else:
+                    if not (
+                        counts["partially_inspected_files"]
+                        or counts["entirely_uninspected_files"]
+                        or ledger_exceptions
+                        or limitations
+                    ):
+                        result.add_error(
+                            "skillspector JSON field 'analysis_completeness' details contradict partial analysis; "
+                            "security scan did not complete"
+                        )
+                        return False
+                    result.add_error(
+                        "skillspector JSON field 'analysis_completeness' reports incomplete analysis "
+                        f"(status '{completeness_status}'); security scan did not complete"
+                    )
+                    result.mark_scan_incomplete(stage_name)
 
         status = data.get("status")
         if status is not None and not isinstance(status, str):
@@ -917,7 +1378,10 @@ class SecurityValidator(ValidatorBase):
             )
             return False
         recommendation = risk.get("recommendation")
-        if recommendation is not None and recommendation != _SKILLSPECTOR_RECOMMENDATION_BY_SEVERITY[severity]:
+        expected_recommendation = _SKILLSPECTOR_RECOMMENDATION_BY_SEVERITY[severity]
+        if result.is_incomplete and severity == "LOW":
+            expected_recommendation = "CAUTION"
+        if not isinstance(recommendation, str) or recommendation != expected_recommendation:
             result.add_error(
                 "skillspector JSON field 'risk_assessment.recommendation' does not match the risk severity; "
                 "security scan did not complete"
@@ -925,8 +1389,39 @@ class SecurityValidator(ValidatorBase):
             return False
 
         for index, issue in enumerate(issues):
-            if not SecurityValidator._validate_skillspector_issue(issue, index, result):
+            if not SecurityValidator._validate_skillspector_issue(
+                issue,
+                index,
+                result,
+                require_finding_id=uses_completeness_schema,
+                require_location_file=uses_versioned_completeness,
+            ):
                 return False
+        if uses_completeness_schema:
+            scoring_fields_by_identity: dict[tuple, tuple] = {}
+            for index, issue in enumerate(issues):
+                match_identity = _skillspector_scoring_match_identity(
+                    issue,
+                    index,
+                    uses_report_identities=True,
+                )
+                identity = (
+                    _skillspector_scoring_source_scope(issue),
+                    issue["id"],
+                    match_identity,
+                )
+                scoring_fields = (
+                    issue["severity"],
+                    issue["confidence"],
+                    issue["finding_id"] if match_identity[0] == "match_fingerprint" else None,
+                )
+                previous = scoring_fields_by_identity.setdefault(identity, scoring_fields)
+                if previous != scoring_fields:
+                    result.add_error(
+                        "skillspector JSON compacted identity has inconsistent scoring fields; "
+                        "security scan did not complete"
+                    )
+                    return False
         if not issues and score != 0:
             result.add_error(
                 "skillspector JSON reports a nonzero risk score without any issues; security scan did not complete"
@@ -970,6 +1465,17 @@ class SecurityValidator(ValidatorBase):
                     "security scan did not complete"
                 )
                 return False
+        if version_error is not None:
+            result.add_error(version_error)
+            return False
+        if uses_versioned_completeness and metadata.get("llm_requested") is not use_llm:
+            stage_description = "LLM" if use_llm else "--no-llm"
+            result.add_error(
+                "skillspector JSON field 'metadata.llm_requested' contradicts the "
+                f"{stage_description} stage; "
+                "security scan did not complete"
+            )
+            return False
         if not use_llm and (
             metadata.get("llm_requested") not in {None, False}
             or metadata.get("llm_available") not in {None, False}
@@ -980,6 +1486,12 @@ class SecurityValidator(ValidatorBase):
             )
             return False
         components = data.get("components")
+        if uses_versioned_completeness and "components" not in data:
+            result.add_error(
+                f"skillspector {completeness_contract} JSON report is missing required "
+                "'components' list; security scan did not complete"
+            )
+            return False
         if components is not None and not isinstance(components, list):
             result.add_error("skillspector JSON field 'components' must be a list; security scan did not complete")
             return False
@@ -988,14 +1500,29 @@ class SecurityValidator(ValidatorBase):
             return False
         normalized_components = components or []
         for index, component in enumerate(normalized_components):
-            path = component.get("path")
-            if path is not None and not isinstance(path, str):
+            for field in ("path", "source_identity", "source_url", "source_digest"):
+                value = component.get(field)
+                if uses_versioned_completeness and field == "path" and (
+                    not isinstance(value, str) or not value
+                ):
+                    result.add_error(
+                        f"skillspector JSON field 'components[{index}].path' must be a non-empty string; "
+                        "security scan did not complete"
+                    )
+                    return False
+                if value is not None and not isinstance(value, str):
+                    result.add_error(
+                        f"skillspector JSON field 'components[{index}].{field}' must be a string or null; "
+                        "security scan did not complete"
+                    )
+                    return False
+            executable = component.get("executable")
+            if uses_versioned_completeness and not isinstance(executable, bool):
                 result.add_error(
-                    f"skillspector JSON field 'components[{index}].path' must be a string or null; "
+                    f"skillspector JSON field 'components[{index}].executable' must be a boolean; "
                     "security scan did not complete"
                 )
                 return False
-            executable = component.get("executable")
             if executable is not None and not isinstance(executable, bool):
                 result.add_error(
                     f"skillspector JSON field 'components[{index}].executable' must be a boolean or null; "
@@ -1003,22 +1530,52 @@ class SecurityValidator(ValidatorBase):
                 )
                 return False
         component_has_executable = any(component.get("executable") is True for component in normalized_components)
-        if component_has_executable and metadata.get("has_executable_scripts") is False:
+        declared_has_executable = metadata.get("has_executable_scripts")
+        if (
+            uses_versioned_completeness
+            and isinstance(declared_has_executable, bool)
+            and declared_has_executable is not component_has_executable
+        ) or (component_has_executable and declared_has_executable is False):
             result.add_error(
-                "skillspector JSON executable component contradicts metadata.has_executable_scripts; "
+                "skillspector JSON components contradict metadata.has_executable_scripts; "
                 "security scan did not complete"
             )
             return False
-        minimum_score = SecurityValidator._minimum_skillspector_risk_score(
-            issues,
-            normalized_components,
-            use_executable_multiplier=(component_has_executable or metadata.get("has_executable_scripts") is True),
-        )
-        if score < minimum_score:
-            result.add_error(
-                "skillspector JSON risk score understates the reported issues; security scan did not complete"
-            )
-            return False
+        if uses_versioned_completeness and not result.is_incomplete:
+            if len(normalized_components) != analysis_completeness["total_components"]:
+                result.add_error(
+                    "skillspector JSON component inventory contradicts analysis completeness; "
+                    "security scan did not complete"
+                )
+                return False
+            component_keys = {
+                (_skillspector_scoring_source_scope(component), component["path"])
+                for component in normalized_components
+            }
+            if len(component_keys) != len(normalized_components):
+                result.add_error(
+                    "skillspector JSON component inventory contains duplicate identities; "
+                    "security scan did not complete"
+                )
+                return False
+            if not universal_analyzer_evidence_valid:
+                result.add_error(
+                    "skillspector JSON universal analyzer evidence contradicts the "
+                    "component inventory; security scan did not complete"
+                )
+                return False
+            for issue in issues:
+                location = issue.get("location") or {}
+                issue_key = (
+                    _skillspector_scoring_source_scope(issue),
+                    str(location.get("file") or "SKILL.md"),
+                )
+                if issue.get("id") != "SC8" and issue_key not in component_keys:
+                    result.add_error(
+                        "skillspector JSON issue has no matching component inventory entry; "
+                        "security scan did not complete"
+                    )
+                    return False
         suppressed_count = data.get("suppressed_count")
         if suppressed_count is not None and (
             isinstance(suppressed_count, bool) or not isinstance(suppressed_count, int) or suppressed_count < 0
@@ -1043,10 +1600,48 @@ class SecurityValidator(ValidatorBase):
                 "security scan did not complete"
             )
             return False
+        if findings_after_filtering is not None:
+            serialized_findings = len(issues) + normalized_suppressed_count
+            serialized_identity_count = len(
+                SecurityValidator._deduplicate_skillspector_issues_for_scoring(
+                    issues,
+                    uses_report_identities=uses_completeness_schema,
+                )[0]
+            )
+            finding_counts_match = (
+                findings_after_filtering == serialized_findings
+                if uses_statusless_completeness_schema
+                else (
+                    (findings_after_filtering == 0) is (serialized_findings == 0)
+                    and normalized_suppressed_count <= findings_after_filtering
+                    and serialized_identity_count <= findings_after_filtering
+                )
+            )
+            if not finding_counts_match:
+                result.add_error(
+                    "skillspector JSON analysis completeness finding counts contradict the serialized findings; "
+                    "security scan did not complete"
+                )
+                return False
         if normalized_suppressed_count:
             result.add_error(
                 "skillspector reported unexpected suppressed findings without a requested baseline; "
                 "security scan did not complete"
+            )
+            return False
+        minimum_score = SecurityValidator._minimum_skillspector_risk_score(
+            issues,
+            normalized_components,
+            uses_report_identities=uses_completeness_schema,
+            findings_after_filtering=findings_after_filtering,
+            all_findings_serialized=(
+                findings_after_filtering is None
+                or findings_after_filtering == len(issues) + normalized_suppressed_count
+            ),
+        )
+        if score < minimum_score:
+            result.add_error(
+                "skillspector JSON risk score understates the reported issues; security scan did not complete"
             )
             return False
 
@@ -1057,60 +1652,219 @@ class SecurityValidator(ValidatorBase):
         issues: list[dict],
         components: list[dict],
         *,
-        use_executable_multiplier: bool,
-    ) -> int:
-        """Recompute the score from the public issue identity fields."""
-        executable_paths = {
-            component.get("path")
+        uses_report_identities: bool,
+        findings_after_filtering: int | None = None,
+        reported_score: int | float | None = None,
+        removed_issues: list[dict] | None = None,
+        all_findings_serialized: bool = False,
+    ) -> int | float:
+        """Return a conservative score floor from the public report fields."""
+        file_executable = {
+            (_skillspector_scoring_source_scope(component), component["path"]):
+            component.get("executable") is True
             for component in components
-            if component.get("executable") is True and isinstance(component.get("path"), str)
+            if isinstance(component.get("path"), str)
         }
-        deduplicated = SecurityValidator._deduplicate_skillspector_issues_for_scoring(issues)
-        by_rule: dict[str, list[dict]] = {}
-        for issue in deduplicated:
-            by_rule.setdefault(issue["id"], []).append(issue)
 
-        score = 0.0
-        for rule_issues in by_rule.values():
-            ordered = sorted(
-                (issue for issue in rule_issues if issue["confidence"] > 0),
-                key=lambda issue: _SKILLSPECTOR_SEVERITY_POINTS[issue["severity"]],
-                reverse=True,
-            )
-            for index, issue in enumerate(ordered[: len(_SKILLSPECTOR_DIMINISHING_WEIGHTS)]):
-                location = issue.get("location") or {}
-                multiplier = 1.3 if use_executable_multiplier and location.get("file") in executable_paths else 1.0
-                score += (
-                    _SKILLSPECTOR_SEVERITY_POINTS[issue["severity"]]
-                    * _SKILLSPECTOR_DIMINISHING_WEIGHTS[index]
-                    * issue["confidence"]
-                    * multiplier
+        def base_contribution(issue: dict, *, trust_location: bool = True) -> float:
+            location = issue.get("location") or {}
+            multiplier = (
+                _SKILLSPECTOR_EXECUTABLE_MULTIPLIER
+                if trust_location
+                and file_executable.get(
+                    (_skillspector_scoring_source_scope(issue), location.get("file")),
+                    False,
                 )
-        return min(100, max(0, int(score)))
+                else 1.0
+            )
+            return _SKILLSPECTOR_SEVERITY_POINTS[issue["severity"]] * issue["confidence"] * multiplier
+
+        def legacy_score(candidate_issues: list[dict]) -> int:
+            by_rule: dict[str, list[dict]] = {}
+            for issue in candidate_issues:
+                by_rule.setdefault(issue["id"], []).append(issue)
+
+            total = 0.0
+            for rule_issues in by_rule.values():
+                ordered = sorted(
+                    (issue for issue in rule_issues if issue["confidence"] > 0),
+                    key=lambda issue: (
+                        -_SKILLSPECTOR_SEVERITY_POINTS[issue["severity"]],
+                        base_contribution(issue),
+                    ),
+                )
+                for index, issue in enumerate(ordered[: len(_SKILLSPECTOR_DIMINISHING_WEIGHTS)]):
+                    total += base_contribution(issue) * _SKILLSPECTOR_DIMINISHING_WEIGHTS[index]
+            score_floor = max(
+                (
+                    _SKILLSPECTOR_RISK_SCORE_FLOORS_BY_RULE_ID.get(issue["id"], 0)
+                    for issue in candidate_issues
+                    if issue["confidence"] > 0
+                ),
+                default=0,
+            )
+            return min(100, max(score_floor, int(total)))
+
+        def compacted_score(
+            candidate_issues: list[dict],
+            ambiguous_identities: set[tuple],
+            unknown_finding_count: int,
+        ) -> int:
+            by_rule: dict[str, list[float]] = {}
+            for index, issue in enumerate(candidate_issues):
+                if issue["confidence"] <= 0:
+                    continue
+                identity = (
+                    _skillspector_scoring_source_scope(issue),
+                    issue["id"],
+                    _skillspector_scoring_match_identity(
+                        issue,
+                        index,
+                        uses_report_identities=True,
+                    ),
+                )
+                by_rule.setdefault(issue["id"], []).append(
+                    base_contribution(
+                        issue,
+                        trust_location=(
+                            unknown_finding_count == 0 and identity not in ambiguous_identities
+                        ),
+                    )
+                )
+
+            total = 0.0
+            reductions: list[float] = []
+            for contributions in by_rule.values():
+                ordered = sorted(contributions)
+                costs = [
+                    sum(
+                        contribution * weight
+                        for contribution, weight in zip(
+                            ordered,
+                            _SKILLSPECTOR_DIMINISHING_WEIGHTS[unknowns:],
+                            strict=False,
+                        )
+                    )
+                    for unknowns in range(len(_SKILLSPECTOR_DIMINISHING_WEIGHTS) + 1)
+                ]
+                total += costs[0]
+                reductions.extend(
+                    costs[index] - costs[index + 1]
+                    for index in range(len(_SKILLSPECTOR_DIMINISHING_WEIGHTS))
+                )
+            total -= sum(sorted(reductions, reverse=True)[:unknown_finding_count])
+            score_floor = max(
+                (
+                    _SKILLSPECTOR_RISK_SCORE_FLOORS_BY_RULE_ID.get(issue["id"], 0)
+                    for issue in candidate_issues
+                    if issue["confidence"] > 0
+                ),
+                default=0,
+            )
+            return min(100, max(score_floor, int(max(0, total))))
+
+        # SkillSpector scores before report compaction, which can discard
+        # occurrence-level confidence, executable status, and same-severity order.
+        deduplicated, _ambiguous_identities = SecurityValidator._deduplicate_skillspector_issues_for_scoring(
+            issues,
+            uses_report_identities=uses_report_identities,
+        )
+        if uses_report_identities:
+            all_visible_issues = [*issues, *(removed_issues or [])]
+            all_deduplicated, all_ambiguous_identities = (
+                SecurityValidator._deduplicate_skillspector_issues_for_scoring(
+                    all_visible_issues,
+                    uses_report_identities=True,
+                )
+            )
+            unknown_finding_count = max(
+                0,
+                (findings_after_filtering or 0) - len(all_deduplicated),
+            )
+            minimum_score = compacted_score(
+                deduplicated,
+                all_ambiguous_identities,
+                unknown_finding_count,
+            )
+        else:
+            minimum_score = min(legacy_score(issues), legacy_score(deduplicated))
+        if reported_score is None or not removed_issues or not all_findings_serialized:
+            return minimum_score
+        maximum_removed_loss = sum(
+            max(
+                _SKILLSPECTOR_SEVERITY_POINTS[issue["severity"]]
+                * issue["confidence"]
+                * _SKILLSPECTOR_EXECUTABLE_MULTIPLIER,
+                _SKILLSPECTOR_RISK_SCORE_FLOORS_BY_RULE_ID.get(issue["id"], 0)
+                if issue["confidence"] > 0
+                else 0,
+            )
+            for issue in removed_issues
+        )
+        reported_floor = max(0, reported_score - math.ceil(maximum_removed_loss))
+        return max(minimum_score, reported_floor)
 
     @staticmethod
-    def _deduplicate_skillspector_issues_for_scoring(issues: list[dict]) -> list[dict]:
-        """Mirror scanner dedup using ``finding`` as its serialized match identity."""
-        same_file_best: dict[tuple[str, str, str], dict] = {}
-        for issue in issues:
-            location = issue.get("location") or {}
-            identity = str(issue.get("finding") or "").strip()[:100]
-            key = (issue["id"], str(location.get("file") or "SKILL.md"), identity)
-            existing = same_file_best.get(key)
-            if existing is None or issue["confidence"] > existing["confidence"]:
-                same_file_best[key] = issue
+    def _deduplicate_skillspector_issues_for_scoring(
+        issues: list[dict],
+        *,
+        uses_report_identities: bool,
+    ) -> tuple[list[dict], set[tuple]]:
+        """Mirror scanner dedup using serialized source and match identities."""
 
-        cross_file_best: dict[tuple[str, str], dict] = {}
-        for issue in same_file_best.values():
-            identity = str(issue.get("finding") or "").strip()[:100]
-            key = (issue["id"], identity)
+        same_file_best: dict[tuple, tuple[int, dict]] = {}
+        modern_identity_counts: Counter[tuple] = Counter()
+        for index, issue in enumerate(issues):
+            location = issue.get("location") or {}
+            identity = _skillspector_scoring_match_identity(
+                issue,
+                index,
+                uses_report_identities=uses_report_identities,
+            )
+            if uses_report_identities:
+                modern_identity_counts[
+                    (_skillspector_scoring_source_scope(issue), issue["id"], identity)
+                ] += 1
+            key = (
+                _skillspector_scoring_source_scope(issue),
+                issue["id"],
+                str(location.get("file") or "SKILL.md"),
+                identity,
+            )
+            existing = same_file_best.get(key)
+            if existing is None or issue["confidence"] > existing[1]["confidence"]:
+                same_file_best[key] = index, issue
+
+        cross_file_best: dict[tuple, dict] = {}
+        for index, issue in same_file_best.values():
+            key = (
+                _skillspector_scoring_source_scope(issue),
+                issue["id"],
+                _skillspector_scoring_match_identity(
+                    issue,
+                    index,
+                    uses_report_identities=uses_report_identities,
+                ),
+            )
             existing = cross_file_best.get(key)
             if existing is None or issue["confidence"] > existing["confidence"]:
                 cross_file_best[key] = issue
-        return list(cross_file_best.values())
+        ambiguous_identities = {
+            identity
+            for identity, count in modern_identity_counts.items()
+            if count > 1
+        }
+        return list(cross_file_best.values()), ambiguous_identities
 
     @staticmethod
-    def _validate_skillspector_issue(issue: dict, index: int, result: ValidationResult) -> bool:
+    def _validate_skillspector_issue(
+        issue: dict,
+        index: int,
+        result: ValidationResult,
+        *,
+        require_finding_id: bool,
+        require_location_file: bool,
+    ) -> bool:
         """Validate every nested issue field consumed by the report converter."""
         prefix = f"skillspector JSON field 'issues[{index}]"
         issue_id = issue.get("id")
@@ -1130,6 +1884,7 @@ class SecurityValidator(ValidatorBase):
             return False
 
         optional_strings = (
+            "finding_id",
             "category",
             "pattern",
             "finding",
@@ -1137,12 +1892,22 @@ class SecurityValidator(ValidatorBase):
             "remediation",
             "code_snippet",
             "intent",
+            "match_fingerprint",
+            "source_identity",
+            "source_url",
+            "source_digest",
         )
         for field in optional_strings:
             value = issue.get(field)
             if value is not None and not isinstance(value, str):
                 result.add_error(f"{prefix}.{field}' must be a string or null; security scan did not complete")
                 return False
+        finding_id = issue.get("finding_id")
+        if require_finding_id and (not isinstance(finding_id, str) or not finding_id.strip()):
+            result.add_error(
+                f"{prefix}.finding_id' must be a non-empty string; security scan did not complete"
+            )
+            return False
         if not any(
             isinstance(issue.get(field), str) and issue[field].strip()
             for field in ("pattern", "finding", "explanation")
@@ -1166,11 +1931,21 @@ class SecurityValidator(ValidatorBase):
 
         location = issue.get("location")
         if location is None:
+            if require_location_file:
+                result.add_error(
+                    f"{prefix}.location.file' must be a non-empty string; security scan did not complete"
+                )
+                return False
             return True
         if not isinstance(location, dict):
             result.add_error(f"{prefix}.location' must be an object or null; security scan did not complete")
             return False
         file_path = location.get("file")
+        if require_location_file and (not isinstance(file_path, str) or not file_path):
+            result.add_error(
+                f"{prefix}.location.file' must be a non-empty string; security scan did not complete"
+            )
+            return False
         if file_path is not None and not isinstance(file_path, str):
             result.add_error(f"{prefix}.location.file' must be a string or null; security scan did not complete")
             return False
@@ -1185,24 +1960,17 @@ class SecurityValidator(ValidatorBase):
                 return False
         return True
 
-    def _process_skillspector_cli_result(self, data: dict, result: ValidationResult) -> None:
-        """Convert skillspector CLI JSON output into ValidationResult entries.
-
-        Handles the skillspector 1.0 JSON schema which includes:
-        - skill: {name, source, scanned_at}
-        - risk_assessment: {score, severity, recommendation}
-        - components: [{path, type, lines, executable, size_bytes}]
-        - issues[]: {id, category, pattern, severity, confidence, location,
-                     finding, explanation, remediation, code_snippet, intent}
-        - metadata: {has_executable_scripts, skillspector_version}
-
-        Applies post-processing to downgrade known false-positive patterns
-        (e.g. trusted package installers, standard Docker commands).
-        """
+    def _process_skillspector_cli_result(
+        self,
+        data: dict,
+        result: ValidationResult,
+    ) -> None:
+        """Convert a validated SkillSpector JSON report into ValidationResult entries."""
         self._store_skillspector_metadata(data, result)
 
         issues = data.get("issues", [])
         scanned_issues = []
+        removed_issues = []
         skipped_generated = 0
         skipped_spdx_comments = 0
         has_critical_or_high = False
@@ -1210,9 +1978,11 @@ class SecurityValidator(ValidatorBase):
             if not isinstance(issue, dict):
                 continue
             if self._is_generated_artifact_issue(issue):
+                removed_issues.append(issue)
                 skipped_generated += 1
                 continue
             if self._is_spdx_only_hidden_instruction(issue):
+                removed_issues.append(issue)
                 skipped_spdx_comments += 1
                 continue
             scanned_issues.append(issue)
@@ -1229,11 +1999,30 @@ class SecurityValidator(ValidatorBase):
         reported_score = data["risk_assessment"]["score"]
         report_components = data.get("components") if isinstance(data.get("components"), list) else []
         report_metadata = data.get("metadata") if isinstance(data.get("metadata"), dict) else {}
+        raw_version = report_metadata.get("skillspector_version")
+        uses_report_identities = (
+            isinstance(raw_version, str)
+            and SEMVER_RE.fullmatch(raw_version) is not None
+            and tuple(int(part) for part in raw_version.split("."))
+            >= _SKILLSPECTOR_COMPLETENESS_SCHEMA_VERSION
+        )
+        analysis_completeness = data.get("analysis_completeness")
+        findings_after_filtering = (
+            analysis_completeness.get("findings_after_filtering")
+            if isinstance(analysis_completeness, dict)
+            else None
+        )
+        suppressed = data.get("suppressed")
+        serialized_findings = len(issues) + (len(suppressed) if isinstance(suppressed, list) else 0)
         effective_score = (
             self._minimum_skillspector_risk_score(
                 scanned_issues,
                 report_components,
-                use_executable_multiplier=report_metadata.get("has_executable_scripts") is True,
+                uses_report_identities=uses_report_identities,
+                findings_after_filtering=findings_after_filtering,
+                reported_score=reported_score,
+                removed_issues=removed_issues,
+                all_findings_serialized=findings_after_filtering == serialized_findings,
             )
             if skipped_generated or skipped_spdx_comments
             else reported_score
@@ -1252,11 +2041,14 @@ class SecurityValidator(ValidatorBase):
             )
             has_critical_or_high = True
 
-        self._summarize_skillspector_results(scanned_issues, has_critical_or_high, result)
+        if not result.is_incomplete:
+            self._summarize_skillspector_results(scanned_issues, has_critical_or_high, result)
 
     @staticmethod
     def _is_generated_artifact_issue(issue: dict) -> bool:
         """Return True when a skillspector issue points at generated output."""
+        if issue.get("id") == "SC8":
+            return False
         file_path, _line_number = SecurityValidator._parse_issue_location(issue)
         path = Path(file_path)
         if path.name.lower() in SCAN_EXCLUDED_FILES:
@@ -1275,7 +2067,7 @@ class SecurityValidator(ValidatorBase):
 
     @staticmethod
     def _store_skillspector_metadata(data: dict, result: ValidationResult) -> None:
-        """Extract and store top-level skillspector 1.0 metadata on the result."""
+        """Store the validated SkillSpector report metadata on the result."""
         skill_info = data.get("skill") or {}
         sp_metadata = data.get("metadata") or {}
         components = data.get("components") or []

--- a/src/skillevaluator/validators/security.py
+++ b/src/skillevaluator/validators/security.py
@@ -827,6 +827,31 @@ class SecurityValidator(ValidatorBase):
                     f"(status '{completeness_status}'); security scan did not complete"
                 )
                 return False
+            coverage_percent = analysis_completeness.get("coverage_percent")
+            incomplete_file_counts = (
+                analysis_completeness.get("partially_inspected_files"),
+                analysis_completeness.get("entirely_uninspected_files"),
+            )
+            ledger_exceptions = analysis_completeness.get("ledger_exceptions")
+            limitations = analysis_completeness.get("limitations")
+            if (
+                isinstance(coverage_percent, bool)
+                or not isinstance(coverage_percent, (int, float))
+                or coverage_percent != 100
+                or any(
+                    isinstance(count, bool) or not isinstance(count, int) or count != 0
+                    for count in incomplete_file_counts
+                )
+                or not isinstance(ledger_exceptions, list)
+                or bool(ledger_exceptions)
+                or not isinstance(limitations, list)
+                or bool(limitations)
+            ):
+                result.add_error(
+                    "skillspector JSON field 'analysis_completeness' details contradict complete analysis; "
+                    "security scan did not complete"
+                )
+                return False
 
         status = data.get("status")
         if status is not None and not isinstance(status, str):

--- a/src/skillevaluator/validators/security.py
+++ b/src/skillevaluator/validators/security.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import contextlib
 import getpass
 import io
+import json
 import math
 import os
 import re
@@ -53,7 +54,8 @@ logger = get_logger(__name__)
 
 _AUTHOR_IDENTITY_RE = re.compile(r"^\S[^<>\n]* <(?P<email>[^<>@\s]+@[^<>\s]+)>$")
 _SKILLSPECTOR_POLICY_EXIT_CODES = frozenset({0, 1})
-_SKILLSPECTOR_STATUSLESS_COMPLETENESS_VERSION = (2, 9, 6)
+_SKILLSPECTOR_STATUSLESS_COMPLETENESS_VERSIONS = {(2, 9, 5), (2, 9, 6)}
+_SKILLSPECTOR_FINDING_IDENTITY_VERSION = (2, 11, 1)
 _SKILLSPECTOR_COMPLETENESS_SCHEMA_VERSION = (2, 10, 0)
 _SKILLSPECTOR_SEMANTIC_ANALYZERS = frozenset(
     {
@@ -457,8 +459,11 @@ def _skillspector_scoring_match_identity(
     index: int,
     *,
     uses_report_identities: bool,
+    uses_finding_identity: bool,
 ) -> tuple[str, str | int]:
     """Return the producer's finding identity used for report compaction."""
+    if uses_finding_identity:
+        return "finding_id", str(issue["finding_id"])
     fingerprint = issue.get("match_fingerprint")
     if isinstance(fingerprint, str) and fingerprint:
         return "match_fingerprint", fingerprint
@@ -880,10 +885,14 @@ class SecurityValidator(ValidatorBase):
             and skillspector_version >= _SKILLSPECTOR_COMPLETENESS_SCHEMA_VERSION
         )
         uses_statusless_completeness_schema = (
-            skillspector_version == _SKILLSPECTOR_STATUSLESS_COMPLETENESS_VERSION
+            skillspector_version in _SKILLSPECTOR_STATUSLESS_COMPLETENESS_VERSIONS
+        )
+        uses_finding_identity = (
+            skillspector_version is not None
+            and skillspector_version >= _SKILLSPECTOR_FINDING_IDENTITY_VERSION
         )
         uses_versioned_completeness = uses_completeness_schema or uses_statusless_completeness_schema
-        completeness_contract = "2.10+" if uses_completeness_schema else "2.9.6"
+        completeness_contract = "2.10+" if uses_completeness_schema else "2.9.5/2.9.6"
 
         execution_successful = data.get("execution_successful")
         if uses_versioned_completeness and "execution_successful" not in data:
@@ -986,7 +995,7 @@ class SecurityValidator(ValidatorBase):
                         return False
                 elif "status" in analysis_completeness:
                     result.add_error(
-                        "skillspector 2.9.6 JSON field 'analysis_completeness.status' must be absent; "
+                        "skillspector 2.9.5/2.9.6 JSON field 'analysis_completeness.status' must be absent; "
                         "security scan did not complete"
                     )
                     return False
@@ -1191,6 +1200,8 @@ class SecurityValidator(ValidatorBase):
                     if uses_statusless_completeness_schema
                     else _SKILLSPECTOR_2_10_REQUIRED_ANALYZERS
                 )
+                if skillspector_version >= (2, 11, 0):
+                    required_analyzer_ids |= {"bundled_execution_surface"}
                 if (
                     uses_completeness_schema
                     and use_llm
@@ -1280,7 +1291,7 @@ class SecurityValidator(ValidatorBase):
                         or is_complete is not (not limitations)
                     ):
                         result.add_error(
-                            "skillspector 2.9.6 JSON field 'analysis_completeness' does not describe "
+                            "skillspector 2.9.5/2.9.6 JSON field 'analysis_completeness' does not describe "
                             "a fully covered scan; security scan did not complete"
                         )
                         return False
@@ -1404,6 +1415,7 @@ class SecurityValidator(ValidatorBase):
                     issue,
                     index,
                     uses_report_identities=True,
+                    uses_finding_identity=uses_finding_identity,
                 )
                 identity = (
                     _skillspector_scoring_source_scope(issue),
@@ -1415,6 +1427,20 @@ class SecurityValidator(ValidatorBase):
                     issue["confidence"],
                     issue["finding_id"] if match_identity[0] == "match_fingerprint" else None,
                 )
+                if uses_finding_identity:
+                    # Occurrence rows may vary in location, not classification.
+                    identity = match_identity
+                    scoring_fields += (
+                        _skillspector_scoring_source_scope(issue),
+                        issue["id"],
+                        issue.get("match_fingerprint"),
+                        *(issue.get(field) for field in (
+                            "finding", "category", "pattern", "explanation",
+                            "remediation", "intent", "tags",
+                        )),
+                        # JSON classification evidence distinguishes true from 1.
+                        json.dumps(issue.get("evidence"), sort_keys=True),
+                    )
                 previous = scoring_fields_by_identity.setdefault(identity, scoring_fields)
                 if previous != scoring_fields:
                     result.add_error(
@@ -1606,6 +1632,7 @@ class SecurityValidator(ValidatorBase):
                 SecurityValidator._deduplicate_skillspector_issues_for_scoring(
                     issues,
                     uses_report_identities=uses_completeness_schema,
+                    uses_finding_identity=uses_finding_identity,
                 )[0]
             )
             finding_counts_match = (
@@ -1633,6 +1660,7 @@ class SecurityValidator(ValidatorBase):
             issues,
             normalized_components,
             uses_report_identities=uses_completeness_schema,
+            uses_finding_identity=uses_finding_identity,
             findings_after_filtering=findings_after_filtering,
             all_findings_serialized=(
                 findings_after_filtering is None
@@ -1653,6 +1681,7 @@ class SecurityValidator(ValidatorBase):
         components: list[dict],
         *,
         uses_report_identities: bool,
+        uses_finding_identity: bool,
         findings_after_filtering: int | None = None,
         reported_score: int | float | None = None,
         removed_issues: list[dict] | None = None,
@@ -1721,6 +1750,7 @@ class SecurityValidator(ValidatorBase):
                         issue,
                         index,
                         uses_report_identities=True,
+                        uses_finding_identity=uses_finding_identity,
                     ),
                 )
                 by_rule.setdefault(issue["id"], []).append(
@@ -1768,6 +1798,7 @@ class SecurityValidator(ValidatorBase):
         deduplicated, _ambiguous_identities = SecurityValidator._deduplicate_skillspector_issues_for_scoring(
             issues,
             uses_report_identities=uses_report_identities,
+            uses_finding_identity=uses_finding_identity,
         )
         if uses_report_identities:
             all_visible_issues = [*issues, *(removed_issues or [])]
@@ -1775,6 +1806,7 @@ class SecurityValidator(ValidatorBase):
                 SecurityValidator._deduplicate_skillspector_issues_for_scoring(
                     all_visible_issues,
                     uses_report_identities=True,
+                    uses_finding_identity=uses_finding_identity,
                 )
             )
             unknown_finding_count = max(
@@ -1809,6 +1841,7 @@ class SecurityValidator(ValidatorBase):
         issues: list[dict],
         *,
         uses_report_identities: bool,
+        uses_finding_identity: bool,
     ) -> tuple[list[dict], set[tuple]]:
         """Mirror scanner dedup using serialized source and match identities."""
 
@@ -1820,6 +1853,7 @@ class SecurityValidator(ValidatorBase):
                 issue,
                 index,
                 uses_report_identities=uses_report_identities,
+                uses_finding_identity=uses_finding_identity,
             )
             if uses_report_identities:
                 modern_identity_counts[
@@ -1844,6 +1878,7 @@ class SecurityValidator(ValidatorBase):
                     issue,
                     index,
                     uses_report_identities=uses_report_identities,
+                    uses_finding_identity=uses_finding_identity,
                 ),
             )
             existing = cross_file_best.get(key)
@@ -2006,6 +2041,11 @@ class SecurityValidator(ValidatorBase):
             and tuple(int(part) for part in raw_version.split("."))
             >= _SKILLSPECTOR_COMPLETENESS_SCHEMA_VERSION
         )
+        uses_finding_identity = (
+            uses_report_identities
+            and tuple(int(part) for part in raw_version.split("."))
+            >= _SKILLSPECTOR_FINDING_IDENTITY_VERSION
+        )
         analysis_completeness = data.get("analysis_completeness")
         findings_after_filtering = (
             analysis_completeness.get("findings_after_filtering")
@@ -2019,6 +2059,7 @@ class SecurityValidator(ValidatorBase):
                 scanned_issues,
                 report_components,
                 uses_report_identities=uses_report_identities,
+                uses_finding_identity=uses_finding_identity,
                 findings_after_filtering=findings_after_filtering,
                 reported_score=reported_score,
                 removed_issues=removed_issues,

--- a/tests/fixtures/skillspector-2.11.1-pe3-no-llm.json
+++ b/tests/fixtures/skillspector-2.11.1-pe3-no-llm.json
@@ -1,0 +1,409 @@
+{
+  "skill": {
+    "name": "classification-probe",
+    "source": "/private/tmp/skillspector-contract-20260908.TCko0h/pe3",
+    "scanned_at": "2026-09-08T04:51:45.070116+00:00"
+  },
+  "risk_assessment": {
+    "score": 39,
+    "severity": "MEDIUM",
+    "recommendation": "CAUTION",
+    "max_issue_severity": "HIGH"
+  },
+  "components": [
+    {
+      "path": "SKILL.md",
+      "type": "markdown",
+      "lines": 8,
+      "executable": false,
+      "size_bytes": 183,
+      "source_url": null,
+      "source_identity": null,
+      "source_digest": null
+    },
+    {
+      "path": "build.sh",
+      "type": "shell",
+      "lines": 3,
+      "executable": true,
+      "size_bytes": 73,
+      "source_url": null,
+      "source_identity": null,
+      "source_digest": null
+    }
+  ],
+  "structured_summaries": [],
+  "issues": [
+    {
+      "id": "PE3",
+      "finding_id": "finding-f793dcf482ed4e6bb6aafb87e01b43c1",
+      "category": "Privilege Escalation",
+      "pattern": "Credential Access",
+      "severity": "HIGH",
+      "confidence": 0.6,
+      "location": {
+        "file": "build.sh",
+        "start_line": 2,
+        "end_line": null
+      },
+      "finding": "/etc/passwd",
+      "explanation": "Code accesses credential files (SSH keys, AWS credentials, etc.). This could indicate credential theft attempts.",
+      "remediation": "Remove references to credential paths. Use environment variables or secrets managers. For docs, use placeholder paths (e.g., /path/to/config). Never load .env or token files in production code paths.",
+      "code_snippet": "#!/bin/sh\ndocker run -v /etc/passwd:/etc/passwd:ro image\ncat /etc/passwd",
+      "intent": null,
+      "tags": [
+        "Privilege Escalation",
+        "contextual-triage",
+        "likely-benign-context"
+      ],
+      "evidence": {},
+      "match_fingerprint": "ac75eea6ed115d0252fb13bbb10e9c4421764d5a7612787edcde6a78569d8f88",
+      "occurrences": [
+        {
+          "file": "build.sh",
+          "start_line": 2,
+          "end_line": null
+        }
+      ]
+    },
+    {
+      "id": "PE3",
+      "finding_id": "finding-4430b1f7f602446bb6fe28c42e610290",
+      "category": "Privilege Escalation",
+      "pattern": "Credential Access",
+      "severity": "HIGH",
+      "confidence": 0.6,
+      "location": {
+        "file": "build.sh",
+        "start_line": 3,
+        "end_line": null
+      },
+      "finding": "/etc/passwd",
+      "explanation": "Code accesses credential files (SSH keys, AWS credentials, etc.). This could indicate credential theft attempts.",
+      "remediation": "Remove references to credential paths. Use environment variables or secrets managers. For docs, use placeholder paths (e.g., /path/to/config). Never load .env or token files in production code paths.",
+      "code_snippet": "#!/bin/sh\ndocker run -v /etc/passwd:/etc/passwd:ro image\ncat /etc/passwd",
+      "intent": null,
+      "tags": [
+        "Privilege Escalation"
+      ],
+      "evidence": {},
+      "match_fingerprint": "ac75eea6ed115d0252fb13bbb10e9c4421764d5a7612787edcde6a78569d8f88",
+      "occurrences": [
+        {
+          "file": "build.sh",
+          "start_line": 3,
+          "end_line": null
+        }
+      ]
+    },
+    {
+      "id": "RP1",
+      "finding_id": "finding-ef48a708c5b14e1ea96a3a124097308e",
+      "category": "MCP Rug Pull",
+      "pattern": null,
+      "severity": "MEDIUM",
+      "confidence": 0.75,
+      "location": {
+        "file": "build.sh",
+        "start_line": 2,
+        "end_line": null
+      },
+      "finding": null,
+      "explanation": "Docker image references without a specific tag (:latest is implicit) or digest (@sha256:...) can be silently replaced by a malicious image.",
+      "remediation": "Pin the image: image:tag or image@sha256:abc123",
+      "code_snippet": null,
+      "intent": null,
+      "tags": [
+        "ASI16"
+      ],
+      "evidence": {},
+      "match_fingerprint": "c40efebb64946fad1ac9260f3622867d7ffb95e17a1c6f66b67bb614d7a5ba02",
+      "occurrences": [
+        {
+          "file": "build.sh",
+          "start_line": 2,
+          "end_line": null
+        }
+      ]
+    }
+  ],
+  "suppressed_count": 0,
+  "suppressed": [],
+  "metadata": {
+    "has_executable_scripts": true,
+    "skillspector_version": "2.11.1",
+    "llm_requested": false,
+    "llm_available": false,
+    "meta_analysis_applied": false,
+    "inference_usage": [],
+    "filtering_mode": "heuristic"
+  },
+  "execution_successful": true,
+  "analysis_completeness": {
+    "total_components": 2,
+    "scanned_components": 2,
+    "coverage_percent": 100.0,
+    "is_complete": true,
+    "status": "complete",
+    "execution_successful": true,
+    "fully_inspected_files": 2,
+    "partially_inspected_files": 0,
+    "entirely_uninspected_files": 0,
+    "ledger_exceptions": [],
+    "scope_exclusions": [],
+    "analyzer_statuses": [
+      {
+        "analyzer_id": "artifact_integrity",
+        "status": "completed",
+        "planned_work": 2,
+        "completed": 2,
+        "partial": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "behavioral_ast",
+        "status": "not_applicable",
+        "planned_work": 0,
+        "completed": 0,
+        "partial": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0,
+        "reason_code": "no_applicable_files",
+        "message": "No files matched this analyzer's applicability contract."
+      },
+      {
+        "analyzer_id": "behavioral_taint_tracking",
+        "status": "not_applicable",
+        "planned_work": 0,
+        "completed": 0,
+        "partial": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0,
+        "reason_code": "no_applicable_files",
+        "message": "No files matched this analyzer's applicability contract."
+      },
+      {
+        "analyzer_id": "bundled_execution_surface",
+        "status": "not_applicable",
+        "planned_work": 0,
+        "completed": 0,
+        "partial": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0,
+        "reason_code": "no_applicable_files",
+        "message": "No files matched this analyzer's applicability contract."
+      },
+      {
+        "analyzer_id": "mcp_least_privilege",
+        "status": "completed",
+        "planned_work": 2,
+        "completed": 2,
+        "partial": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "mcp_rug_pull",
+        "status": "completed",
+        "planned_work": 2,
+        "completed": 2,
+        "partial": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "mcp_tool_poisoning",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "partial": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "meta_analyzer",
+        "status": "disabled",
+        "planned_work": 0,
+        "completed": 0,
+        "partial": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0,
+        "reason_code": "disabled_by_configuration",
+        "message": "Analyzer was disabled by the requested configuration."
+      },
+      {
+        "analyzer_id": "static_patterns_agent_snooping",
+        "status": "completed",
+        "planned_work": 2,
+        "completed": 2,
+        "partial": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_anti_refusal",
+        "status": "completed",
+        "planned_work": 2,
+        "completed": 2,
+        "partial": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_data_exfiltration",
+        "status": "completed",
+        "planned_work": 2,
+        "completed": 2,
+        "partial": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_deserialization",
+        "status": "completed",
+        "planned_work": 2,
+        "completed": 2,
+        "partial": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_excessive_agency",
+        "status": "completed",
+        "planned_work": 2,
+        "completed": 2,
+        "partial": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_harmful_content",
+        "status": "completed",
+        "planned_work": 2,
+        "completed": 2,
+        "partial": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_memory_poisoning",
+        "status": "completed",
+        "planned_work": 2,
+        "completed": 2,
+        "partial": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_output_handling",
+        "status": "completed",
+        "planned_work": 2,
+        "completed": 2,
+        "partial": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_privilege_escalation",
+        "status": "completed",
+        "planned_work": 2,
+        "completed": 2,
+        "partial": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_prompt_injection",
+        "status": "completed",
+        "planned_work": 2,
+        "completed": 2,
+        "partial": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_rogue_agent",
+        "status": "completed",
+        "planned_work": 2,
+        "completed": 2,
+        "partial": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_ssrf",
+        "status": "completed",
+        "planned_work": 2,
+        "completed": 2,
+        "partial": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_supply_chain",
+        "status": "completed",
+        "planned_work": 2,
+        "completed": 2,
+        "partial": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_system_prompt_leakage",
+        "status": "completed",
+        "planned_work": 2,
+        "completed": 2,
+        "partial": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_tool_misuse",
+        "status": "completed",
+        "planned_work": 2,
+        "completed": 2,
+        "partial": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_yara",
+        "status": "completed",
+        "planned_work": 2,
+        "completed": 2,
+        "partial": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      }
+    ],
+    "references": [],
+    "limitations": [],
+    "findings_before_filtering": 3,
+    "findings_after_filtering": 3
+  }
+}

--- a/tests/fixtures/skillspector-2.11.1-safe-no-llm.json
+++ b/tests/fixtures/skillspector-2.11.1-safe-no-llm.json
@@ -1,0 +1,308 @@
+{
+  "skill": {
+    "name": "greeting",
+    "source": "/private/tmp/skillspector-contract-20260908.TCko0h/safe",
+    "scanned_at": "2026-09-08T04:52:16.734816+00:00"
+  },
+  "risk_assessment": {
+    "score": 0,
+    "severity": "LOW",
+    "recommendation": "SAFE",
+    "max_issue_severity": "NONE"
+  },
+  "components": [
+    {
+      "path": "SKILL.md",
+      "type": "markdown",
+      "lines": 8,
+      "executable": false,
+      "size_bytes": 100,
+      "source_url": null,
+      "source_identity": null,
+      "source_digest": null
+    }
+  ],
+  "structured_summaries": [],
+  "issues": [],
+  "suppressed_count": 0,
+  "suppressed": [],
+  "metadata": {
+    "has_executable_scripts": false,
+    "skillspector_version": "2.11.1",
+    "llm_requested": false,
+    "llm_available": false,
+    "meta_analysis_applied": false,
+    "inference_usage": [],
+    "filtering_mode": "heuristic"
+  },
+  "execution_successful": true,
+  "analysis_completeness": {
+    "total_components": 1,
+    "scanned_components": 1,
+    "coverage_percent": 100.0,
+    "is_complete": true,
+    "status": "complete",
+    "execution_successful": true,
+    "fully_inspected_files": 1,
+    "partially_inspected_files": 0,
+    "entirely_uninspected_files": 0,
+    "ledger_exceptions": [],
+    "scope_exclusions": [],
+    "analyzer_statuses": [
+      {
+        "analyzer_id": "artifact_integrity",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "partial": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "behavioral_ast",
+        "status": "not_applicable",
+        "planned_work": 0,
+        "completed": 0,
+        "partial": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0,
+        "reason_code": "no_applicable_files",
+        "message": "No files matched this analyzer's applicability contract."
+      },
+      {
+        "analyzer_id": "behavioral_taint_tracking",
+        "status": "not_applicable",
+        "planned_work": 0,
+        "completed": 0,
+        "partial": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0,
+        "reason_code": "no_applicable_files",
+        "message": "No files matched this analyzer's applicability contract."
+      },
+      {
+        "analyzer_id": "bundled_execution_surface",
+        "status": "not_applicable",
+        "planned_work": 0,
+        "completed": 0,
+        "partial": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0,
+        "reason_code": "no_applicable_files",
+        "message": "No files matched this analyzer's applicability contract."
+      },
+      {
+        "analyzer_id": "mcp_least_privilege",
+        "status": "not_applicable",
+        "planned_work": 0,
+        "completed": 0,
+        "partial": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0,
+        "reason_code": "no_applicable_files",
+        "message": "No files matched this analyzer's applicability contract."
+      },
+      {
+        "analyzer_id": "mcp_rug_pull",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "partial": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "mcp_tool_poisoning",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "partial": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "meta_analyzer",
+        "status": "not_applicable",
+        "planned_work": 0,
+        "completed": 0,
+        "partial": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0,
+        "reason_code": "no_applicable_files",
+        "message": "No files matched this analyzer's applicability contract."
+      },
+      {
+        "analyzer_id": "static_patterns_agent_snooping",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "partial": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_anti_refusal",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "partial": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_data_exfiltration",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "partial": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_deserialization",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "partial": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_excessive_agency",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "partial": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_harmful_content",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "partial": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_memory_poisoning",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "partial": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_output_handling",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "partial": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_privilege_escalation",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "partial": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_prompt_injection",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "partial": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_rogue_agent",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "partial": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_ssrf",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "partial": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_supply_chain",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "partial": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_system_prompt_leakage",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "partial": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_tool_misuse",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "partial": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_yara",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "partial": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      }
+    ],
+    "references": [],
+    "limitations": [],
+    "findings_before_filtering": 0,
+    "findings_after_filtering": 0
+  }
+}

--- a/tests/fixtures/skillspector-2.9.5-safe-no-llm.json
+++ b/tests/fixtures/skillspector-2.9.5-safe-no-llm.json
@@ -1,0 +1,294 @@
+{
+  "skill": {
+    "name": "greeting",
+    "source": "/private/tmp/skillspector-contract-20260908.TCko0h/safe",
+    "scanned_at": "2026-09-08T04:51:49.780419+00:00"
+  },
+  "risk_assessment": {
+    "score": 0,
+    "severity": "LOW",
+    "recommendation": "SAFE"
+  },
+  "components": [
+    {
+      "path": "SKILL.md",
+      "type": "markdown",
+      "lines": 8,
+      "executable": false,
+      "size_bytes": 100
+    }
+  ],
+  "issues": [],
+  "suppressed_count": 0,
+  "suppressed": [],
+  "metadata": {
+    "has_executable_scripts": false,
+    "skillspector_version": "2.9.5",
+    "llm_requested": false,
+    "llm_available": false,
+    "meta_analysis_applied": false,
+    "inference_usage": [],
+    "filtering_mode": "heuristic"
+  },
+  "execution_successful": true,
+  "analysis_completeness": {
+    "total_components": 1,
+    "scanned_components": 1,
+    "coverage_percent": 100.0,
+    "is_complete": false,
+    "execution_successful": true,
+    "fully_inspected_files": 1,
+    "partially_inspected_files": 0,
+    "entirely_uninspected_files": 0,
+    "ledger_exceptions": [],
+    "scope_exclusions": [],
+    "analyzer_statuses": [
+      {
+        "analyzer_id": "behavioral_ast",
+        "status": "not_applicable",
+        "planned_work": 0,
+        "completed": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0,
+        "reason_code": "no_applicable_files",
+        "message": "No files matched this analyzer's applicability contract."
+      },
+      {
+        "analyzer_id": "behavioral_taint_tracking",
+        "status": "not_applicable",
+        "planned_work": 0,
+        "completed": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0,
+        "reason_code": "no_applicable_files",
+        "message": "No files matched this analyzer's applicability contract."
+      },
+      {
+        "analyzer_id": "mcp_least_privilege",
+        "status": "not_applicable",
+        "planned_work": 0,
+        "completed": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0,
+        "reason_code": "no_applicable_files",
+        "message": "No files matched this analyzer's applicability contract."
+      },
+      {
+        "analyzer_id": "mcp_rug_pull",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "mcp_tool_poisoning",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "meta_analyzer",
+        "status": "not_applicable",
+        "planned_work": 0,
+        "completed": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0,
+        "reason_code": "no_applicable_files",
+        "message": "No files matched this analyzer's applicability contract."
+      },
+      {
+        "analyzer_id": "semantic_developer_intent",
+        "status": "disabled",
+        "planned_work": 0,
+        "completed": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0,
+        "reason_code": "disabled_by_configuration",
+        "message": "Analyzer was disabled by the requested configuration."
+      },
+      {
+        "analyzer_id": "semantic_quality_policy",
+        "status": "disabled",
+        "planned_work": 0,
+        "completed": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0,
+        "reason_code": "disabled_by_configuration",
+        "message": "Analyzer was disabled by the requested configuration."
+      },
+      {
+        "analyzer_id": "semantic_security_discovery",
+        "status": "disabled",
+        "planned_work": 0,
+        "completed": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0,
+        "reason_code": "disabled_by_configuration",
+        "message": "Analyzer was disabled by the requested configuration."
+      },
+      {
+        "analyzer_id": "static_patterns_agent_snooping",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_anti_refusal",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_data_exfiltration",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_deserialization",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_excessive_agency",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_harmful_content",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_memory_poisoning",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_output_handling",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_privilege_escalation",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_prompt_injection",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_rogue_agent",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_ssrf",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_supply_chain",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_system_prompt_leakage",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_tool_misuse",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_yara",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      }
+    ],
+    "limitations": [
+      "Analyzer was disabled by the requested configuration.",
+      "Analyzer was disabled by the requested configuration.",
+      "Analyzer was disabled by the requested configuration."
+    ],
+    "findings_before_filtering": 0,
+    "findings_after_filtering": 0
+  }
+}

--- a/tests/fixtures/skillspector-2.9.6-no-llm.json
+++ b/tests/fixtures/skillspector-2.9.6-no-llm.json
@@ -1,0 +1,294 @@
+{
+  "skill": {
+    "name": "safe-greeting",
+    "source": "/private/tmp/skillspector-296.emz8Ld/repo/tests/fixtures/safe_skill",
+    "scanned_at": "2026-09-03T10:55:14.020516+00:00"
+  },
+  "risk_assessment": {
+    "score": 0,
+    "severity": "LOW",
+    "recommendation": "SAFE"
+  },
+  "components": [
+    {
+      "path": "SKILL.md",
+      "type": "markdown",
+      "lines": 30,
+      "executable": false,
+      "size_bytes": 510
+    }
+  ],
+  "issues": [],
+  "suppressed_count": 0,
+  "suppressed": [],
+  "metadata": {
+    "has_executable_scripts": false,
+    "skillspector_version": "2.9.6",
+    "llm_requested": false,
+    "llm_available": false,
+    "meta_analysis_applied": false,
+    "inference_usage": [],
+    "filtering_mode": "heuristic"
+  },
+  "execution_successful": true,
+  "analysis_completeness": {
+    "total_components": 1,
+    "scanned_components": 1,
+    "coverage_percent": 100.0,
+    "is_complete": false,
+    "execution_successful": true,
+    "fully_inspected_files": 1,
+    "partially_inspected_files": 0,
+    "entirely_uninspected_files": 0,
+    "ledger_exceptions": [],
+    "scope_exclusions": [],
+    "analyzer_statuses": [
+      {
+        "analyzer_id": "behavioral_ast",
+        "status": "not_applicable",
+        "planned_work": 0,
+        "completed": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0,
+        "reason_code": "no_applicable_files",
+        "message": "No files matched this analyzer's applicability contract."
+      },
+      {
+        "analyzer_id": "behavioral_taint_tracking",
+        "status": "not_applicable",
+        "planned_work": 0,
+        "completed": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0,
+        "reason_code": "no_applicable_files",
+        "message": "No files matched this analyzer's applicability contract."
+      },
+      {
+        "analyzer_id": "mcp_least_privilege",
+        "status": "not_applicable",
+        "planned_work": 0,
+        "completed": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0,
+        "reason_code": "no_applicable_files",
+        "message": "No files matched this analyzer's applicability contract."
+      },
+      {
+        "analyzer_id": "mcp_rug_pull",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "mcp_tool_poisoning",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "meta_analyzer",
+        "status": "not_applicable",
+        "planned_work": 0,
+        "completed": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0,
+        "reason_code": "no_applicable_files",
+        "message": "No files matched this analyzer's applicability contract."
+      },
+      {
+        "analyzer_id": "semantic_developer_intent",
+        "status": "disabled",
+        "planned_work": 0,
+        "completed": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0,
+        "reason_code": "disabled_by_configuration",
+        "message": "Analyzer was disabled by the requested configuration."
+      },
+      {
+        "analyzer_id": "semantic_quality_policy",
+        "status": "disabled",
+        "planned_work": 0,
+        "completed": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0,
+        "reason_code": "disabled_by_configuration",
+        "message": "Analyzer was disabled by the requested configuration."
+      },
+      {
+        "analyzer_id": "semantic_security_discovery",
+        "status": "disabled",
+        "planned_work": 0,
+        "completed": 0,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0,
+        "reason_code": "disabled_by_configuration",
+        "message": "Analyzer was disabled by the requested configuration."
+      },
+      {
+        "analyzer_id": "static_patterns_agent_snooping",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_anti_refusal",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_data_exfiltration",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_deserialization",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_excessive_agency",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_harmful_content",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_memory_poisoning",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_output_handling",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_privilege_escalation",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_prompt_injection",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_rogue_agent",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_ssrf",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_supply_chain",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_system_prompt_leakage",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_patterns_tool_misuse",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      },
+      {
+        "analyzer_id": "static_yara",
+        "status": "completed",
+        "planned_work": 1,
+        "completed": 1,
+        "skipped": 0,
+        "failed": 0,
+        "unaccounted": 0
+      }
+    ],
+    "limitations": [
+      "Analyzer was disabled by the requested configuration.",
+      "Analyzer was disabled by the requested configuration.",
+      "Analyzer was disabled by the requested configuration."
+    ],
+    "findings_before_filtering": 0,
+    "findings_after_filtering": 0
+  }
+}

--- a/tests/validators/test_artifact_dir_exclusion.py
+++ b/tests/validators/test_artifact_dir_exclusion.py
@@ -110,7 +110,11 @@ def _clean_spector_result():
             {
                 "risk_assessment": {"score": 0, "severity": "LOW", "recommendation": "SAFE"},
                 "issues": [],
-                "metadata": {"llm_requested": False, "llm_available": False},
+                "metadata": {
+                    "skillspector_version": "1.0.0",
+                    "llm_requested": False,
+                    "llm_available": False,
+                },
             }
         ),
         stderr="",
@@ -156,6 +160,48 @@ class TestSkillspectorFilteredCopy:
 
     @patch.object(Tools.skillspector, "_path", "/usr/bin/skillspector")
     @patch.object(Tools.skillspector, "run")
+    def test_staged_scan_preserves_shipped_bytecode_for_sc8(self, mock_run, skill_with_artifacts):
+        bytecode = skill_with_artifacts / "__pycache__" / "payload.pyc"
+        bytecode.parent.mkdir()
+        bytecode.write_bytes(b"shipped bytecode")
+        seen: dict = {}
+
+        def capture(args, **kwargs):
+            scanned = Path(args[args.index("scan") + 1])
+            seen["path"] = scanned
+            seen["has_bytecode"] = (scanned / "__pycache__" / "payload.pyc").is_file()
+            seen["has_generated_results"] = (scanned / "evals" / "results").exists()
+            if not seen["has_bytecode"]:
+                return _clean_spector_result()
+            data = json.loads(_clean_spector_result().stdout)
+            data["risk_assessment"] = {
+                "score": 51,
+                "severity": "HIGH",
+                "recommendation": "DO_NOT_INSTALL",
+            }
+            data["issues"] = [
+                {
+                    "id": "SC8",
+                    "pattern": "Shipped Python bytecode",
+                    "severity": "HIGH",
+                    "confidence": 0.95,
+                    "finding": "Compiled Python artifact",
+                    "location": {"file": "__pycache__/payload.pyc", "start_line": 1},
+                }
+            ]
+            return ToolResult(success=False, stdout=json.dumps(data), stderr="", exit_code=1)
+
+        mock_run.side_effect = capture
+        result = SecurityValidator()._run_skillspector(skill_with_artifacts)
+
+        assert seen["path"] != skill_with_artifacts.resolve()
+        assert seen["has_bytecode"] is True
+        assert seen["has_generated_results"] is False
+        assert result.status == "failed"
+        assert any(finding.check_name.endswith("(SC8)") for finding in result.findings)
+
+    @patch.object(Tools.skillspector, "_path", "/usr/bin/skillspector")
+    @patch.object(Tools.skillspector, "run")
     def test_findings_map_back_to_original_paths(self, mock_run, skill_with_artifacts):
         def report_on_copy(args, **kwargs):
             scanned = args[args.index("scan") + 1]
@@ -173,6 +219,7 @@ class TestSkillspectorFilteredCopy:
                         "finding": "dangerous call",
                     }
                 ],
+                "metadata": {"skillspector_version": "1.0.0"},
             }
             return ToolResult(success=False, stdout=json.dumps(data), stderr="", exit_code=1)
 

--- a/tests/validators/test_scan_incomplete.py
+++ b/tests/validators/test_scan_incomplete.py
@@ -138,7 +138,7 @@ class TestScanIncompleteMarking:
                 {
                     "risk_assessment": {"score": 0, "severity": "LOW", "recommendation": "SAFE"},
                     "issues": [],
-                    "metadata": {},
+                    "metadata": {"skillspector_version": "1.0.0"},
                 }
             ),
             stderr="",

--- a/tests/validators/test_security.py
+++ b/tests/validators/test_security.py
@@ -1339,6 +1339,72 @@ Call us at 555-123-4567 or +1-555-987-6543
         assert not any("recommendation" in error for error in result.errors)
 
     @pytest.mark.parametrize(
+        "completeness_detail",
+        (
+            pytest.param({"coverage_percent": 0}, id="zero-coverage"),
+            pytest.param({"partially_inspected_files": 1}, id="partially-inspected-file"),
+            pytest.param({"entirely_uninspected_files": 1}, id="uninspected-file"),
+            pytest.param({"ledger_exceptions": [{"fatal": True}]}, id="fatal-ledger-exception"),
+            pytest.param({"limitations": ["Analyzer failed."]}, id="limitation"),
+        ),
+    )
+    @patch("skillevaluator.validators.security.Tools")
+    def test_skillspector_complete_summary_rejects_contradictory_details(
+        self,
+        mock_tools,
+        sample_skill_dir: Path,
+        completeness_detail: dict,
+    ) -> None:
+        payload = _skillspector_json_report()
+        payload["analysis_completeness"].update(completeness_detail)
+        mock_tools.skillspector.is_available = True
+        mock_tools.skillspector.run.return_value = ToolResult(
+            success=True,
+            stdout=json.dumps(payload),
+            stderr="",
+            exit_code=0,
+        )
+
+        result = SecurityValidator(use_llm=False).validate_security_only(sample_skill_dir)
+
+        assert result.status == "incomplete"
+        assert any("analysis_completeness" in error for error in result.errors)
+        assert not any(detail.check_name == "skillspector" for detail in result.success_details)
+
+    @pytest.mark.parametrize(
+        "missing_detail",
+        (
+            "coverage_percent",
+            "partially_inspected_files",
+            "entirely_uninspected_files",
+            "ledger_exceptions",
+            "limitations",
+        ),
+    )
+    @patch("skillevaluator.validators.security.Tools")
+    def test_skillspector_completeness_rejects_missing_authoritative_details(
+        self,
+        mock_tools,
+        sample_skill_dir: Path,
+        missing_detail: str,
+    ) -> None:
+        payload = _skillspector_json_report()
+        payload["analysis_completeness"].pop(missing_detail)
+        mock_tools.skillspector.is_available = True
+        mock_tools.skillspector.run.return_value = ToolResult(
+            success=True,
+            stdout=json.dumps(payload),
+            stderr="",
+            exit_code=0,
+        )
+
+        result = SecurityValidator(use_llm=False).validate_security_only(sample_skill_dir)
+
+        assert result.status == "incomplete"
+        assert any("analysis_completeness" in error for error in result.errors)
+        assert not any(detail.check_name == "skillspector" for detail in result.success_details)
+
+    @pytest.mark.parametrize(
         ("payload", "expected_error"),
         (
             pytest.param({}, "missing required 'issues' list", id="empty-object"),
@@ -1609,6 +1675,29 @@ Call us at 555-123-4567 or +1-555-987-6543
         mock_tools.skillspector.run.return_value = ToolResult(
             success=True,
             stdout=json.dumps(_skillspector_json_report()),
+            stderr="",
+            exit_code=0,
+        )
+
+        result = SecurityValidator(use_llm=False).validate_security_only(sample_skill_dir)
+
+        assert result.passed
+        assert not result.errors
+        assert any(detail.check_name == "skillspector" for detail in result.success_details)
+
+    @patch("skillevaluator.validators.security.Tools")
+    def test_skillspector_accepts_legacy_clean_report_without_completeness(
+        self,
+        mock_tools,
+        sample_skill_dir: Path,
+    ) -> None:
+        payload = _skillspector_json_report()
+        payload.pop("execution_successful")
+        payload.pop("analysis_completeness")
+        mock_tools.skillspector.is_available = True
+        mock_tools.skillspector.run.return_value = ToolResult(
+            success=True,
+            stdout=json.dumps(payload),
             stderr="",
             exit_code=0,
         )

--- a/tests/validators/test_security.py
+++ b/tests/validators/test_security.py
@@ -1305,25 +1305,18 @@ Call us at 555-123-4567 or +1-555-987-6543
                 "max_issue_severity": "NONE",
             }
         )
-        payload["metadata"]["skillspector_version"] = "2.10.0"
-        payload["execution_successful"] = True
-        payload["analysis_completeness"] = {
-            "total_components": 4,
-            "scanned_components": 4,
-            "coverage_percent": 100.0,
-            "is_complete": False,
-            "status": "partial",
-            "execution_successful": True,
-            "fully_inspected_files": 4,
-            "partially_inspected_files": 0,
-            "entirely_uninspected_files": 0,
-            "ledger_exceptions": [
-                {"reason_code": "reference_unresolved", "fatal": False} for _ in range(12)
-            ],
-            "scope_exclusions": [],
-            "analyzer_statuses": [],
-            "limitations": [],
-        }
+        payload["analysis_completeness"].update(
+            {
+                "total_components": 4,
+                "scanned_components": 4,
+                "is_complete": False,
+                "status": "partial",
+                "fully_inspected_files": 4,
+                "ledger_exceptions": [
+                    {"reason_code": "reference_unresolved", "fatal": False} for _ in range(12)
+                ],
+            }
+        )
         mock_tools.skillspector.is_available = True
         mock_tools.skillspector.run.return_value = ToolResult(
             success=True,
@@ -1646,31 +1639,18 @@ Call us at 555-123-4567 or +1-555-987-6543
         assert result.status == "incomplete"
         assert any("--no-llm" in error for error in result.errors)
 
+    @pytest.mark.parametrize("legacy", [False, True], ids=["current", "legacy"])
     @patch("skillevaluator.validators.security.Tools")
-    def test_skillspector_accepts_valid_clean_report(self, mock_tools, sample_skill_dir: Path) -> None:
-        mock_tools.skillspector.is_available = True
-        mock_tools.skillspector.run.return_value = ToolResult(
-            success=True,
-            stdout=json.dumps(_skillspector_json_report()),
-            stderr="",
-            exit_code=0,
-        )
-
-        result = SecurityValidator(use_llm=False).validate_security_only(sample_skill_dir)
-
-        assert result.passed
-        assert not result.errors
-        assert any(detail.check_name == "skillspector" for detail in result.success_details)
-
-    @patch("skillevaluator.validators.security.Tools")
-    def test_skillspector_accepts_legacy_clean_report_without_completeness(
+    def test_skillspector_accepts_valid_clean_report(
         self,
         mock_tools,
         sample_skill_dir: Path,
+        legacy: bool,
     ) -> None:
         payload = _skillspector_json_report()
-        payload.pop("execution_successful")
-        payload.pop("analysis_completeness")
+        if legacy:
+            payload.pop("execution_successful")
+            payload.pop("analysis_completeness")
         mock_tools.skillspector.is_available = True
         mock_tools.skillspector.run.return_value = ToolResult(
             success=True,

--- a/tests/validators/test_security.py
+++ b/tests/validators/test_security.py
@@ -1339,57 +1339,34 @@ Call us at 555-123-4567 or +1-555-987-6543
         assert not any("recommendation" in error for error in result.errors)
 
     @pytest.mark.parametrize(
-        "completeness_detail",
+        ("completeness_detail", "missing_detail"),
         (
-            pytest.param({"coverage_percent": 0}, id="zero-coverage"),
-            pytest.param({"partially_inspected_files": 1}, id="partially-inspected-file"),
-            pytest.param({"entirely_uninspected_files": 1}, id="uninspected-file"),
-            pytest.param({"ledger_exceptions": [{"fatal": True}]}, id="fatal-ledger-exception"),
-            pytest.param({"limitations": ["Analyzer failed."]}, id="limitation"),
+            pytest.param({"coverage_percent": 0}, None, id="zero-coverage"),
+            pytest.param({"partially_inspected_files": 1}, None, id="partially-inspected-file"),
+            pytest.param({"entirely_uninspected_files": 1}, None, id="uninspected-file"),
+            pytest.param({"ledger_exceptions": [{"fatal": True}]}, None, id="fatal-ledger-exception"),
+            pytest.param({"limitations": ["Analyzer failed."]}, None, id="limitation"),
+            pytest.param(None, "coverage_percent", id="coverage_percent"),
+            pytest.param(None, "partially_inspected_files", id="partially_inspected_files"),
+            pytest.param(None, "entirely_uninspected_files", id="entirely_uninspected_files"),
+            pytest.param(None, "ledger_exceptions", id="ledger_exceptions"),
+            pytest.param(None, "limitations", id="limitations"),
         ),
     )
     @patch("skillevaluator.validators.security.Tools")
-    def test_skillspector_complete_summary_rejects_contradictory_details(
+    def test_skillspector_complete_summary_rejects_invalid_details(
         self,
         mock_tools,
         sample_skill_dir: Path,
-        completeness_detail: dict,
+        completeness_detail: dict | None,
+        missing_detail: str | None,
     ) -> None:
         payload = _skillspector_json_report()
-        payload["analysis_completeness"].update(completeness_detail)
-        mock_tools.skillspector.is_available = True
-        mock_tools.skillspector.run.return_value = ToolResult(
-            success=True,
-            stdout=json.dumps(payload),
-            stderr="",
-            exit_code=0,
-        )
-
-        result = SecurityValidator(use_llm=False).validate_security_only(sample_skill_dir)
-
-        assert result.status == "incomplete"
-        assert any("analysis_completeness" in error for error in result.errors)
-        assert not any(detail.check_name == "skillspector" for detail in result.success_details)
-
-    @pytest.mark.parametrize(
-        "missing_detail",
-        (
-            "coverage_percent",
-            "partially_inspected_files",
-            "entirely_uninspected_files",
-            "ledger_exceptions",
-            "limitations",
-        ),
-    )
-    @patch("skillevaluator.validators.security.Tools")
-    def test_skillspector_completeness_rejects_missing_authoritative_details(
-        self,
-        mock_tools,
-        sample_skill_dir: Path,
-        missing_detail: str,
-    ) -> None:
-        payload = _skillspector_json_report()
-        payload["analysis_completeness"].pop(missing_detail)
+        if missing_detail is None:
+            assert completeness_detail is not None
+            payload["analysis_completeness"].update(completeness_detail)
+        else:
+            payload["analysis_completeness"].pop(missing_detail)
         mock_tools.skillspector.is_available = True
         mock_tools.skillspector.run.return_value = ToolResult(
             success=True,

--- a/tests/validators/test_security.py
+++ b/tests/validators/test_security.py
@@ -18,6 +18,46 @@ from skillevaluator.validators.base import Finding, Severity, ValidationResult
 from skillevaluator.validators.schema import SchemaValidator
 from skillevaluator.validators.security import SecurityValidator, _skillspector_child_env
 
+_SKILLSPECTOR_2_9_6_NO_LLM_REPORT = (
+    Path(__file__).parents[1] / "fixtures" / "skillspector-2.9.6-no-llm.json"
+)
+_SKILLSPECTOR_2_10_REQUIRED_ANALYZERS = (
+    "artifact_integrity",
+    "behavioral_ast",
+    "behavioral_taint_tracking",
+    "mcp_least_privilege",
+    "mcp_rug_pull",
+    "mcp_tool_poisoning",
+    "meta_analyzer",
+    "static_patterns_agent_snooping",
+    "static_patterns_anti_refusal",
+    "static_patterns_data_exfiltration",
+    "static_patterns_deserialization",
+    "static_patterns_excessive_agency",
+    "static_patterns_harmful_content",
+    "static_patterns_memory_poisoning",
+    "static_patterns_output_handling",
+    "static_patterns_privilege_escalation",
+    "static_patterns_prompt_injection",
+    "static_patterns_rogue_agent",
+    "static_patterns_ssrf",
+    "static_patterns_supply_chain",
+    "static_patterns_system_prompt_leakage",
+    "static_patterns_tool_misuse",
+    "static_yara",
+)
+_SKILLSPECTOR_SEMANTIC_ANALYZERS = (
+    "semantic_developer_intent",
+    "semantic_quality_policy",
+    "semantic_security_discovery",
+)
+_SKILLSPECTOR_UNIVERSAL_ANALYZERS = {
+    analyzer_id
+    for analyzer_id in _SKILLSPECTOR_2_10_REQUIRED_ANALYZERS
+    if analyzer_id in {"artifact_integrity", "static_yara"}
+    or analyzer_id.startswith("static_patterns_")
+}
+
 
 def _api_key_assignment(*fragments: str, separator: str = " = ") -> str:
     """Build a representative hardcoded-key assignment without embedding it in source."""
@@ -53,7 +93,26 @@ def _skillspector_json_report(
     llm_available: bool = False,
 ) -> dict:
     """Return the pinned SkillSpector JSON report shape used by contract tests."""
-    normalized_issues = [{"confidence": 1.0, **issue} for issue in (issues or [])]
+    normalized_issues = [
+        {"confidence": 1.0, "finding_id": f"finding-{index}", **issue}
+        for index, issue in enumerate(issues or [])
+    ]
+    components_by_key: dict[tuple, dict] = {}
+    for issue in normalized_issues:
+        location = issue.get("location")
+        path = location.get("file") if isinstance(location, dict) else None
+        path = path if isinstance(path, str) and path else "SKILL.md"
+        source = {
+            key: issue[key]
+            for key in ("source_identity", "source_url", "source_digest")
+            if isinstance(issue.get(key), str) and issue[key]
+        }
+        source_key = next(((key, source[key]) for key in source), ("", ""))
+        components_by_key.setdefault((source_key, path), {"path": path, "executable": False, **source})
+    components = list(components_by_key.values())
+    analyzer_ids = _SKILLSPECTOR_2_10_REQUIRED_ANALYZERS + (
+        _SKILLSPECTOR_SEMANTIC_ANALYZERS if llm_requested else ()
+    )
     return {
         "skill": {
             "name": "test-skill",
@@ -65,25 +124,39 @@ def _skillspector_json_report(
             "severity": "LOW" if not issues else "HIGH",
             "recommendation": "SAFE" if not issues else "DO_NOT_INSTALL",
         },
-        "components": [],
+        "components": components,
         "issues": normalized_issues,
         "suppressed_count": 0,
         "suppressed": [],
         "execution_successful": True,
         "analysis_completeness": {
-            "total_components": 0,
-            "scanned_components": 0,
+            "total_components": len(components),
+            "scanned_components": len(components),
             "coverage_percent": 100.0,
             "is_complete": True,
             "status": "complete",
             "execution_successful": True,
-            "fully_inspected_files": 0,
+            "fully_inspected_files": len(components),
             "partially_inspected_files": 0,
             "entirely_uninspected_files": 0,
             "ledger_exceptions": [],
             "scope_exclusions": [],
-            "analyzer_statuses": [],
+            "analyzer_statuses": [
+                {
+                    "analyzer_id": analyzer_id,
+                    "status": "completed",
+                    "planned_work": len(components) if analyzer_id in _SKILLSPECTOR_UNIVERSAL_ANALYZERS else 0,
+                    "completed": len(components) if analyzer_id in _SKILLSPECTOR_UNIVERSAL_ANALYZERS else 0,
+                    "partial": 0,
+                    "skipped": 0,
+                    "failed": 0,
+                    "unaccounted": 0,
+                }
+                for analyzer_id in analyzer_ids
+            ],
             "limitations": [],
+            "findings_before_filtering": len(normalized_issues),
+            "findings_after_filtering": len(normalized_issues),
         },
         "metadata": {
             "has_executable_scripts": False,
@@ -94,6 +167,43 @@ def _skillspector_json_report(
             "filtering_mode": "heuristic",
         },
     }
+
+
+def _validate_skillspector_payload(
+    mock_tools,
+    sample_skill_dir: Path,
+    payload: dict,
+    *,
+    exit_code: int = 0,
+) -> ValidationResult:
+    """Run one deterministic SkillSpector payload through the public validation seam."""
+    mock_tools.skillspector.is_available = True
+    mock_tools.skillspector.run.return_value = ToolResult(
+        success=True,
+        stdout=json.dumps(payload),
+        stderr="",
+        exit_code=exit_code,
+    )
+    return SecurityValidator(use_llm=False).validate_security_only(sample_skill_dir)
+
+
+def _set_universal_analyzer_work(payload: dict) -> None:
+    """Keep synthetic complete reports aligned with producer work accounting."""
+    component_count = len(payload["components"])
+    for status in payload["analysis_completeness"]["analyzer_statuses"]:
+        if status["analyzer_id"] in _SKILLSPECTOR_UNIVERSAL_ANALYZERS:
+            status.update(
+                {
+                    "status": "completed",
+                    "planned_work": component_count,
+                    "completed": component_count,
+                    "skipped": 0,
+                    "failed": 0,
+                    "unaccounted": 0,
+                }
+            )
+            if "partial" in status:
+                status["partial"] = 0
 
 
 def _user_facing_reports(result: ValidationResult) -> list[str]:
@@ -1204,6 +1314,42 @@ Call us at 555-123-4567 or +1-555-987-6543
         assert result.incomplete_scans == ["skillspector-llm"]
         assert any(finding.check_name == "Static instruction override (PI-STATIC)" for finding in result.findings)
 
+    @pytest.mark.parametrize("missing_analyzer", _SKILLSPECTOR_SEMANTIC_ANALYZERS)
+    @patch("skillevaluator.validators.security.Tools")
+    def test_llm_enrichment_requires_semantic_analyzer_evidence(
+        self,
+        mock_tools,
+        sample_skill_dir: Path,
+        missing_analyzer: str,
+    ) -> None:
+        enrichment_report = _skillspector_json_report(llm_requested=True, llm_available=True)
+        enrichment_report["analysis_completeness"]["analyzer_statuses"] = [
+            status
+            for status in enrichment_report["analysis_completeness"]["analyzer_statuses"]
+            if status["analyzer_id"] != missing_analyzer
+        ]
+        mock_tools.skillspector.is_available = True
+        mock_tools.skillspector.run.side_effect = [
+            ToolResult(
+                success=True,
+                stdout=json.dumps(_skillspector_json_report()),
+                stderr="",
+                exit_code=0,
+            ),
+            ToolResult(
+                success=True,
+                stdout=json.dumps(enrichment_report),
+                stderr="",
+                exit_code=0,
+            ),
+        ]
+
+        result = SecurityValidator(use_llm=True).validate_security_only(sample_skill_dir)
+
+        assert result.status == "incomplete"
+        assert result.incomplete_scans == ["skillspector-llm"]
+        assert any("missing required analyzer evidence" in error for error in result.errors)
+
     @patch("skillevaluator.validators.security.Tools")
     def test_successful_llm_enrichment_cannot_erase_deterministic_findings(
         self,
@@ -1260,6 +1406,7 @@ Call us at 555-123-4567 or +1-555-987-6543
                             "location": {"file": "SKILL.md", "start_line": 8},
                         }
                     ],
+                    "metadata": {"skillspector_version": "1.0.0"},
                 }
             ),
             stderr="",
@@ -1279,6 +1426,9 @@ Call us at 555-123-4567 or +1-555-987-6543
         payload = _skillspector_json_report()
         payload["suppressed_count"] = 2
         payload["suppressed"] = [{"id": "one"}, {"id": "two"}]
+        payload["analysis_completeness"].update(
+            {"findings_before_filtering": 2, "findings_after_filtering": 2}
+        )
         mock_tools.skillspector.run.return_value = ToolResult(
             success=True,
             stdout=json.dumps(payload),
@@ -1317,33 +1467,380 @@ Call us at 555-123-4567 or +1-555-987-6543
                 ],
             }
         )
-        mock_tools.skillspector.is_available = True
-        mock_tools.skillspector.run.return_value = ToolResult(
-            success=True,
-            stdout=json.dumps(payload),
-            stderr="",
-            exit_code=0,
-        )
-
-        result = SecurityValidator(use_llm=False).validate_security_only(sample_skill_dir)
+        result = _validate_skillspector_payload(mock_tools, sample_skill_dir, payload)
 
         assert result.status == "incomplete"
         assert any("analysis_completeness" in error and "partial" in error for error in result.errors)
         assert not any("recommendation" in error for error in result.errors)
 
+    @patch("skillevaluator.validators.security.Tools")
+    def test_skillspector_partial_scan_preserves_valid_high_findings(
+        self,
+        mock_tools,
+        sample_skill_dir: Path,
+    ) -> None:
+        issue = {
+            "id": "PI-1",
+            "category": "Prompt Injection",
+            "pattern": "Instruction override",
+            "severity": "HIGH",
+            "finding": "Ignore prior instructions",
+            "location": {"file": "SKILL.md", "start_line": 8},
+        }
+        payload = _skillspector_json_report([issue])
+        payload["analysis_completeness"].update(
+            {
+                "is_complete": False,
+                "status": "complete",
+                "limitations": ["Transitive traversal truncated: target budget 1 reached"],
+            }
+        )
+        result = _validate_skillspector_payload(
+            mock_tools,
+            sample_skill_dir,
+            payload,
+            exit_code=1,
+        )
+
+        assert result.status == "incomplete"
+        assert any(finding.check_name == "Instruction override (PI-1)" for finding in result.findings)
+        assert not any(detail.check_name == "skillspector" for detail in result.success_details)
+
+    @pytest.mark.parametrize("analyzer_state", ["degraded", "unavailable"])
+    @patch("skillevaluator.validators.security.Tools")
+    def test_skillspector_analyzer_partial_scan_preserves_valid_high_findings(
+        self,
+        mock_tools,
+        sample_skill_dir: Path,
+        analyzer_state: str,
+    ) -> None:
+        issue = {
+            "id": "PI-1",
+            "category": "Prompt Injection",
+            "pattern": "Instruction override",
+            "severity": "HIGH",
+            "finding": "Ignore prior instructions",
+            "location": {"file": "SKILL.md", "start_line": 8},
+        }
+        limitations = [
+            "Zeta analyzer skipped one target.",
+            "Alpha analyzer skipped one target.",
+            "Transitive traversal truncated: target budget 1 reached",
+        ]
+        payload = _skillspector_json_report([issue])
+        analyzer_status = next(
+            status
+            for status in payload["analysis_completeness"]["analyzer_statuses"]
+            if status["analyzer_id"] == "static_patterns_prompt_injection"
+        )
+        analyzer_status.update(
+            {
+                "status": analyzer_state,
+                "message": limitations[1],
+                "planned_work": 1 if analyzer_state == "degraded" else 0,
+                "completed": 0,
+                "partial": 1 if analyzer_state == "degraded" else 0,
+            }
+        )
+        payload["analysis_completeness"]["analyzer_statuses"].append(
+            {**analyzer_status, "message": limitations[0]}
+        )
+        payload["analysis_completeness"].update(
+            {
+                "is_complete": False,
+                "status": "partial",
+                "limitations": limitations,
+            }
+        )
+        result = _validate_skillspector_payload(
+            mock_tools,
+            sample_skill_dir,
+            payload,
+            exit_code=1,
+        )
+
+        assert result.status == "incomplete"
+        assert any(finding.check_name == "Instruction override (PI-1)" for finding in result.findings)
+        assert not any(detail.check_name == "skillspector" for detail in result.success_details)
+
+    @patch("skillevaluator.validators.security.Tools")
+    def test_skillspector_partial_low_scan_requires_caution_recommendation(
+        self,
+        mock_tools,
+        sample_skill_dir: Path,
+    ) -> None:
+        payload = _skillspector_json_report()
+        payload["analysis_completeness"].update(
+            {
+                "is_complete": False,
+                "status": "partial",
+                "ledger_exceptions": [{"reason_code": "reference_unresolved", "fatal": False}],
+            }
+        )
+        result = _validate_skillspector_payload(mock_tools, sample_skill_dir, payload)
+
+        assert result.status == "incomplete"
+        assert any("risk_assessment.recommendation" in error for error in result.errors)
+
+    @pytest.mark.parametrize(
+        ("failure_mode", "expected_error"),
+        (
+            pytest.param("top-level", "execution_successful=false", id="top-level-execution-failed"),
+            pytest.param("nested", "execution_successful fields contradict", id="nested-execution-failed"),
+            pytest.param("status", "reports failed analysis", id="nested-status-failed"),
+        ),
+    )
+    @patch("skillevaluator.validators.security.Tools")
+    def test_skillspector_failed_report_does_not_process_findings(
+        self,
+        mock_tools,
+        sample_skill_dir: Path,
+        failure_mode: str,
+        expected_error: str,
+    ) -> None:
+        issue = {
+            "id": "PI-1",
+            "category": "Prompt Injection",
+            "pattern": "Instruction override",
+            "severity": "HIGH",
+            "finding": "Ignore prior instructions",
+            "location": {"file": "SKILL.md", "start_line": 8},
+        }
+        payload = _skillspector_json_report([issue])
+        payload["analysis_completeness"].update(
+            {
+                "is_complete": False,
+                "status": "failed",
+                "ledger_exceptions": [{"reason_code": "scan_failed", "fatal": True}],
+            }
+        )
+        if failure_mode == "top-level":
+            payload["execution_successful"] = False
+            payload["analysis_completeness"]["execution_successful"] = False
+        elif failure_mode == "nested":
+            payload["analysis_completeness"]["execution_successful"] = False
+        result = _validate_skillspector_payload(
+            mock_tools,
+            sample_skill_dir,
+            payload,
+            exit_code=1,
+        )
+
+        assert result.status == "incomplete"
+        assert not result.findings
+        assert any(expected_error in error for error in result.errors)
+
+    @pytest.mark.parametrize(
+        "completeness_detail",
+        (
+            pytest.param({"scanned_components": 1}, id="scanned-does-not-equal-fully-inspected"),
+            pytest.param({"entirely_uninspected_files": 1}, id="partitions-do-not-equal-total"),
+            pytest.param({"coverage_percent": 50}, id="coverage-does-not-match-fully-inspected"),
+        ),
+    )
+    @patch("skillevaluator.validators.security.Tools")
+    def test_skillspector_partial_scan_rejects_inconsistent_completeness_counters(
+        self,
+        mock_tools,
+        sample_skill_dir: Path,
+        completeness_detail: dict,
+    ) -> None:
+        payload = _skillspector_json_report()
+        payload["risk_assessment"]["recommendation"] = "CAUTION"
+        payload["analysis_completeness"].update(
+            {
+                "total_components": 1,
+                "scanned_components": 0,
+                "coverage_percent": 0,
+                "is_complete": False,
+                "status": "partial",
+                "fully_inspected_files": 0,
+                "partially_inspected_files": 1,
+                **completeness_detail,
+            }
+        )
+        result = _validate_skillspector_payload(mock_tools, sample_skill_dir, payload)
+
+        assert result.status == "incomplete"
+        assert any("inconsistent counters or coverage" in error for error in result.errors)
+        assert not any(detail.check_name == "skillspector" for detail in result.success_details)
+
+    @pytest.mark.parametrize(
+        ("completeness_detail", "expected_error"),
+        (
+            pytest.param({}, "contradict partial analysis", id="partial-without-incomplete-detail"),
+            pytest.param(
+                {"ledger_exceptions": [{"fatal": True}]},
+                "fatal exception despite successful execution",
+                id="fatal-ledger-exception",
+            ),
+            pytest.param({"limitations": [1]}, "invalid detail lists", id="non-string-limitation"),
+        ),
+    )
+    @patch("skillevaluator.validators.security.Tools")
+    def test_skillspector_partial_scan_rejects_contradictory_details(
+        self,
+        mock_tools,
+        sample_skill_dir: Path,
+        completeness_detail: dict,
+        expected_error: str,
+    ) -> None:
+        payload = _skillspector_json_report()
+        payload["risk_assessment"]["recommendation"] = "CAUTION"
+        payload["analysis_completeness"].update(
+            {
+                "is_complete": False,
+                "status": "partial",
+                **completeness_detail,
+            }
+        )
+        result = _validate_skillspector_payload(mock_tools, sample_skill_dir, payload)
+
+        assert result.status == "incomplete"
+        assert any(expected_error in error for error in result.errors)
+        assert not any(detail.check_name == "skillspector" for detail in result.success_details)
+
+    @patch("skillevaluator.validators.security.Tools")
+    def test_skillspector_invalid_partial_scan_does_not_process_findings(
+        self,
+        mock_tools,
+        sample_skill_dir: Path,
+    ) -> None:
+        issue = {
+            "id": "PI-1",
+            "category": "Prompt Injection",
+            "pattern": "Instruction override",
+            "severity": "HIGH",
+            "finding": "Ignore prior instructions",
+            "location": {"file": "SKILL.md", "start_line": 8},
+        }
+        payload = _skillspector_json_report([issue])
+        payload["analysis_completeness"].update(
+            {
+                "total_components": 1,
+                "scanned_components": 0,
+                "coverage_percent": 0,
+                "is_complete": False,
+                "status": "partial",
+                "fully_inspected_files": 0,
+                "partially_inspected_files": 1,
+                "analyzer_statuses": [
+                    {
+                        "analyzer_id": "static_patterns",
+                        "status": "completed",
+                        "planned_work": 1,
+                        "completed": 0,
+                        "partial": 0,
+                        "skipped": 0,
+                        "failed": 1,
+                        "unaccounted": 0,
+                    }
+                ],
+            }
+        )
+        result = _validate_skillspector_payload(
+            mock_tools,
+            sample_skill_dir,
+            payload,
+            exit_code=1,
+        )
+
+        assert result.status == "incomplete"
+        assert not result.findings
+        assert any("status that contradicts its work accounting" in error for error in result.errors)
+
     @pytest.mark.parametrize(
         ("completeness_detail", "missing_detail"),
         (
             pytest.param({"coverage_percent": 0}, None, id="zero-coverage"),
+            pytest.param({"coverage_percent": 10**399}, None, id="unbounded-integer-coverage"),
             pytest.param({"partially_inspected_files": 1}, None, id="partially-inspected-file"),
             pytest.param({"entirely_uninspected_files": 1}, None, id="uninspected-file"),
             pytest.param({"ledger_exceptions": [{"fatal": True}]}, None, id="fatal-ledger-exception"),
             pytest.param({"limitations": ["Analyzer failed."]}, None, id="limitation"),
+            pytest.param({"total_components": -1}, None, id="negative-total-components"),
+            pytest.param({"scanned_components": True}, None, id="boolean-scanned-components"),
+            pytest.param({"fully_inspected_files": "0"}, None, id="string-fully-inspected-files"),
+            pytest.param(
+                {
+                    "total_components": 1,
+                    "scanned_components": 10**399,
+                    "fully_inspected_files": 10**399,
+                },
+                None,
+                id="unbounded-mismatched-component-counts",
+            ),
+            pytest.param(
+                {"total_components": 2, "scanned_components": 1, "fully_inspected_files": 1},
+                None,
+                id="component-count-mismatch",
+            ),
+            pytest.param({"fully_inspected_files": 1}, None, id="fully-inspected-count-mismatch"),
+            pytest.param(
+                {
+                    "analyzer_statuses": [
+                        {
+                            "analyzer_id": "static_patterns",
+                            "status": "failed",
+                            "planned_work": 0,
+                            "completed": 0,
+                            "partial": 0,
+                            "skipped": 0,
+                            "failed": 0,
+                            "unaccounted": 0,
+                        }
+                    ]
+                },
+                None,
+                id="failed-analyzer-status",
+            ),
+            pytest.param(
+                {
+                    "analyzer_statuses": [
+                        {
+                            "analyzer_id": "static_patterns",
+                            "status": "completed",
+                            "planned_work": 1,
+                            "completed": 0,
+                            "partial": 0,
+                            "skipped": 0,
+                            "failed": 1,
+                            "unaccounted": 0,
+                        }
+                    ]
+                },
+                None,
+                id="completed-analyzer-with-failed-work",
+            ),
+            pytest.param(
+                {
+                    "analyzer_statuses": [
+                        {
+                            "analyzer_id": "static_patterns",
+                            "status": "completed",
+                            "planned_work": 0,
+                            "completed": 0,
+                            "partial": 0,
+                            "skipped": 0,
+                            "failed": 0,
+                            "unaccounted": 0,
+                            "message": 7,
+                        }
+                    ]
+                },
+                None,
+                id="non-string-analyzer-message",
+            ),
+            pytest.param({"analyzer_statuses": []}, None, id="empty-analyzer-statuses"),
             pytest.param(None, "coverage_percent", id="coverage_percent"),
+            pytest.param(None, "total_components", id="total_components"),
+            pytest.param(None, "scanned_components", id="scanned_components"),
+            pytest.param(None, "fully_inspected_files", id="fully_inspected_files"),
             pytest.param(None, "partially_inspected_files", id="partially_inspected_files"),
             pytest.param(None, "entirely_uninspected_files", id="entirely_uninspected_files"),
             pytest.param(None, "ledger_exceptions", id="ledger_exceptions"),
             pytest.param(None, "limitations", id="limitations"),
+            pytest.param(None, "analyzer_statuses", id="analyzer_statuses"),
         ),
     )
     @patch("skillevaluator.validators.security.Tools")
@@ -1360,15 +1857,7 @@ Call us at 555-123-4567 or +1-555-987-6543
             payload["analysis_completeness"].update(completeness_detail)
         else:
             payload["analysis_completeness"].pop(missing_detail)
-        mock_tools.skillspector.is_available = True
-        mock_tools.skillspector.run.return_value = ToolResult(
-            success=True,
-            stdout=json.dumps(payload),
-            stderr="",
-            exit_code=0,
-        )
-
-        result = SecurityValidator(use_llm=False).validate_security_only(sample_skill_dir)
+        result = _validate_skillspector_payload(mock_tools, sample_skill_dir, payload)
 
         assert result.status == "incomplete"
         assert any("analysis_completeness" in error for error in result.errors)
@@ -1402,9 +1891,10 @@ Call us at 555-123-4567 or +1-555-987-6543
             ),
             pytest.param(
                 {
-                    "risk_assessment": {"score": 0, "severity": "LOW"},
+                    "risk_assessment": {"score": 0, "severity": "LOW", "recommendation": "SAFE"},
                     "issues": [],
                     "suppressed_count": "unknown",
+                    "metadata": {"skillspector_version": "1.0.0"},
                 },
                 "suppressed_count",
                 id="invalid-suppressed-count",
@@ -1425,13 +1915,16 @@ Call us at 555-123-4567 or +1-555-987-6543
                 id="unbounded-integer-risk-score",
             ),
             pytest.param(
-                {"risk_assessment": {"score": 0, "severity": "LOW"}, "issues": [{}]},
+                {
+                    "risk_assessment": {"score": 0, "severity": "LOW", "recommendation": "SAFE"},
+                    "issues": [{}],
+                },
                 "issues[0].id",
                 id="empty-issue",
             ),
             pytest.param(
                 {
-                    "risk_assessment": {"score": 80, "severity": "HIGH"},
+                    "risk_assessment": {"score": 80, "severity": "HIGH", "recommendation": "DO_NOT_INSTALL"},
                     "issues": [
                         {
                             "id": "P1",
@@ -1447,7 +1940,7 @@ Call us at 555-123-4567 or +1-555-987-6543
             ),
             pytest.param(
                 {
-                    "risk_assessment": {"score": 80, "severity": "HIGH"},
+                    "risk_assessment": {"score": 80, "severity": "HIGH", "recommendation": "DO_NOT_INSTALL"},
                     "issues": [
                         {
                             "id": "P1",
@@ -1462,7 +1955,7 @@ Call us at 555-123-4567 or +1-555-987-6543
             ),
             pytest.param(
                 {
-                    "risk_assessment": {"score": 0, "severity": "LOW"},
+                    "risk_assessment": {"score": 0, "severity": "LOW", "recommendation": "SAFE"},
                     "issues": [
                         {
                             "id": "P1",
@@ -1477,9 +1970,10 @@ Call us at 555-123-4567 or +1-555-987-6543
             ),
             pytest.param(
                 {
-                    "risk_assessment": {"score": 0, "severity": "LOW"},
+                    "risk_assessment": {"score": 0, "severity": "LOW", "recommendation": "SAFE"},
                     "issues": [],
                     "suppressed_count": 1,
+                    "metadata": {"skillspector_version": "1.0.0"},
                 },
                 "suppressed_count",
                 id="suppression-count-without-list",
@@ -1495,7 +1989,7 @@ Call us at 555-123-4567 or +1-555-987-6543
             ),
             pytest.param(
                 {
-                    "risk_assessment": {"score": 0, "severity": "LOW"},
+                    "risk_assessment": {"score": 0, "severity": "LOW", "recommendation": "SAFE"},
                     "issues": [],
                     "metadata": {"has_executable_scripts": "false"},
                 },
@@ -1508,7 +2002,14 @@ Call us at 555-123-4567 or +1-555-987-6543
                 id="unknown-risk-severity",
             ),
             pytest.param(
-                {"risk_assessment": {"score": 100, "severity": "CRITICAL"}, "issues": []},
+                {
+                    "risk_assessment": {
+                        "score": 100,
+                        "severity": "CRITICAL",
+                        "recommendation": "DO_NOT_INSTALL",
+                    },
+                    "issues": [],
+                },
                 "nonzero risk score without any issues",
                 id="risk-without-issues",
             ),
@@ -1519,6 +2020,11 @@ Call us at 555-123-4567 or +1-555-987-6543
                 },
                 "risk_assessment.recommendation",
                 id="complete-low-caution-recommendation",
+            ),
+            pytest.param(
+                {"risk_assessment": {"score": 0, "severity": "LOW"}, "issues": []},
+                "risk_assessment.recommendation",
+                id="missing-recommendation",
             ),
             pytest.param(
                 {
@@ -1545,7 +2051,7 @@ Call us at 555-123-4567 or +1-555-987-6543
             ),
             pytest.param(
                 {
-                    "risk_assessment": {"score": 80, "severity": "HIGH"},
+                    "risk_assessment": {"score": 80, "severity": "HIGH", "recommendation": "DO_NOT_INSTALL"},
                     "issues": [{"id": "P1", "severity": " HIGH", "finding": "unsafe"}],
                 },
                 "issues[0].severity",
@@ -1581,6 +2087,7 @@ Call us at 555-123-4567 or +1-555-987-6543
                         }
                         for index in range(6)
                     ],
+                    "metadata": {"skillspector_version": "1.0.0"},
                 },
                 "understates the reported issues",
                 id="understated-aggregate-risk",
@@ -1639,18 +2146,13 @@ Call us at 555-123-4567 or +1-555-987-6543
         assert result.status == "incomplete"
         assert any("--no-llm" in error for error in result.errors)
 
-    @pytest.mark.parametrize("legacy", [False, True], ids=["current", "legacy"])
     @patch("skillevaluator.validators.security.Tools")
     def test_skillspector_accepts_valid_clean_report(
         self,
         mock_tools,
         sample_skill_dir: Path,
-        legacy: bool,
     ) -> None:
         payload = _skillspector_json_report()
-        if legacy:
-            payload.pop("execution_successful")
-            payload.pop("analysis_completeness")
         mock_tools.skillspector.is_available = True
         mock_tools.skillspector.run.return_value = ToolResult(
             success=True,
@@ -1664,6 +2166,345 @@ Call us at 555-123-4567 or +1-555-987-6543
         assert result.passed
         assert not result.errors
         assert any(detail.check_name == "skillspector" for detail in result.success_details)
+
+    @patch("skillevaluator.validators.security.Tools")
+    def test_skillspector_accepts_captured_2_9_6_no_llm_report(
+        self,
+        mock_tools,
+        sample_skill_dir: Path,
+    ) -> None:
+        mock_tools.skillspector.is_available = True
+        mock_tools.skillspector.run.return_value = ToolResult(
+            success=True,
+            stdout=_SKILLSPECTOR_2_9_6_NO_LLM_REPORT.read_text(encoding="utf-8"),
+            stderr="",
+            exit_code=0,
+        )
+
+        result = SecurityValidator(use_llm=False).validate_security_only(sample_skill_dir)
+
+        assert result.passed
+        assert not result.errors
+        assert any(detail.check_name == "skillspector" for detail in result.success_details)
+
+    @pytest.mark.parametrize("skillspector_version", ["2.9.6", "2.10.0"])
+    @patch("skillevaluator.validators.security.Tools")
+    def test_skillspector_rejects_missing_required_analyzer_evidence(
+        self,
+        mock_tools,
+        sample_skill_dir: Path,
+        skillspector_version: str,
+    ) -> None:
+        payload = (
+            json.loads(_SKILLSPECTOR_2_9_6_NO_LLM_REPORT.read_text(encoding="utf-8"))
+            if skillspector_version == "2.9.6"
+            else _skillspector_json_report()
+        )
+        payload["analysis_completeness"]["analyzer_statuses"] = [
+            status
+            for status in payload["analysis_completeness"]["analyzer_statuses"]
+            if status["analyzer_id"] != "static_patterns_prompt_injection"
+        ]
+        result = _validate_skillspector_payload(mock_tools, sample_skill_dir, payload)
+
+        assert result.status == "incomplete"
+        assert any("missing required analyzer evidence" in error for error in result.errors)
+        assert not any(detail.check_name == "skillspector" for detail in result.success_details)
+
+    @patch("skillevaluator.validators.security.Tools")
+    def test_skillspector_rejects_2_9_6_report_with_failed_analyzer(
+        self,
+        mock_tools,
+        sample_skill_dir: Path,
+    ) -> None:
+        payload = json.loads(_SKILLSPECTOR_2_9_6_NO_LLM_REPORT.read_text(encoding="utf-8"))
+        disabled_status = next(
+            status
+            for status in payload["analysis_completeness"]["analyzer_statuses"]
+            if status["status"] == "disabled"
+        )
+        disabled_status.update({"status": "failed", "reason_code": "analyzer_failed"})
+        result = _validate_skillspector_payload(mock_tools, sample_skill_dir, payload)
+
+        assert result.status == "incomplete"
+        assert any("incomplete analyzer" in error for error in result.errors)
+
+    @pytest.mark.parametrize(
+        ("contradiction", "expected_error"),
+        [
+            pytest.param(
+                {"scanned_components": 10**399, "fully_inspected_files": 10**399},
+                "inconsistent counters or coverage",
+                id="component-coverage",
+            ),
+            pytest.param(
+                {"findings_after_filtering": 1},
+                "finding counts",
+                id="serialized-findings",
+            ),
+        ],
+    )
+    @patch("skillevaluator.validators.security.Tools")
+    def test_skillspector_rejects_2_9_6_report_with_contradictory_counts(
+        self,
+        mock_tools,
+        sample_skill_dir: Path,
+        contradiction: dict[str, int],
+        expected_error: str,
+    ) -> None:
+        payload = json.loads(_SKILLSPECTOR_2_9_6_NO_LLM_REPORT.read_text(encoding="utf-8"))
+        payload["analysis_completeness"].update(contradiction)
+        result = _validate_skillspector_payload(mock_tools, sample_skill_dir, payload)
+
+        assert result.status == "incomplete"
+        assert any(expected_error in error for error in result.errors)
+
+    @patch("skillevaluator.validators.security.Tools")
+    def test_skillspector_rejects_2_9_6_report_without_llm_requested(
+        self,
+        mock_tools,
+        sample_skill_dir: Path,
+    ) -> None:
+        payload = json.loads(_SKILLSPECTOR_2_9_6_NO_LLM_REPORT.read_text(encoding="utf-8"))
+        payload["metadata"].pop("llm_requested")
+        result = _validate_skillspector_payload(mock_tools, sample_skill_dir, payload)
+
+        assert result.status == "incomplete"
+        assert any("metadata.llm_requested" in error for error in result.errors)
+
+    @patch("skillevaluator.validators.security.Tools")
+    def test_skillspector_accepts_legacy_report_without_completeness(
+        self,
+        mock_tools,
+        sample_skill_dir: Path,
+    ) -> None:
+        payload = _skillspector_json_report()
+        payload["metadata"]["skillspector_version"] = "1.0.0"
+        payload.pop("execution_successful")
+        payload.pop("analysis_completeness")
+        result = _validate_skillspector_payload(mock_tools, sample_skill_dir, payload)
+
+        assert result.passed
+        assert not result.errors
+
+    @pytest.mark.parametrize("version", ["2.9.6", "2.10.0", "2.11.0"])
+    @pytest.mark.parametrize("missing_field", ["execution_successful", "analysis_completeness"])
+    @patch("skillevaluator.validators.security.Tools")
+    def test_skillspector_versioned_contract_requires_completeness_fields(
+        self,
+        mock_tools,
+        sample_skill_dir: Path,
+        missing_field: str,
+        version: str,
+    ) -> None:
+        payload = _skillspector_json_report()
+        payload["metadata"]["skillspector_version"] = version
+        payload.pop(missing_field)
+        result = _validate_skillspector_payload(mock_tools, sample_skill_dir, payload)
+
+        assert result.status == "incomplete"
+        assert any(missing_field in error for error in result.errors)
+
+    @pytest.mark.parametrize(
+        "missing_field",
+        ["findings_before_filtering", "findings_after_filtering"],
+    )
+    @patch("skillevaluator.validators.security.Tools")
+    def test_skillspector_versioned_contract_requires_finding_counts(
+        self,
+        mock_tools,
+        sample_skill_dir: Path,
+        missing_field: str,
+    ) -> None:
+        payload = _skillspector_json_report()
+        payload["analysis_completeness"].pop(missing_field)
+        result = _validate_skillspector_payload(mock_tools, sample_skill_dir, payload)
+
+        assert result.status == "incomplete"
+        assert any(missing_field in error for error in result.errors)
+
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [
+            pytest.param(field, value, id=f"{field}-{type(value).__name__}")
+            for field in ("findings_before_filtering", "findings_after_filtering")
+            for value in (True, -1, "1")
+        ],
+    )
+    @patch("skillevaluator.validators.security.Tools")
+    def test_skillspector_versioned_contract_rejects_invalid_finding_counts(
+        self,
+        mock_tools,
+        sample_skill_dir: Path,
+        field: str,
+        value: object,
+    ) -> None:
+        payload = _skillspector_json_report()
+        payload["analysis_completeness"][field] = value
+        result = _validate_skillspector_payload(mock_tools, sample_skill_dir, payload)
+
+        assert result.status == "incomplete"
+        assert any(field in error for error in result.errors)
+
+    @pytest.mark.parametrize(
+        ("section", "field"),
+        [
+            pytest.param("issue", "finding_id", id="issue-finding-id"),
+            pytest.param("issue", "match_fingerprint", id="issue-match-fingerprint"),
+            pytest.param("issue", "source_identity", id="issue-source-identity"),
+            pytest.param("component", "source_identity", id="component-source-identity"),
+        ],
+    )
+    @patch("skillevaluator.validators.security.Tools")
+    def test_skillspector_versioned_contract_rejects_invalid_score_identity_fields(
+        self,
+        mock_tools,
+        sample_skill_dir: Path,
+        section: str,
+        field: str,
+    ) -> None:
+        issues = (
+            [{"id": "M1", "severity": "MEDIUM", "finding": "advisory", field: []}]
+            if section == "issue"
+            else []
+        )
+        payload = _skillspector_json_report(issues)
+        if issues:
+            payload["risk_assessment"] = {
+                "score": 10,
+                "severity": "LOW",
+                "recommendation": "SAFE",
+            }
+        else:
+            payload["components"] = [{"path": "SKILL.md", "executable": False, field: []}]
+        result = _validate_skillspector_payload(mock_tools, sample_skill_dir, payload)
+
+        assert result.status == "incomplete"
+        assert any(field in error for error in result.errors)
+
+    @patch("skillevaluator.validators.security.Tools")
+    def test_skillspector_versioned_contract_requires_finding_id(
+        self,
+        mock_tools,
+        sample_skill_dir: Path,
+    ) -> None:
+        payload = _skillspector_json_report(
+            [{"id": "M1", "severity": "MEDIUM", "finding": "advisory"}]
+        )
+        payload["issues"][0].pop("finding_id")
+        payload["risk_assessment"] = {
+            "score": 10,
+            "severity": "LOW",
+            "recommendation": "SAFE",
+        }
+        result = _validate_skillspector_payload(mock_tools, sample_skill_dir, payload)
+
+        assert result.status == "incomplete"
+        assert any("finding_id" in error for error in result.errors)
+
+    @pytest.mark.parametrize(
+        ("before", "after", "issues"),
+        [
+            pytest.param(0, 1, [], id="before-less-than-after"),
+            pytest.param(7, 7, [], id="missing-serialized-findings"),
+            pytest.param(7, 0, [], id="all-findings-filtered"),
+            pytest.param(
+                7,
+                1,
+                [
+                    {
+                        "id": "PI-1",
+                        "severity": "HIGH",
+                        "finding": "Ignore prior instructions",
+                    }
+                ],
+                id="complete-report-filtered-findings",
+            ),
+            pytest.param(
+                1,
+                0,
+                [
+                    {
+                        "id": "PI-1",
+                        "severity": "HIGH",
+                        "finding": "Ignore prior instructions",
+                    }
+                ],
+                id="unexpected-serialized-finding",
+            ),
+            pytest.param(
+                1,
+                1,
+                [
+                    {
+                        "id": f"M{index}",
+                        "match_fingerprint": f"fingerprint-{index}",
+                        "severity": "MEDIUM",
+                        "finding": "advisory",
+                        "location": {"file": f"finding-{index}.md", "start_line": 1},
+                    }
+                    for index in range(6)
+                ],
+                id="fewer-raw-findings-than-serialized-identities",
+            ),
+        ],
+    )
+    @patch("skillevaluator.validators.security.Tools")
+    def test_skillspector_versioned_contract_reconciles_finding_counts(
+        self,
+        mock_tools,
+        sample_skill_dir: Path,
+        before: int,
+        after: int,
+        issues: list[dict],
+    ) -> None:
+        payload = _skillspector_json_report(issues)
+        payload["analysis_completeness"].update(
+            {
+                "findings_before_filtering": before,
+                "findings_after_filtering": after,
+            }
+        )
+        result = _validate_skillspector_payload(
+            mock_tools,
+            sample_skill_dir,
+            payload,
+            exit_code=1 if issues else 0,
+        )
+
+        assert result.status == "incomplete"
+        assert any("finding counts" in error for error in result.errors)
+
+    @pytest.mark.parametrize("version", [None, "2.10", "release-2.10.0"])
+    @patch("skillevaluator.validators.security.Tools")
+    def test_skillspector_rejects_missing_or_invalid_version(
+        self,
+        mock_tools,
+        sample_skill_dir: Path,
+        version: str | None,
+    ) -> None:
+        payload = _skillspector_json_report()
+        if version is None:
+            payload["metadata"].pop("skillspector_version")
+        else:
+            payload["metadata"]["skillspector_version"] = version
+        result = _validate_skillspector_payload(mock_tools, sample_skill_dir, payload)
+
+        assert result.status == "incomplete"
+        assert any("metadata.skillspector_version" in error for error in result.errors)
+
+    @patch("skillevaluator.validators.security.Tools")
+    def test_skillspector_rejects_missing_metadata(
+        self,
+        mock_tools,
+        sample_skill_dir: Path,
+    ) -> None:
+        payload = _skillspector_json_report()
+        payload.pop("metadata")
+        result = _validate_skillspector_payload(mock_tools, sample_skill_dir, payload)
+
+        assert result.status == "incomplete"
+        assert any("metadata.skillspector_version" in error for error in result.errors)
 
     @patch("skillevaluator.validators.security.Tools")
     def test_skillspector_accepts_valid_findings_report(self, mock_tools, sample_skill_dir: Path) -> None:
@@ -1689,6 +2530,71 @@ Call us at 555-123-4567 or +1-555-987-6543
         assert any(finding.check_name == "Instruction override (PI-1)" for finding in result.findings)
 
     @patch("skillevaluator.validators.security.Tools")
+    def test_skillspector_accepts_post_filter_count_before_report_deduplication(
+        self,
+        mock_tools,
+        sample_skill_dir: Path,
+    ) -> None:
+        payload = _skillspector_json_report(
+            [
+                {
+                    "id": "E1",
+                    "finding_id": "finding-b",
+                    "severity": "MEDIUM",
+                    "finding": "same advisory",
+                    "confidence": 0.5,
+                    "location": {"file": "SKILL.md", "start_line": 1},
+                }
+            ]
+        )
+        payload["analysis_completeness"].update(
+            {"findings_before_filtering": 2, "findings_after_filtering": 2}
+        )
+        payload["risk_assessment"] = {
+            "score": 7,
+            "severity": "LOW",
+            "recommendation": "SAFE",
+        }
+        result = _validate_skillspector_payload(mock_tools, sample_skill_dir, payload)
+
+        assert result.passed
+        assert not result.is_incomplete
+        assert not any("scan did not complete" in error for error in result.errors)
+        assert len(result.findings) == 1
+
+    @patch("skillevaluator.validators.security.Tools")
+    def test_skillspector_accepts_occurrence_expanded_finding_count(
+        self,
+        mock_tools,
+        sample_skill_dir: Path,
+    ) -> None:
+        issues = [
+            {
+                "id": "PI-1",
+                "finding_id": "finding-1",
+                "severity": "HIGH",
+                "finding": "Ignore prior instructions",
+                "location": {"file": path, "start_line": line},
+            }
+            for path, line in (("SKILL.md", 8), ("reference.md", 3))
+        ]
+        payload = _skillspector_json_report(issues)
+        payload["analysis_completeness"].update(
+            {"findings_before_filtering": 1, "findings_after_filtering": 1}
+        )
+        payload["risk_assessment"] = {
+            "score": 25,
+            "severity": "MEDIUM",
+            "recommendation": "CAUTION",
+        }
+        result = _validate_skillspector_payload(mock_tools, sample_skill_dir, payload)
+
+        assert result.status == "failed"
+        assert not result.is_incomplete
+        assert not any("scan did not complete" in error for error in result.errors)
+        assert len(result.findings) == 2
+
+    @patch("skillevaluator.validators.security.Tools")
     def test_skillspector_aggregate_policy_risk_fails_without_high_issue(
         self,
         mock_tools,
@@ -1701,6 +2607,7 @@ Call us at 555-123-4567 or +1-555-987-6543
                     "severity": "MEDIUM",
                     "finding": "advisory",
                     "confidence": 1.0,
+                    "location": {"file": "SKILL.md", "start_line": index + 1},
                 }
                 for index in range(6)
             ]
@@ -1731,8 +2638,10 @@ Call us at 555-123-4567 or +1-555-987-6543
     ) -> None:
         duplicate = {
             "id": "TM1",
+            "finding_id": "finding-1",
             "severity": "MEDIUM",
             "finding": "same advisory",
+            "match_fingerprint": "fingerprint-1",
             "confidence": 1.0,
             "location": {"file": "SKILL.md", "start_line": 4},
         }
@@ -1752,6 +2661,41 @@ Call us at 555-123-4567 or +1-555-987-6543
         assert result.passed
 
     @patch("skillevaluator.validators.security.Tools")
+    def test_skillspector_risk_reconciliation_accepts_pre_compaction_score(
+        self,
+        mock_tools,
+        sample_skill_dir: Path,
+    ) -> None:
+        issues = [
+            {
+                "id": "E1",
+                "finding_id": "finding-a",
+                "severity": "MEDIUM",
+                "finding": "https://a.example/",
+                "confidence": 0.5,
+                "location": {"file": "SKILL.md", "start_line": line},
+            }
+            for line in (1, 2, 3)
+        ]
+        issues.extend(
+            {
+                "id": "E1",
+                "finding_id": f"finding-{suffix}",
+                "severity": "MEDIUM",
+                "finding": f"https://{suffix}.example/",
+                "confidence": 0.6,
+                "location": {"file": "SKILL.md", "start_line": index + 4},
+            }
+            for index, suffix in enumerate(("b", "c"))
+        )
+        payload = _skillspector_json_report(issues)
+        payload["risk_assessment"] = {"score": 8, "severity": "LOW", "recommendation": "SAFE"}
+        result = _validate_skillspector_payload(mock_tools, sample_skill_dir, payload)
+
+        assert result.status != "incomplete"
+        assert not result.errors
+
+    @patch("skillevaluator.validators.security.Tools")
     def test_skillspector_risk_reconciliation_allows_private_cross_file_identity(
         self,
         mock_tools,
@@ -1760,14 +2704,30 @@ Call us at 555-123-4567 or +1-555-987-6543
         issues = [
             {
                 "id": "RP1",
+                "finding_id": "finding-1",
                 "severity": "MEDIUM",
                 "pattern": "Rogue behavior",
+                "finding": "same advisory",
                 "confidence": 0.7,
                 "location": {"file": file_name, "start_line": 1},
             }
             for file_name in ("a.md", "b.md")
         ]
-        payload = _skillspector_json_report(issues)
+        payload = json.loads(_SKILLSPECTOR_2_9_6_NO_LLM_REPORT.read_text(encoding="utf-8"))
+        payload["issues"] = issues
+        payload["components"] = [
+            {"path": file_name, "executable": False} for file_name in ("a.md", "b.md")
+        ]
+        payload["analysis_completeness"].update(
+            {
+                "total_components": 2,
+                "scanned_components": 2,
+                "fully_inspected_files": 2,
+                "findings_before_filtering": 2,
+                "findings_after_filtering": 2,
+            }
+        )
+        _set_universal_analyzer_work(payload)
         payload["risk_assessment"] = {"score": 7, "severity": "LOW", "recommendation": "SAFE"}
         mock_tools.skillspector.is_available = True
         mock_tools.skillspector.run.return_value = ToolResult(
@@ -1781,6 +2741,169 @@ Call us at 555-123-4567 or +1-555-987-6543
 
         assert result.status != "incomplete"
         assert result.passed
+
+    @patch("skillevaluator.validators.security.Tools")
+    def test_skillspector_legacy_risk_reconciliation_keeps_findings_without_match_text(
+        self,
+        mock_tools,
+        sample_skill_dir: Path,
+    ) -> None:
+        issues = [
+            {
+                "id": f"M{rule_index}",
+                "finding_id": f"finding-{rule_index}-{occurrence_index}",
+                "severity": "MEDIUM",
+                "pattern": "same advisory",
+                "finding": None,
+                "confidence": 1.0,
+                "location": {"file": f"file-{occurrence_index}.md", "start_line": 1},
+            }
+            for rule_index in range(4)
+            for occurrence_index in range(3)
+        ]
+        payload = json.loads(_SKILLSPECTOR_2_9_6_NO_LLM_REPORT.read_text(encoding="utf-8"))
+        payload["issues"] = issues
+        payload["components"] = [
+            {"path": f"file-{occurrence_index}.md", "executable": False}
+            for occurrence_index in range(3)
+        ]
+        payload["analysis_completeness"].update(
+            {
+                "total_components": 3,
+                "scanned_components": 3,
+                "fully_inspected_files": 3,
+                "findings_before_filtering": 12,
+                "findings_after_filtering": 12,
+            }
+        )
+        _set_universal_analyzer_work(payload)
+        payload["risk_assessment"] = {
+            "score": 40,
+            "severity": "MEDIUM",
+            "recommendation": "CAUTION",
+        }
+        result = _validate_skillspector_payload(mock_tools, sample_skill_dir, payload)
+
+        assert result.status == "incomplete"
+        assert any("understates the reported issues" in error for error in result.errors)
+
+    @patch("skillevaluator.validators.security.Tools")
+    def test_skillspector_risk_reconciliation_scopes_executable_paths(
+        self,
+        mock_tools,
+        sample_skill_dir: Path,
+    ) -> None:
+        issues = [
+            {
+                "id": f"M{index}",
+                "severity": "MEDIUM",
+                "finding": "advisory",
+                "confidence": 1.0,
+                "source_identity": "source-b",
+                "location": {"file": "scripts/check.py", "start_line": index + 1},
+            }
+            for index in range(4)
+        ]
+        payload = _skillspector_json_report(issues)
+        payload["risk_assessment"] = {
+            "score": 40,
+            "severity": "MEDIUM",
+            "recommendation": "CAUTION",
+        }
+        payload["components"] = [
+            {"path": "scripts/check.py", "source_identity": "source-a", "executable": True},
+            {"path": "scripts/check.py", "source_identity": "source-b", "executable": False},
+        ]
+        payload["analysis_completeness"].update(
+            {"total_components": 2, "scanned_components": 2, "fully_inspected_files": 2}
+        )
+        _set_universal_analyzer_work(payload)
+        payload["metadata"]["has_executable_scripts"] = True
+        result = _validate_skillspector_payload(mock_tools, sample_skill_dir, payload)
+
+        assert result.passed
+        assert not result.is_incomplete
+
+    @patch("skillevaluator.validators.security.Tools")
+    def test_skillspector_risk_reconciliation_uses_producer_source_scope_priority(
+        self,
+        mock_tools,
+        sample_skill_dir: Path,
+    ) -> None:
+        issues = [
+            {
+                "id": "M1",
+                "finding_id": "finding-1",
+                "match_fingerprint": "fingerprint-1",
+                "severity": "MEDIUM",
+                "finding": "same advisory",
+                "confidence": 1.0,
+                "source_url": "https://example.com/skill",
+                "source_digest": source_digest,
+                "location": {"file": "SKILL.md", "start_line": index + 1},
+            }
+            for index, source_digest in enumerate(("digest-a", "digest-b"))
+        ]
+        payload = _skillspector_json_report(issues)
+        payload["components"] = [
+            {
+                "path": "SKILL.md",
+                "executable": False,
+                "source_url": "https://example.com/skill",
+                "source_digest": "digest-a",
+            }
+        ]
+        payload["analysis_completeness"].update(
+            {"total_components": 1, "scanned_components": 1, "fully_inspected_files": 1}
+        )
+        payload["risk_assessment"] = {
+            "score": 10,
+            "severity": "LOW",
+            "recommendation": "SAFE",
+        }
+
+        result = _validate_skillspector_payload(mock_tools, sample_skill_dir, payload)
+
+        assert result.passed
+        assert not result.is_incomplete
+
+    @pytest.mark.parametrize("identity_dimension", ["source", "match", "null-match"])
+    @patch("skillevaluator.validators.security.Tools")
+    def test_skillspector_risk_reconciliation_keeps_distinct_report_identities(
+        self,
+        mock_tools,
+        sample_skill_dir: Path,
+        identity_dimension: str,
+    ) -> None:
+        issues = []
+        for rule_index in range(4):
+            for occurrence_index in range(3):
+                issue = {
+                    "id": f"M{rule_index}",
+                    "severity": "MEDIUM",
+                    "finding": "same advisory",
+                    "confidence": 1.0,
+                    "location": {"file": "SKILL.md", "start_line": 1},
+                }
+                if identity_dimension == "source":
+                    issue["source_identity"] = f"source-{occurrence_index}"
+                elif identity_dimension == "match":
+                    issue["match_fingerprint"] = f"fingerprint-{rule_index}-{occurrence_index}"
+                else:
+                    issue["finding_id"] = f"finding-{rule_index}-{occurrence_index}"
+                    issue["match_fingerprint"] = None
+                issues.append(issue)
+
+        payload = _skillspector_json_report(issues)
+        payload["risk_assessment"] = {
+            "score": 40,
+            "severity": "MEDIUM",
+            "recommendation": "CAUTION",
+        }
+        result = _validate_skillspector_payload(mock_tools, sample_skill_dir, payload)
+
+        assert result.status == "incomplete"
+        assert any("understates the reported issues" in error for error in result.errors)
 
     @patch("skillevaluator.validators.security.Tools")
     def test_skillspector_risk_reconciliation_applies_executable_multiplier(
@@ -1814,6 +2937,548 @@ Call us at 555-123-4567 or +1-555-987-6543
 
         assert result.status == "incomplete"
         assert any("understates the reported issues" in error for error in result.errors)
+
+    @patch("skillevaluator.validators.security.Tools")
+    def test_skillspector_filtered_score_uses_executable_component_evidence(
+        self,
+        mock_tools,
+        sample_skill_dir: Path,
+    ) -> None:
+        issues = [
+            {
+                "id": f"M{index}",
+                "severity": "MEDIUM",
+                "finding": "advisory",
+                "confidence": 1.0,
+                "location": {"file": f"scripts/check_{index}.py", "start_line": 1},
+            }
+            for index in range(5)
+        ]
+        issues.append(
+            {
+                "id": "SQP-2",
+                "severity": "HIGH",
+                "finding": "generated benchmark output",
+                "confidence": 0.0,
+                "location": {"file": "BENCHMARK.md", "start_line": 1},
+            }
+        )
+        payload = _skillspector_json_report(issues)
+        payload["risk_assessment"] = {
+            "score": 65,
+            "severity": "HIGH",
+            "recommendation": "DO_NOT_INSTALL",
+        }
+        payload["components"] = [
+            *[
+                {"path": f"scripts/check_{index}.py", "executable": True}
+                for index in range(5)
+            ],
+            {"path": "BENCHMARK.md", "executable": False},
+        ]
+        payload["analysis_completeness"].update(
+            {
+                "total_components": 6,
+                "scanned_components": 6,
+                "fully_inspected_files": 6,
+            }
+        )
+        payload["metadata"].pop("has_executable_scripts")
+        result = _validate_skillspector_payload(
+            mock_tools,
+            sample_skill_dir,
+            payload,
+            exit_code=1,
+        )
+
+        assert result.status == "failed"
+        assert any(finding.check_name == "skillspector_risk_score" for finding in result.findings)
+
+    @patch("skillevaluator.validators.security.Tools")
+    def test_skillspector_versioned_report_requires_component_inventory(
+        self,
+        mock_tools,
+        sample_skill_dir: Path,
+    ) -> None:
+        issues = [
+            {
+                "id": f"M{index}",
+                "severity": "MEDIUM",
+                "finding": "advisory",
+                "confidence": 1.0,
+                "location": {"file": f"scripts/check_{index}.py", "start_line": 1},
+            }
+            for index in range(5)
+        ]
+        payload = _skillspector_json_report(issues)
+        payload.pop("components")
+        payload["metadata"]["has_executable_scripts"] = True
+        payload["analysis_completeness"].update(
+            {
+                "total_components": 5,
+                "scanned_components": 5,
+                "fully_inspected_files": 5,
+            }
+        )
+        payload["risk_assessment"] = {
+            "score": 50,
+            "severity": "MEDIUM",
+            "recommendation": "CAUTION",
+        }
+
+        result = _validate_skillspector_payload(mock_tools, sample_skill_dir, payload)
+
+        assert result.status == "incomplete"
+        assert any("components" in error for error in result.errors)
+
+    @pytest.mark.parametrize(
+        ("components", "has_executable_scripts"),
+        [
+            pytest.param([{"path": "", "executable": False}], False, id="empty-path"),
+            pytest.param([{"path": "SKILL.md"}], False, id="missing-executable"),
+            pytest.param([{"path": "SKILL.md", "executable": None}], False, id="null-executable"),
+            pytest.param([{"path": "SKILL.md", "executable": False}], True, id="contradictory-metadata"),
+            pytest.param([{"path": "other.md", "executable": False}], False, id="unresolved-issue"),
+        ],
+    )
+    @patch("skillevaluator.validators.security.Tools")
+    def test_skillspector_versioned_report_rejects_incomplete_component_evidence(
+        self,
+        mock_tools,
+        sample_skill_dir: Path,
+        components: list[dict],
+        has_executable_scripts: bool,
+    ) -> None:
+        payload = _skillspector_json_report(
+            [
+                {
+                    "id": "M1",
+                    "severity": "MEDIUM",
+                    "finding": "advisory",
+                    "location": {"file": "SKILL.md", "start_line": 1},
+                }
+            ]
+        )
+        payload["components"] = components
+        payload["metadata"]["has_executable_scripts"] = has_executable_scripts
+        payload["analysis_completeness"].update(
+            {
+                "total_components": 1,
+                "scanned_components": 1,
+                "fully_inspected_files": 1,
+            }
+        )
+        payload["risk_assessment"] = {
+            "score": 10,
+            "severity": "LOW",
+            "recommendation": "SAFE",
+        }
+
+        result = _validate_skillspector_payload(mock_tools, sample_skill_dir, payload)
+
+        assert result.status == "incomplete"
+        assert any("component" in error for error in result.errors)
+
+    @patch("skillevaluator.validators.security.Tools")
+    def test_skillspector_versioned_report_rejects_duplicate_component_identities(
+        self,
+        mock_tools,
+        sample_skill_dir: Path,
+    ) -> None:
+        payload = _skillspector_json_report(
+            [
+                {
+                    "id": "M1",
+                    "severity": "MEDIUM",
+                    "finding": "advisory",
+                    "location": {"file": "scripts/check.py", "start_line": 1},
+                }
+            ]
+        )
+        payload["components"] = [
+            {"path": "scripts/check.py", "executable": True},
+            {"path": "scripts/check.py", "executable": False},
+        ]
+        payload["metadata"]["has_executable_scripts"] = True
+        payload["analysis_completeness"].update(
+            {"total_components": 2, "scanned_components": 2, "fully_inspected_files": 2}
+        )
+        payload["risk_assessment"] = {
+            "score": 10,
+            "severity": "LOW",
+            "recommendation": "SAFE",
+        }
+
+        result = _validate_skillspector_payload(mock_tools, sample_skill_dir, payload)
+
+        assert result.status == "incomplete"
+        assert any("duplicate identities" in error for error in result.errors)
+
+    @pytest.mark.parametrize("location", [None, {}, {"file": ""}])
+    @patch("skillevaluator.validators.security.Tools")
+    def test_skillspector_versioned_report_requires_issue_path(
+        self,
+        mock_tools,
+        sample_skill_dir: Path,
+        location: dict | None,
+    ) -> None:
+        payload = _skillspector_json_report(
+            [{"id": "M1", "severity": "MEDIUM", "finding": "advisory", "location": location}]
+        )
+        payload["risk_assessment"] = {
+            "score": 10,
+            "severity": "LOW",
+            "recommendation": "SAFE",
+        }
+
+        result = _validate_skillspector_payload(mock_tools, sample_skill_dir, payload)
+
+        assert result.status == "incomplete"
+        assert any("location.file" in error for error in result.errors)
+
+    @pytest.mark.parametrize(
+        ("skillspector_version", "case"),
+        [
+            pytest.param("2.9.6", "not-applicable", id="2.9.6-not-applicable"),
+            pytest.param("2.10.0", "not-applicable", id="2.10-not-applicable"),
+            pytest.param("2.10.0", "undercounted", id="2.10-undercounted"),
+        ],
+    )
+    @patch("skillevaluator.validators.security.Tools")
+    def test_skillspector_complete_report_requires_universal_analyzer_work(
+        self,
+        mock_tools,
+        sample_skill_dir: Path,
+        skillspector_version: str,
+        case: str,
+    ) -> None:
+        payload = (
+            json.loads(_SKILLSPECTOR_2_9_6_NO_LLM_REPORT.read_text(encoding="utf-8"))
+            if skillspector_version == "2.9.6"
+            else _skillspector_json_report()
+        )
+        payload["components"] = [
+            {"path": "SKILL.md", "executable": False},
+            *([{"path": "guide.md", "executable": False}] if case == "undercounted" else []),
+        ]
+        component_count = len(payload["components"])
+        payload["analysis_completeness"].update(
+            {
+                "total_components": component_count,
+                "scanned_components": component_count,
+                "fully_inspected_files": component_count,
+            }
+        )
+        universal_statuses = [
+            status
+            for status in payload["analysis_completeness"]["analyzer_statuses"]
+            if status["analyzer_id"] in _SKILLSPECTOR_UNIVERSAL_ANALYZERS
+        ]
+        for status in universal_statuses:
+            status.update(
+                {
+                    "status": "not_applicable" if case == "not-applicable" else "completed",
+                    "planned_work": 0 if case == "not-applicable" else 1,
+                    "completed": 0 if case == "not-applicable" else 1,
+                }
+            )
+
+        result = _validate_skillspector_payload(mock_tools, sample_skill_dir, payload)
+
+        assert result.status == "incomplete"
+        assert any("universal analyzer" in error for error in result.errors)
+
+    @patch("skillevaluator.validators.security.Tools")
+    def test_skillspector_complete_report_accepts_future_not_applicable_analyzer(
+        self,
+        mock_tools,
+        sample_skill_dir: Path,
+    ) -> None:
+        payload = _skillspector_json_report()
+        payload["components"] = [{"path": "SKILL.md", "executable": False}]
+        payload["analysis_completeness"].update(
+            {"total_components": 1, "scanned_components": 1, "fully_inspected_files": 1}
+        )
+        _set_universal_analyzer_work(payload)
+        payload["analysis_completeness"]["analyzer_statuses"].append(
+            {
+                "analyzer_id": "future_optional_analyzer",
+                "status": "not_applicable",
+                "planned_work": 0,
+                "completed": 0,
+                "partial": 0,
+                "skipped": 0,
+                "failed": 0,
+                "unaccounted": 0,
+            }
+        )
+
+        result = _validate_skillspector_payload(mock_tools, sample_skill_dir, payload)
+
+        assert result.passed
+        assert not result.is_incomplete
+
+    @patch("skillevaluator.validators.security.Tools")
+    def test_skillspector_compacted_score_does_not_overstate_executable_evidence(
+        self,
+        mock_tools,
+        sample_skill_dir: Path,
+    ) -> None:
+        issues = [
+            {
+                "id": "M1",
+                "finding_id": "finding-1",
+                "match_fingerprint": "fingerprint-1",
+                "severity": "MEDIUM",
+                "finding": "same advisory",
+                "confidence": 0.99,
+                "location": {"file": file_name, "start_line": 1},
+            }
+            for file_name in ("a.py", "z.md")
+        ]
+        payload = _skillspector_json_report(issues)
+        payload["components"] = [
+            {"path": "a.py", "executable": True},
+            {"path": "z.md", "executable": False},
+        ]
+        payload["metadata"]["has_executable_scripts"] = True
+        payload["analysis_completeness"].update(
+            {
+                "total_components": 2,
+                "scanned_components": 2,
+                "fully_inspected_files": 2,
+            }
+        )
+        payload["risk_assessment"] = {
+            "score": 9,
+            "severity": "LOW",
+            "recommendation": "SAFE",
+        }
+
+        result = _validate_skillspector_payload(mock_tools, sample_skill_dir, payload)
+
+        assert result.status == "passed"
+        assert len(result.findings) == 2
+
+    @patch("skillevaluator.validators.security.Tools")
+    def test_skillspector_compacted_score_does_not_trust_representative_confidence(
+        self,
+        mock_tools,
+        sample_skill_dir: Path,
+    ) -> None:
+        payload = _skillspector_json_report(
+            [
+                {
+                    "id": "M1",
+                    "finding_id": "finding-1",
+                    "match_fingerprint": "fingerprint-1",
+                    "severity": "MEDIUM",
+                    "finding": "same advisory",
+                    "confidence": 1.0,
+                    "location": {"file": path, "start_line": 1},
+                }
+                for path in ("a.md", "z.md")
+            ]
+        )
+        payload["risk_assessment"] = {
+            "score": 6,
+            "severity": "LOW",
+            "recommendation": "SAFE",
+        }
+
+        result = _validate_skillspector_payload(mock_tools, sample_skill_dir, payload)
+
+        assert result.status == "passed"
+        assert len(result.findings) == 2
+
+    @pytest.mark.parametrize(
+        "conflicting_fields",
+        [
+            pytest.param({"severity": "LOW", "confidence": 1.0}, id="severity-confidence"),
+            pytest.param({"finding_id": "conflicting-finding"}, id="finding-id"),
+        ],
+    )
+    @patch("skillevaluator.validators.security.Tools")
+    def test_skillspector_compacted_identity_rejects_conflicting_score_fields(
+        self,
+        mock_tools,
+        sample_skill_dir: Path,
+        conflicting_fields: dict,
+    ) -> None:
+        issues = [
+            {
+                "id": f"M{rule_index}",
+                "finding_id": f"finding-{rule_index}",
+                "match_fingerprint": f"fingerprint-{rule_index}",
+                "severity": "MEDIUM",
+                "finding": "same advisory",
+                "confidence": 0.9,
+                "location": {"file": f"rule-{rule_index}-{occurrence}.md", "start_line": 1},
+                **(conflicting_fields if occurrence else {}),
+            }
+            for rule_index in range(6)
+            for occurrence in range(2)
+        ]
+        payload = _skillspector_json_report(issues)
+        payload["risk_assessment"] = {
+            "score": 15,
+            "severity": "LOW",
+            "recommendation": "SAFE",
+        }
+
+        result = _validate_skillspector_payload(mock_tools, sample_skill_dir, payload)
+
+        assert result.status == "incomplete"
+        assert any("compacted identity" in error for error in result.errors)
+
+    @pytest.mark.parametrize("case", ["hidden", "expanded"])
+    @patch("skillevaluator.validators.security.Tools")
+    def test_skillspector_unknown_occurrences_preserve_visible_score_floor(
+        self,
+        mock_tools,
+        sample_skill_dir: Path,
+        case: str,
+    ) -> None:
+        issues = [
+            {
+                "id": f"M{rule_index}",
+                "finding_id": f"finding-{rule_index}",
+                "match_fingerprint": f"fingerprint-{rule_index}",
+                "severity": "MEDIUM",
+                "finding": "advisory",
+                "confidence": 1.0,
+                "location": {
+                    "file": f"rule-{rule_index}-{occurrence_index}.md",
+                    "start_line": 1,
+                },
+            }
+            for rule_index in range(6)
+            for occurrence_index in range(2 if case == "expanded" else 1)
+        ]
+        payload = _skillspector_json_report(issues)
+        if case == "hidden":
+            payload["analysis_completeness"].update(
+                {"findings_before_filtering": 7, "findings_after_filtering": 7}
+            )
+        payload["risk_assessment"] = {
+            "score": 0,
+            "severity": "LOW",
+            "recommendation": "SAFE",
+        }
+
+        result = _validate_skillspector_payload(mock_tools, sample_skill_dir, payload)
+
+        assert result.status == "incomplete"
+        assert any("understates the reported issues" in error for error in result.errors)
+
+    @pytest.mark.parametrize(
+        ("filtered_confidence", "reported_score"),
+        [
+            pytest.param(0.0, 70, id="zero-loss"),
+            pytest.param(1.0, 75, id="bounded-loss"),
+            pytest.param(0.0, 50.9, id="fractional-zero-loss"),
+        ],
+    )
+    @patch("skillevaluator.validators.security.Tools")
+    def test_skillspector_filtered_score_retains_reported_risk_floor(
+        self,
+        mock_tools,
+        sample_skill_dir: Path,
+        filtered_confidence: float,
+        reported_score: int | float,
+    ) -> None:
+        issues = [
+            {
+                "id": f"M{rule_index}",
+                "finding_id": f"finding-{rule_index}",
+                "severity": "MEDIUM",
+                "finding": "same advisory",
+                "match_fingerprint": f"fingerprint-{rule_index}",
+                "confidence": 1.0,
+                "location": {"file": "SKILL.md", "start_line": occurrence_index + 1},
+            }
+            for rule_index in range(4)
+            for occurrence_index in range(3)
+        ]
+        issues.append(
+            {
+                "id": "G1",
+                "severity": "LOW",
+                "finding": "generated benchmark output",
+                "confidence": filtered_confidence,
+                "location": {"file": "BENCHMARK.md", "start_line": 1},
+            }
+        )
+        payload = _skillspector_json_report(issues)
+        severity = "HIGH" if reported_score >= 51 else "MEDIUM"
+        payload["risk_assessment"] = {
+            "score": reported_score,
+            "severity": severity,
+            "recommendation": "DO_NOT_INSTALL" if severity == "HIGH" else "CAUTION",
+        }
+        result = _validate_skillspector_payload(
+            mock_tools,
+            sample_skill_dir,
+            payload,
+            exit_code=1,
+        )
+
+        assert result.status == "failed"
+        assert any(finding.check_name == "skillspector_risk_score" for finding in result.findings)
+
+    @patch("skillevaluator.validators.security.Tools")
+    def test_skillspector_filtered_score_does_not_use_incomplete_serialized_bound(
+        self,
+        mock_tools,
+        sample_skill_dir: Path,
+    ) -> None:
+        issues = [
+            {
+                "id": f"M{index}",
+                "severity": "MEDIUM",
+                "finding": "retained advisory",
+                "confidence": 1.0,
+                "location": {"file": f"retained-{index}.md", "start_line": 1},
+            }
+            for index in range(4)
+        ]
+        issues.extend(
+            [
+                {
+                    "id": "L1",
+                    "severity": "LOW",
+                    "finding": "retained low advisory",
+                    "confidence": 1.0,
+                    "location": {"file": "retained-low.md", "start_line": 1},
+                },
+                {
+                    "id": "SQP-2",
+                    "severity": "HIGH",
+                    "finding": "generated benchmark output",
+                    "confidence": 1.0,
+                    "location": {"file": "BENCHMARK.md", "start_line": 1},
+                },
+            ]
+        )
+        payload = _skillspector_json_report(issues)
+        payload["analysis_completeness"].update(
+            {"findings_before_filtering": 8, "findings_after_filtering": 8}
+        )
+        payload["risk_assessment"] = {
+            "score": 88,
+            "severity": "CRITICAL",
+            "recommendation": "DO_NOT_INSTALL",
+        }
+
+        result = _validate_skillspector_payload(
+            mock_tools,
+            sample_skill_dir,
+            payload,
+            exit_code=1,
+        )
+
+        assert result.status == "passed"
+        assert not any(finding.check_name == "skillspector_risk_score" for finding in result.findings)
 
     @patch("skillevaluator.validators.security.Tools")
     def test_skillspector_risk_reconciliation_applies_diminishing_occurrence_weights(
@@ -2222,6 +3887,81 @@ Call us at 555-123-4567 or +1-555-987-6543
         assert "Remove references" in (finding.suggestion or "")
 
     @patch("skillevaluator.validators.security.Tools")
+    def test_skillspector_sc8_shipped_bytecode_finding_is_preserved(
+        self,
+        mock_tools,
+        sample_skill_dir: Path,
+    ) -> None:
+        payload = _skillspector_json_report(
+            [
+                {
+                    "id": "SC8",
+                    "pattern": "Shipped Python bytecode",
+                    "severity": "HIGH",
+                    "confidence": 0.95,
+                    "finding": "Compiled Python artifact",
+                    "location": {"file": "__pycache__/payload.pyc", "start_line": 1},
+                }
+            ]
+        )
+        payload["risk_assessment"] = {
+            "score": 51,
+            "severity": "HIGH",
+            "recommendation": "DO_NOT_INSTALL",
+        }
+        result = _validate_skillspector_payload(
+            mock_tools,
+            sample_skill_dir,
+            payload,
+            exit_code=1,
+        )
+
+        assert result.status == "failed"
+        assert not result.is_incomplete
+        assert any(finding.check_name.endswith("(SC8)") for finding in result.findings)
+
+    @patch("skillevaluator.validators.security.Tools")
+    def test_skillspector_sc8_score_floor_survives_generated_artifact_filter(
+        self,
+        mock_tools,
+        sample_skill_dir: Path,
+    ) -> None:
+        payload = _skillspector_json_report(
+            [
+                {
+                    "id": "SC8",
+                    "pattern": "Shipped Python bytecode",
+                    "severity": "LOW",
+                    "confidence": 0.95,
+                    "finding": "Compiled Python artifact",
+                    "location": {"file": "__pycache__/payload.pyc", "start_line": 1},
+                },
+                {
+                    "id": "SQP-2",
+                    "pattern": "Generated card warning",
+                    "severity": "HIGH",
+                    "confidence": 0.9,
+                    "finding": "Generated card includes outputs",
+                    "location": {"file": "skill-card.md", "start_line": 1},
+                },
+            ]
+        )
+        payload["risk_assessment"] = {
+            "score": 51,
+            "severity": "HIGH",
+            "recommendation": "DO_NOT_INSTALL",
+        }
+        result = _validate_skillspector_payload(
+            mock_tools,
+            sample_skill_dir,
+            payload,
+            exit_code=1,
+        )
+
+        assert result.status == "failed"
+        assert any(finding.check_name == "skillspector_risk_score" for finding in result.findings)
+
+    @patch("skillevaluator.validators.security.Tools")
     def test_skillspector_findings_for_generated_artifacts_are_ignored(self, mock_tools, sample_skill_dir: Path):
         """Generated publishing artifacts should not fail Tier 1 security scanning."""
         mock_tools.skillspector.is_available = True
@@ -2231,7 +3971,7 @@ Call us at 555-123-4567 or +1-555-987-6543
                 "source": "/tmp/sample",
                 "scanned_at": "2026-01-01T00:00:00Z",
             },
-            "risk_assessment": {"score": 90, "severity": "CRITICAL", "recommendation": "DO_NOT_INSTALL"},
+            "risk_assessment": {"score": 22, "severity": "MEDIUM", "recommendation": "CAUTION"},
             "components": [
                 {
                     "path": "skill-card.md",
@@ -2267,7 +4007,7 @@ Call us at 555-123-4567 or +1-555-987-6543
             success=True,
             stdout=json.dumps(cli_json),
             stderr="",
-            exit_code=1,
+            exit_code=0,
         )
 
         validator = SecurityValidator(use_llm=False)

--- a/tests/validators/test_security.py
+++ b/tests/validators/test_security.py
@@ -69,9 +69,25 @@ def _skillspector_json_report(
         "issues": normalized_issues,
         "suppressed_count": 0,
         "suppressed": [],
+        "execution_successful": True,
+        "analysis_completeness": {
+            "total_components": 0,
+            "scanned_components": 0,
+            "coverage_percent": 100.0,
+            "is_complete": True,
+            "status": "complete",
+            "execution_successful": True,
+            "fully_inspected_files": 0,
+            "partially_inspected_files": 0,
+            "entirely_uninspected_files": 0,
+            "ledger_exceptions": [],
+            "scope_exclusions": [],
+            "analyzer_statuses": [],
+            "limitations": [],
+        },
         "metadata": {
             "has_executable_scripts": False,
-            "skillspector_version": "1.0.0",
+            "skillspector_version": "2.10.0",
             "llm_requested": llm_requested,
             "llm_available": llm_available,
             "meta_analysis_applied": False,
@@ -1275,6 +1291,53 @@ Call us at 555-123-4567 or +1-555-987-6543
         assert result.status == "incomplete"
         assert any("unexpected suppressed findings" in error.lower() for error in result.errors)
 
+    @patch("skillevaluator.validators.security.Tools")
+    def test_skillspector_2_10_partial_scan_reports_incomplete_before_recommendation(
+        self,
+        mock_tools,
+        sample_skill_dir: Path,
+    ) -> None:
+        """LOW/CAUTION is the documented projection of an incomplete 2.10 scan."""
+        payload = _skillspector_json_report()
+        payload["risk_assessment"].update(
+            {
+                "recommendation": "CAUTION",
+                "max_issue_severity": "NONE",
+            }
+        )
+        payload["metadata"]["skillspector_version"] = "2.10.0"
+        payload["execution_successful"] = True
+        payload["analysis_completeness"] = {
+            "total_components": 4,
+            "scanned_components": 4,
+            "coverage_percent": 100.0,
+            "is_complete": False,
+            "status": "partial",
+            "execution_successful": True,
+            "fully_inspected_files": 4,
+            "partially_inspected_files": 0,
+            "entirely_uninspected_files": 0,
+            "ledger_exceptions": [
+                {"reason_code": "reference_unresolved", "fatal": False} for _ in range(12)
+            ],
+            "scope_exclusions": [],
+            "analyzer_statuses": [],
+            "limitations": [],
+        }
+        mock_tools.skillspector.is_available = True
+        mock_tools.skillspector.run.return_value = ToolResult(
+            success=True,
+            stdout=json.dumps(payload),
+            stderr="",
+            exit_code=0,
+        )
+
+        result = SecurityValidator(use_llm=False).validate_security_only(sample_skill_dir)
+
+        assert result.status == "incomplete"
+        assert any("analysis_completeness" in error and "partial" in error for error in result.errors)
+        assert not any("recommendation" in error for error in result.errors)
+
     @pytest.mark.parametrize(
         ("payload", "expected_error"),
         (
@@ -1415,11 +1478,34 @@ Call us at 555-123-4567 or +1-555-987-6543
             ),
             pytest.param(
                 {
-                    "risk_assessment": {"score": 0, "severity": "LOW", "recommendation": "DO_NOT_INSTALL"},
+                    "risk_assessment": {"score": 0, "severity": "LOW", "recommendation": "CAUTION"},
                     "issues": [],
                 },
                 "risk_assessment.recommendation",
-                id="contradictory-risk-recommendation",
+                id="complete-low-caution-recommendation",
+            ),
+            pytest.param(
+                {
+                    "execution_successful": False,
+                    "risk_assessment": {"score": 0, "severity": "LOW", "recommendation": "SAFE"},
+                    "issues": [],
+                },
+                "execution_successful=false",
+                id="unsuccessful-execution",
+            ),
+            pytest.param(
+                {
+                    "execution_successful": True,
+                    "analysis_completeness": {
+                        "is_complete": True,
+                        "status": "complete",
+                        "execution_successful": "true",
+                    },
+                    "risk_assessment": {"score": 0, "severity": "LOW", "recommendation": "SAFE"},
+                    "issues": [],
+                },
+                "analysis_completeness.execution_successful",
+                id="invalid-completeness-execution-marker",
             ),
             pytest.param(
                 {

--- a/tests/validators/test_security.py
+++ b/tests/validators/test_security.py
@@ -2206,16 +2206,20 @@ Call us at 555-123-4567 or +1-555-987-6543
         assert not result.errors
         assert any(detail.check_name == "skillspector" for detail in result.success_details)
 
+    @pytest.mark.parametrize("version", ["2.9.5-safe", "2.9.6", "2.11.1-safe"])
     @patch("skillevaluator.validators.security.Tools")
-    def test_skillspector_accepts_captured_2_9_6_no_llm_report(
+    def test_skillspector_accepts_captured_no_llm_report(
         self,
         mock_tools,
         sample_skill_dir: Path,
+        version: str,
     ) -> None:
         mock_tools.skillspector.is_available = True
         mock_tools.skillspector.run.return_value = ToolResult(
             success=True,
-            stdout=_SKILLSPECTOR_2_9_6_NO_LLM_REPORT.read_text(encoding="utf-8"),
+            stdout=(
+                Path(__file__).parents[1] / "fixtures" / f"skillspector-{version}-no-llm.json"
+            ).read_text(encoding="utf-8"),
             stderr="",
             exit_code=0,
         )
@@ -2225,6 +2229,74 @@ Call us at 555-123-4567 or +1-555-987-6543
         assert result.passed
         assert not result.errors
         assert any(detail.check_name == "skillspector" for detail in result.success_details)
+
+    @pytest.mark.parametrize("version", ["2.10.0", "2.11.0", "2.11.1"])
+    @patch("skillevaluator.validators.security.Tools")
+    def test_skillspector_requires_bundled_execution_surface_since_2_11(
+        self, mock_tools, sample_skill_dir: Path, version: str,
+    ) -> None:
+        payload = json.loads((
+            Path(__file__).parents[1] / "fixtures" / "skillspector-2.11.1-safe-no-llm.json"
+        ).read_text(encoding="utf-8"))
+        payload["metadata"]["skillspector_version"] = version
+        payload["analysis_completeness"]["analyzer_statuses"] = [
+            item for item in payload["analysis_completeness"]["analyzer_statuses"]
+            if item["analyzer_id"] != "bundled_execution_surface"
+        ]
+        result = _validate_skillspector_payload(mock_tools, sample_skill_dir, payload)
+        if version == "2.10.0":
+            assert result.passed
+        else:
+            assert result.is_incomplete
+            assert any("missing required analyzer evidence" in error for error in result.errors)
+
+    @pytest.mark.parametrize(
+        "mutation", [None, "finding_id", "score", "count", "old-version", "expanded", "evidence-types"]
+    )
+    @patch("skillevaluator.validators.security.Tools")
+    def test_skillspector_captured_classification_distinct_pe3(
+        self, mock_tools, sample_skill_dir: Path, mutation: str | None,
+    ) -> None:
+        # Captured from NVIDIA/SkillSpector v2.11.1 with --no-llm. build.sh:
+        # docker run -v /etc/passwd:/etc/passwd:ro image
+        # cat /etc/passwd
+        payload = json.loads((
+            Path(__file__).parents[1] / "fixtures" / "skillspector-2.11.1-pe3-no-llm.json"
+        ).read_text(encoding="utf-8"))
+        first, second = [issue for issue in payload["issues"] if issue["id"] == "PE3"]
+        assert first["match_fingerprint"] == second["match_fingerprint"]
+        assert first["finding_id"] != second["finding_id"]
+        assert first["tags"] != second["tags"]
+        if mutation == "finding_id":
+            second["finding_id"] = first["finding_id"]
+        elif mutation == "score":
+            payload["risk_assessment"]["score"] = 30
+        elif mutation == "count":
+            payload["analysis_completeness"]["findings_after_filtering"] = 2
+        elif mutation == "old-version":
+            payload["metadata"]["skillspector_version"] = "2.11.0"
+        elif mutation == "expanded":
+            payload["issues"].append({**first, "location": {"file": "build.sh", "start_line": 4}})
+        elif mutation == "evidence-types":
+            second.update(first)
+            first["evidence"] = {"classification": True}
+            second["evidence"] = {"classification": 1}
+        result = _validate_skillspector_payload(mock_tools, sample_skill_dir, payload)
+        if mutation in {None, "expanded"}:
+            assert not result.is_incomplete
+            assert len([finding for finding in result.findings if finding.check_name.endswith("(PE3)")]) == (
+                3 if mutation == "expanded" else 2
+            )
+        else:
+            assert result.is_incomplete
+            expected = {
+                "finding_id": "compacted identity",
+                "score": "understates",
+                "count": "finding counts",
+                "old-version": "compacted identity",
+                "evidence-types": "compacted identity",
+            }[mutation]
+            assert any(expected in error for error in result.errors)
 
     @pytest.mark.parametrize("skillspector_version", ["2.9.6", "2.10.0"])
     @patch("skillevaluator.validators.security.Tools")


### PR DESCRIPTION
## Summary

SkillEvaluator now validates the SkillSpector report contract across the supported schema generations. It explicitly supports statusless 2.9.5 and 2.9.6 reports, status-bearing 2.10+ reports, and requires `bundled_execution_surface` beginning with 2.11.0. For 2.11.1 and newer reports, `finding_id` is the logical finding identity throughout validation, deduplication, and score reconstruction. Older report generations retain fingerprint-first behavior.

The evaluator now validates completeness counts and coverage, the required analyzer roster and work partitions, source-scoped component inventories and paths, filtering counts, and the risk recommendation. It preserves valid HIGH findings from coherent partial scans while keeping the overall result incomplete. Score reconstruction is conservative across compaction and hidden occurrences. The SC8 shipped-bytecode floor is explicit, and the staged scanner retains shipped bytecode for that check.

For 2.11.1+, validation rejects conflicting reuse of a finding ID across scoring, classification, and source fields. Evidence JSON comparisons preserve `true`-versus-`1` type distinctions. The fixture set includes real 2.9.5 SAFE, 2.11.1 SAFE, and 2.11.1 classification-distinct PE3 cases; the existing 2.9.6 fixture remains covered.

`CHANGELOG.md` records the release impact.

## Verification

On the exact final tree (`e6799e85fff8e42c3785c2fe5f115a4ffd6c0195`):

- The focused suite passed: 367 tests.
- The full suite passed: 5,997 tests; 17 skipped and 4 deselected under the repository's default test configuration.
- Ruff passed for `src` and `tests`.
- Source and wheel builds passed.
- Live evaluator CLI `--no-llm` SAFE probes passed for tagged 2.9.5, 2.9.6, 2.10.0, and 2.11.1 reports.

Three independent native review lanes reported no new supported findings on this tree. The first review identified a JSON evidence equality gap; its regression failed before correction and passes afterward. Local execution receipts and the reconciled finding registry validate. Host execution provenance remains partial.

## AI assistance

Codex implemented, tested, and reviewed these changes.
