### PR TITLE
Fix local mode handling of empty loader environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to SkillEvaluator are documented in this file.
 
 ### Fixed
 
+- Tier 3 local mode no longer rejects evaluator-managed empty process-loader environment variables.
 - Unpinned-dependency warnings are no longer suppressed by comparison
   operators inside PEP 508 environment markers; requirements such as
   `pkg; python_version < "3.13"` are now correctly reported, while direct

--- a/src/skillevaluator/tier3/harbor/local_environment.py
+++ b/src/skillevaluator/tier3/harbor/local_environment.py
@@ -1013,6 +1013,8 @@ class SkillEvaluatorLocalEnvironment(BaseEnvironment):
         for key, value in env.items():
             normalized = key.upper()
             if normalized in _BLOCKED_COMMAND_ENV_NAMES or normalized.startswith(_BLOCKED_COMMAND_ENV_PREFIXES):
+                if value == "":
+                    continue
                 raise ValueError(
                     f"environment variable {key} can execute or alter code before confinement and is not allowed"
                 )

--- a/tests/test_harbor_local_mode.py
+++ b/tests/test_harbor_local_mode.py
@@ -1974,6 +1974,15 @@ def test_runtime_injection_env_is_blocked_before_launcher(name: str, tmp_path: P
     assert name in (result.stderr or "")
 
 
+@pytest.mark.parametrize("name", ["BASH_ENV", "LD_PRELOAD", "PYTHONPATH"])
+def test_empty_runtime_injection_env_is_ignored(name: str) -> None:
+    filtered = SkillEvaluatorLocalEnvironment._filter_command_env(
+        {name: "", "SAFE_VALUE": "kept"}, protected=set()
+    )
+
+    assert filtered == {"SAFE_VALUE": "kept"}
+
+
 @pytest.mark.skipif(os.name == "nt", reason=_NATIVE_WINDOWS_LOCAL_REASON)
 def test_persistent_runtime_injection_env_is_blocked_before_launcher(tmp_path: Path) -> None:
     environment = _local_environment(tmp_path, persistent_env={"NODE_OPTIONS": "--require=/tmp/attack.js"})


### PR DESCRIPTION
## Summary

Tier 3 local mode rejects process-loader environment variables before considering their values. The evaluator itself supplies empty loader variables such as `BASH_ENV`, so a local run can fail before the agent process starts.

This drops blocked loader variables when their value is empty while preserving the existing rejection for every non-empty value.

Closes #136.

## Verification

- [x] I am familiar with the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] Added or updated focused tests
- [x] Updated documentation for user-visible changes
- [x] Ran `make lint`
- [x] Ran `make test`
- [x] Ran `make build`
- [x] Did not add credentials, private datasets, or proprietary benchmark content

Focused local-mode tests: 16 passed. Ruff and package build pass.

`make test` completed with 6034 passed, 17 skipped, and 5 failures unrelated to this change. The CLI golden failure and the three Anthropic `httpx`/`httpx2` failures reproduce on unmodified current `main`; the remaining DNS deadline test is timing-sensitive and passes when rerun alone.

## Release Impact

- [ ] No user-visible release note needed
- [x] Updated `CHANGELOG.md`
